### PR TITLE
Prevent double Fastify use decorator registration

### DIFF
--- a/server/src/hltb-cache.ts
+++ b/server/src/hltb-cache.ts
@@ -1,9 +1,9 @@
 import crypto from 'node:crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import middie from '@fastify/middie';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import type { Pool } from 'pg';
 import { incrementHltbMetric } from './cache-metrics.js';
+import { ensureMiddieRegistered } from './middleware.js';
 
 interface HltbCacheRow {
   response_json: unknown;
@@ -42,7 +42,7 @@ export async function registerHltbCachedRoute(
     response.setHeader('Content-Type', 'application/json; charset=utf-8');
     response.end(JSON.stringify({ error: 'Too many requests.' }));
   };
-  await app.register(middie);
+  await ensureMiddieRegistered(app);
   app.use(
     '/v1/hltb/search',
     expressRateLimit({

--- a/server/src/image-cache.ts
+++ b/server/src/image-cache.ts
@@ -3,10 +3,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { promises as fsPromises } from 'node:fs';
 import type { FastifyInstance } from 'fastify';
-import middie from '@fastify/middie';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import type { Pool } from 'pg';
 import { incrementImageMetric } from './cache-metrics.js';
+import { ensureMiddieRegistered } from './middleware.js';
 
 interface ImageAssetRow {
   cache_key: string;
@@ -54,7 +54,7 @@ export async function registerImageProxyRoute(
     response.setHeader('Content-Type', 'application/json; charset=utf-8');
     response.end(JSON.stringify({ error: 'Too many requests.' }));
   };
-  await app.register(middie);
+  await ensureMiddieRegistered(app);
 
   app.use(
     '/v1/images/cache/purge',

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,13 +4,13 @@ import { fileURLToPath } from 'node:url';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
-import middie from '@fastify/middie';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import { config } from './config.js';
 import { registerCacheObservabilityRoutes } from './cache-observability.js';
 import { createPool } from './db.js';
 import { registerImageProxyRoute } from './image-cache.js';
 import { registerHltbCachedRoute } from './hltb-cache.js';
+import { ensureMiddieRegistered } from './middleware.js';
 import { proxyMetadataToWorker } from './metadata.js';
 import { registerManualRoutes } from './manuals.js';
 import { shouldRequireAuth } from './request-security.js';
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
     credentials: true
   });
 
-  await app.register(middie);
+  await ensureMiddieRegistered(app);
   app.use(
     expressRateLimit({
       windowMs: 60_000,

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -1,0 +1,8 @@
+import type { FastifyInstance } from 'fastify';
+import middie from '@fastify/middie';
+
+export async function ensureMiddieRegistered(app: FastifyInstance): Promise<void> {
+  if (!app.hasDecorator('use')) {
+    await app.register(middie);
+  }
+}

--- a/server/src/sync.ts
+++ b/server/src/sync.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
-import middie from '@fastify/middie';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import type { Pool, PoolClient } from 'pg';
+import { ensureMiddieRegistered } from './middleware.js';
 import type {
   ClientSyncOperation,
   SyncEntityType,
@@ -39,7 +39,7 @@ export async function registerSyncRoutes(app: FastifyInstance, pool: Pool): Prom
     response.setHeader('Content-Type', 'application/json; charset=utf-8');
     response.end(JSON.stringify({ error: 'Too many requests.' }));
   };
-  await app.register(middie);
+  await ensureMiddieRegistered(app);
   app.use(
     '/v1/sync/push',
     expressRateLimit({


### PR DESCRIPTION
Summary
- describe the resolved issue: Fastify endpoints were crashing when the `use` decorator was registered twice in the API container
- ensure the decorator is only added once to avoid the `FST_ERR_DEC_ALREADY_PRESENT` error when the container boots

Testing
- Not run (not requested)