### PR TITLE
Add drop shadow to game detail cover

### DIFF
--- a/src/app/features/game-detail/game-detail-content.component.scss
+++ b/src/app/features/game-detail/game-detail-content.component.scss
@@ -29,6 +29,7 @@
   max-height: 100%;
   object-fit: contain;
   border-radius: 5px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
 }
 
 .detail-cover-backdrop {


### PR DESCRIPTION
## Summary
- add a deeper box shadow to the game detail image to emphasize its presence on the page

## Testing
- Not run (not requested)