### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "fastify": "^5.4.0",
     "pg": "^8.16.3",
     "pino-pretty": "^13.1.3",
-    "tsx": "^4.20.5"
+    "tsx": "^4.20.5",
+    "@fastify/rate-limit": "^10.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import Fastify from 'fastify';
 import type { FastifyRequest } from 'fastify';
 import cors from '@fastify/cors';
+import rateLimit from '@fastify/rate-limit';
 import { config } from './config.js';
 import { registerCacheObservabilityRoutes } from './cache-observability.js';
 import { createPool } from './db.js';
@@ -35,6 +36,11 @@ async function main(): Promise<void> {
         }
       }
     }
+  });
+
+  await app.register(rateLimit, {
+    max: 100,
+    timeWindow: '1 minute'
   });
 
   app.log.info({


### PR DESCRIPTION
Potential fix for [https://github.com/thetigeregg/game-shelf/security/code-scanning/4](https://github.com/thetigeregg/game-shelf/security/code-scanning/4)

In general, the best fix is to introduce a rate-limiting middleware at the Fastify level so that requests hitting authorization logic are throttled. For Fastify, the canonical solution is to use the well-known `@fastify/rate-limit` plugin, configured with sensible defaults (e.g., per-IP limits) and applied globally or at least to protected routes handled by `isProtectedRoute`/`isAuthorizedRequest`.

Concretely for `server/src/index.ts`, we should:
- Import `@fastify/rate-limit`.
- Register it on the `app` instance shortly after creating the Fastify app and before defining routes/hooks that perform authorization or expensive work.
- Configure reasonable limits, ideally driven by existing `config` fields if present, but since we cannot assume extra config, we’ll use static, conservative values that won’t break existing behavior for normal traffic (e.g., a per-IP limit like 100 requests per minute) while mitigating abuse.

We will only touch `server/src/index.ts`:
1. Add `import rateLimit from '@fastify/rate-limit';` alongside other imports.
2. After `const app = Fastify({ ... });` and before CORS and hooks/routes, add `await app.register(rateLimit, { ...options... });`. Because `main` is already `async` and uses `await app.register(cors, ...)`, adding another awaited registration is consistent and safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
