### PR TITLE
Move Device Write Token to Advanced settings

### DIFF
--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -92,7 +92,7 @@
 
     <ion-list lines="full">
       <ion-list-header>
-        <ion-label>Debug</ion-label>
+        <ion-label>Advanced</ion-label>
       </ion-list-header>
 
       <ion-item>
@@ -114,6 +114,12 @@
           >Clear</ion-button
         >
       </ion-item>
+    </ion-list>
+
+    <ion-list lines="full">
+      <ion-list-header>
+        <ion-label>Debug</ion-label>
+      </ion-list-header>
 
       <ion-item>
         <ion-icon slot="start" color="medium" name="bug"></ion-icon>

--- a/src/assets/runtime-config.js
+++ b/src/assets/runtime-config.js
@@ -2,7 +2,7 @@ window.__GAME_SHELF_RUNTIME_CONFIG__ = Object.assign(
   {},
   window.__GAME_SHELF_RUNTIME_CONFIG__,
   {
-    appVersion: "0.1.8",
+    appVersion: "0.1.17",
     featureFlags: {
       showMgcImport: false,
     },


### PR DESCRIPTION
Summary
- relocate the Device Write Token UI block to a new “Advanced” section on the settings page so it now appears above the debug section and below import/export controls

Testing
- Not run (not requested)