### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "fastify": "^5.4.0",
     "pg": "^8.16.3",
     "pino-pretty": "^13.1.3",
-    "tsx": "^4.20.5"
+    "tsx": "^4.20.5",
+    "@fastify/rate-limit": "^10.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/server/src/cache-observability.ts
+++ b/server/src/cache-observability.ts
@@ -7,34 +7,45 @@ interface CacheCountRow {
 }
 
 export function registerCacheObservabilityRoutes(app: FastifyInstance, pool: Pool): void {
-  app.get('/v1/cache/stats', async (_request, reply) => {
-    const metrics = getCacheMetrics();
+  app.get(
+    '/v1/cache/stats',
+    {
+      config: {
+        rateLimit: {
+          max: 60,
+          timeWindow: '1 minute'
+        }
+      }
+    },
+    async (_request, reply) => {
+      const metrics = getCacheMetrics();
 
-    let imageAssetCount: number | null = null;
-    let hltbEntryCount: number | null = null;
-    let dbError: string | null = null;
+      let imageAssetCount: number | null = null;
+      let hltbEntryCount: number | null = null;
+      let dbError: string | null = null;
 
-    try {
-      const imageCountResult = await pool.query<CacheCountRow>(
-        'SELECT COUNT(*)::text AS count FROM image_assets'
-      );
-      const hltbCountResult = await pool.query<CacheCountRow>(
-        'SELECT COUNT(*)::text AS count FROM hltb_search_cache'
-      );
-      imageAssetCount = Number.parseInt(imageCountResult.rows[0]?.count ?? '0', 10);
-      hltbEntryCount = Number.parseInt(hltbCountResult.rows[0]?.count ?? '0', 10);
-    } catch (error) {
-      dbError = error instanceof Error ? error.message : String(error);
+      try {
+        const imageCountResult = await pool.query<CacheCountRow>(
+          'SELECT COUNT(*)::text AS count FROM image_assets'
+        );
+        const hltbCountResult = await pool.query<CacheCountRow>(
+          'SELECT COUNT(*)::text AS count FROM hltb_search_cache'
+        );
+        imageAssetCount = Number.parseInt(imageCountResult.rows[0]?.count ?? '0', 10);
+        hltbEntryCount = Number.parseInt(hltbCountResult.rows[0]?.count ?? '0', 10);
+      } catch (error) {
+        dbError = error instanceof Error ? error.message : String(error);
+      }
+
+      reply.send({
+        timestamp: new Date().toISOString(),
+        metrics,
+        counts: {
+          imageAssets: imageAssetCount,
+          hltbEntries: hltbEntryCount
+        },
+        dbError
+      });
     }
-
-    reply.send({
-      timestamp: new Date().toISOString(),
-      metrics,
-      counts: {
-        imageAssets: imageAssetCount,
-        hltbEntries: hltbEntryCount
-      },
-      dbError
-    });
-  });
+  );
 }


### PR DESCRIPTION
Potential fix for [https://github.com/thetigeregg/game-shelf/security/code-scanning/2](https://github.com/thetigeregg/game-shelf/security/code-scanning/2)

In general, to fix missing rate limiting for a Fastify route that performs database access, you attach a rate-limiting plugin or preHandler to that route (or globally) so that each client can only make a bounded number of requests per time window. For Fastify, the standard solution is the `@fastify/rate-limit` plugin, which integrates cleanly without changing route behavior beyond rejecting excessive requests.

For this specific route, the safest change with minimal impact is to use Fastify’s built‑in per‑route rate limit configuration, assuming `@fastify/rate-limit` is registered elsewhere during app setup. We can add a `config` object to the `app.get` call for `/v1/cache/stats` specifying a modest rate limit (for example, 60 requests per minute per IP). This shields the database from floods while preserving normal use. The request handler logic (queries, response shape, error handling) remains unchanged.

Concretely, in `server/src/cache-observability.ts`, update the `app.get('/v1/cache/stats', async (_request, reply) => { ... })` call so that it passes a route options object with a `config` field including `rateLimit` before the handler function, e.g.:

```ts
app.get(
  '/v1/cache/stats',
  {
    config: {
      rateLimit: {
        max: 60,
        timeWindow: '1 minute'
      }
    }
  },
  async (_request, reply) => { ... }
);
```

No new imports are needed in this file, as the rate-limit configuration is just a plain object; the actual plugin registration happens elsewhere in the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
