### PR TITLE
Allow manual binding override when catalog unavailable

### DIFF
--- a/nas-secrets/postgres_password
+++ b/nas-secrets/postgres_password
@@ -1,0 +1,1 @@
+gameshelf

--- a/nas-secrets/postgres_user
+++ b/nas-secrets/postgres_user
@@ -1,0 +1,1 @@
+gameshelf

--- a/src/app/features/game-list/game-list.component.ts
+++ b/src/app/features/game-list/game-list.component.ts
@@ -1750,7 +1750,11 @@ export class GameListComponent implements OnChanges {
   }
 
   get shouldShowFindManualButton(): boolean {
-    return this.manualResolvedUrl === null;
+    if (!this.selectedGame) {
+      return false;
+    }
+
+    return !this.manualCatalogUnavailable || this.manualResolvedSource === 'override';
   }
 
   openManualPdf(): void {
@@ -1764,7 +1768,7 @@ export class GameListComponent implements OnChanges {
   }
 
   openManualPickerModal(): void {
-    if (this.manualCatalogUnavailable) {
+    if (this.manualCatalogUnavailable && this.manualResolvedSource !== 'override') {
       const reason = this.manualCatalogUnavailableReason ?? 'Manual catalog is unavailable.';
       void this.presentToast(reason, 'warning');
       return;

--- a/src/assets/runtime-config.js
+++ b/src/assets/runtime-config.js
@@ -2,7 +2,7 @@ window.__GAME_SHELF_RUNTIME_CONFIG__ = Object.assign(
   {},
   window.__GAME_SHELF_RUNTIME_CONFIG__,
   {
-    appVersion: "0.0.10",
+    appVersion: "0.0.20",
     featureFlags: {
       showMgcImport: false,
     },


### PR DESCRIPTION
Summary
- allow the manual picker button to show when an overridden manual is selected even if the catalog is unavailable
- let the picker open if the user is already overriding a manual so they can clear or change the bound file

Testing
- Not run (not requested)