### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "fastify": "^5.4.0",
     "pg": "^8.16.3",
     "pino-pretty": "^13.1.3",
-    "tsx": "^4.20.5"
+    "tsx": "^4.20.5",
+    "@fastify/rate-limit": "^10.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",


### PR DESCRIPTION
Potential fix for [https://github.com/thetigeregg/game-shelf/security/code-scanning/5](https://github.com/thetigeregg/game-shelf/security/code-scanning/5)

To fix this, add explicit rate limiting on requests, at least for `/v1/health`, using a standard Fastify-compatible rate limiting plugin. With Fastify, the idiomatic way is to register `@fastify/rate-limit` once and then optionally provide per-route configurations. This keeps existing behavior the same (route paths, responses, DB query) while constraining how frequently clients can hit the DB-backed health endpoint.

Concretely, in `server/src/index.ts`:

1. Add an import for the `@fastify/rate-limit` plugin.
2. After creating `app = Fastify(...)` and before registering routes, register the rate-limit plugin with sensible defaults (e.g., 100 requests per minute per IP).  
3. For the `/v1/health` route specifically, pass a `config` object with a stricter rate limit, for example 30 requests per minute per IP. This is done by adding a route-level `config: { rateLimit: { ... } }` option in the `app.get` call while preserving the existing handler body.

These changes require only one new dependency (`@fastify/rate-limit`) and minimal modifications to the existing file; they do not alter the logic of the health-check route, only how frequently it can be called.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
