### PR TITLE
fix(edge): include config artifacts in edge Docker build

### DIFF
--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -5,6 +5,7 @@ COPY package*.json ./
 RUN npm ci --no-audit --no-fund
 
 COPY angular.json ngsw-config.json tsconfig.json tsconfig.app.json tsconfig.spec.json ionic.config.json capacitor.config.ts ./
+COPY config ./config
 COPY scripts ./scripts
 COPY src ./src
 RUN npm run build


### PR DESCRIPTION
## Summary

Fix the `edge` image build failure in CI by ensuring required config artifacts are present during `npm run build`.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Updated [edge/Dockerfile](/Users/sixtopia/projects/game-shelf/edge/Dockerfile) build stage to copy the repo `config/` directory into `/app`.
- Added:
  - `COPY config ./config`
- This makes `/app/config/metacritic-platform-map.json` available to the `prebuild` script executed by `npm run build`.

## Testing performed

- Reviewed CI logs and confirmed failure was:
  - `ENOENT: no such file or directory, open '/app/config/metacritic-platform-map.json'`
- Verified `.dockerignore` does not exclude `config/`.
- Local image build/workflow rerun was not executed in this session.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [ ] Lint passes
- [ ] Tests pass
- [x] No console errors

## Related issues

Fixes #