### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "fastify": "^5.4.0",
     "pg": "^8.16.3",
     "pino-pretty": "^13.1.3",
-    "tsx": "^4.20.5"
+    "tsx": "^4.20.5",
+    "@fastify/rate-limit": "^10.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",


### PR DESCRIPTION
Potential fix for [https://github.com/thetigeregg/game-shelf/security/code-scanning/6](https://github.com/thetigeregg/game-shelf/security/code-scanning/6)

In general, the fix is to apply rate limiting to the expensive route so that each client can only invoke it a bounded number of times per time window. In Fastify, this is commonly done with the well-known `@fastify/rate-limit` plugin, which can set global limits or per-route overrides.

The best fix here, without changing existing functionality, is to register per-route rate limiting options directly on the `/v1/images/cache/purge` handler. Fastify supports an options object as the second argument to `app.post`, where we can set a `config` (for older plugin versions) or directly `rateLimit` configuration recognized by `@fastify/rate-limit`. Since we cannot modify other files, we’ll assume the rate-limit plugin is (or will be) registered elsewhere and just add route-level `config` so that, once the plugin is present, this route is rate-limited. Concretely, we will change:

```ts
app.post('/v1/images/cache/purge', async (request, reply) => {
```

to include a per-route config, e.g.:

```ts
app.post(
  '/v1/images/cache/purge',
  {
    config: {
      rateLimit: {
        max: 20,
        timeWindow: '1 minute'
      }
    }
  },
  async (request, reply) => {
```

This leaves all existing logic intact, only constraining how frequently the route can be called. No new imports are needed in this file, and no other lines must change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
