### PR TITLE
Add dependabot semver major ignores for docker dirs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,10 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(docker)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "docker"
     directory: "/server"
@@ -97,6 +101,10 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(docker)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "docker"
     directory: "/hltb-scraper"
@@ -112,3 +120,7 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(docker)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Summary
- add per-package ignores for semver-major docker updates in `/server`, `/edge`, and `/hltb-scraper`
- these rules keep dependabot from opening major bump PRs for those docker directories that are already handled elsewhere

Testing
- Not run (not requested)