### PR TITLE
Allow notes content to scroll independently

### DIFF
--- a/src/app/features/game-list/game-list.component.html
+++ b/src/app/features/game-list/game-list.component.html
@@ -512,7 +512,7 @@
       <ng-container [ngTemplateOutlet]="noteEditorToolbarTemplate"></ng-container>
     </ion-toolbar>
   </ion-header>
-  <ion-content class="detail-notes-content" [scrollY]="false">
+  <ion-content class="detail-notes-content">
     <ng-container [ngTemplateOutlet]="noteEditorCoreTemplate"></ng-container>
   </ion-content>
 </ng-template>


### PR DESCRIPTION
Summary
- remove the `scrollY` disable flag on the notes content so that only the inner content scrolls when the keyboard is open on phones, preventing the header from moving

Testing
- Not run (not requested)