### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/hltb-scraper/src/server.mjs
+++ b/hltb-scraper/src/server.mjs
@@ -434,7 +434,10 @@ async function searchHltbInBrowser(page, title, releaseYear, platform) {
     let shouldParsePayload = false;
     try {
       const parsedUrl = new URL(url);
-      const isHltbDomain = parsedUrl.hostname.toLowerCase().includes('howlongtobeat.com');
+      const hostname = parsedUrl.hostname.toLowerCase();
+      const isHltbDomain =
+        hostname === 'howlongtobeat.com' ||
+        hostname.endsWith('.howlongtobeat.com');
       const isLikelySearchPayload =
         parsedUrl.pathname.includes('/api/') ||
         parsedUrl.pathname.includes('/_next/data/') ||


### PR DESCRIPTION
Potential fix for [https://github.com/thetigeregg/game-shelf/security/code-scanning/10](https://github.com/thetigeregg/game-shelf/security/code-scanning/10)

In general, to fix incomplete URL substring sanitization, you should never rely on `includes` or other substring checks on the raw URL or hostname. Instead, parse the URL, normalize the hostname to a consistent case, and compare it against a strict allowlist of exact hosts or, if you truly intend to allow all subdomains, enforce that via suffix checks that operate on label boundaries (e.g., `"howlongtobeat.com"` must be a full suffix, not just any substring).

For this file, the single best change is to replace `parsedUrl.hostname.toLowerCase().includes('howlongtobeat.com')` with a robust host check that (a) matches `howlongtobeat.com` exactly, and (b) matches any subdomain that ends with `.howlongtobeat.com`. This preserves the intent of “is this an HLTB domain?” while avoiding hosts such as `howlongtobeat.com.evil.com`. We can implement this inline without introducing new dependencies by computing `const hostname = parsedUrl.hostname.toLowerCase();` and then `const isHltbDomain = hostname === 'howlongtobeat.com' || hostname.endsWith('.howlongtobeat.com');`. No new imports are needed; the `URL` constructor is already in use, and we only adjust the logic on line 437. All other behavior (status checks, path checks, JSON parsing, logging) is left unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
