### PR TITLE
fix(emulator): proxy rom/bios assets and harden iOS standalone startup

### DIFF
--- a/scripts/pwa-https-server.mjs
+++ b/scripts/pwa-https-server.mjs
@@ -348,7 +348,12 @@ export function createHandler(rootDir, proxyOrigin) {
       return;
     }
 
-    if (requestUrl.pathname.startsWith('/api/') || requestUrl.pathname.startsWith('/manuals/')) {
+    if (
+      requestUrl.pathname.startsWith('/api/') ||
+      requestUrl.pathname.startsWith('/manuals/') ||
+      requestUrl.pathname.startsWith('/roms/') ||
+      requestUrl.pathname.startsWith('/bios/')
+    ) {
       proxyRequest(request, response, proxyOrigin);
       return;
     }

--- a/scripts/pwa-https-server.test.mjs
+++ b/scripts/pwa-https-server.test.mjs
@@ -299,7 +299,15 @@ test('createHandler proxies rom and bios paths to upstream origin', async () => 
       '/bios/psx/psx-bios.zip',
     ]);
   } finally {
-    upstream.close();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
     rmSync(rootDir, { recursive: true, force: true });
   }
 });

--- a/scripts/pwa-https-server.test.mjs
+++ b/scripts/pwa-https-server.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -250,6 +251,55 @@ test('createHandler returns 404 for missing asset paths instead of the SPA shell
     assert.match(response.body, /Not found/);
     assert.equal(response.headers?.['Content-Type'], 'text/plain; charset=utf-8');
   } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test('createHandler proxies rom and bios paths to upstream origin', async () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), 'pwa-https-server-'));
+  writeFileSync(path.join(rootDir, 'index.html'), '<!doctype html><title>Game Shelf</title>');
+
+  const forwardedPaths = [];
+  const upstream = createServer((request, response) => {
+    forwardedPaths.push(request.url ?? '');
+    response.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    response.end('ok');
+  });
+
+  await new Promise((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address === 'object');
+  const proxyOrigin = `http://127.0.0.1:${String(address.port)}`;
+
+  try {
+    const handler = createHandler(rootDir, proxyOrigin);
+
+    const romResponse = new MockResponse();
+    const romRequest = new PassThrough();
+    romRequest.method = 'GET';
+    romRequest.url = '/roms/nes__pid-18/Super%20Mario%20Bros.%20(World)%20(HVC-SM).nes';
+    romRequest.headers = {};
+    handler(romRequest, romResponse);
+    romRequest.end();
+    await waitForStreamEnd(romResponse);
+    assert.equal(romResponse.statusCode, 200);
+
+    const biosResponse = new MockResponse();
+    const biosRequest = new PassThrough();
+    biosRequest.method = 'GET';
+    biosRequest.url = '/bios/psx/psx-bios.zip';
+    biosRequest.headers = {};
+    handler(biosRequest, biosResponse);
+    biosRequest.end();
+    await waitForStreamEnd(biosResponse);
+    assert.equal(biosResponse.statusCode, 200);
+
+    assert.deepEqual(forwardedPaths, [
+      '/roms/nes__pid-18/Super%20Mario%20Bros.%20(World)%20(HVC-SM).nes',
+      '/bios/psx/psx-bios.zip',
+    ]);
+  } finally {
+    upstream.close();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });

--- a/src/app/features/game-detail/emulator-js-modal.component.html
+++ b/src/app/features/game-detail/emulator-js-modal.component.html
@@ -1,6 +1,6 @@
 <ion-modal [isOpen]="isOpen" class="emulator-js-modal" (didDismiss)="onClose()">
   <ng-template>
-    <ion-content class="emulator-js-modal-content" [scrollY]="false">
+    <ion-content class="emulator-js-modal-content gs-safe-bottom" [scrollY]="false">
       @if (safeLaunchUrl) {
         <iframe
           #playFrame

--- a/src/app/features/game-detail/emulator-js-modal.component.html
+++ b/src/app/features/game-detail/emulator-js-modal.component.html
@@ -1,6 +1,6 @@
 <ion-modal [isOpen]="isOpen" class="emulator-js-modal" (didDismiss)="onClose()">
   <ng-template>
-    <ion-content class="emulator-js-modal-content gs-safe-bottom" [scrollY]="false">
+    <ion-content class="emulator-js-modal-content" [scrollY]="false">
       @if (safeLaunchUrl) {
         <iframe
           #playFrame

--- a/src/app/features/game-detail/emulator-js-modal.component.scss
+++ b/src/app/features/game-detail/emulator-js-modal.component.scss
@@ -7,6 +7,7 @@
 }
 
 .emulator-js-modal-content {
+  --background: #000;
   --ion-safe-area-bottom: 0px;
   --padding-start: 0;
   --padding-end: 0;

--- a/src/app/features/game-detail/emulator-js-modal.component.scss
+++ b/src/app/features/game-detail/emulator-js-modal.component.scss
@@ -16,10 +16,6 @@
   height: 100%;
 }
 
-.emulator-js-modal-content.gs-safe-bottom {
-  --padding-bottom: 0px;
-}
-
 .emulator-js-iframe {
   width: 100%;
   height: 100%;

--- a/src/app/features/game-detail/emulator-js-modal.component.scss
+++ b/src/app/features/game-detail/emulator-js-modal.component.scss
@@ -10,7 +10,7 @@
   --ion-safe-area-bottom: 0px;
   --padding-start: 0;
   --padding-end: 0;
-  --padding-top: 0;
+  --padding-top: var(--ion-safe-area-top, env(safe-area-inset-top));
   --padding-bottom: 0;
   height: 100%;
 }

--- a/src/app/features/game-detail/emulator-js-modal.component.scss
+++ b/src/app/features/game-detail/emulator-js-modal.component.scss
@@ -7,11 +7,16 @@
 }
 
 .emulator-js-modal-content {
+  --ion-safe-area-bottom: 0px;
   --padding-start: 0;
   --padding-end: 0;
   --padding-top: 0;
   --padding-bottom: 0;
   height: 100%;
+}
+
+.emulator-js-modal-content.gs-safe-bottom {
+  --padding-bottom: 0px;
 }
 
 .emulator-js-iframe {

--- a/src/assets/emulatorjs/play.html
+++ b/src/assets/emulatorjs/play.html
@@ -217,7 +217,13 @@
         } catch (_error) {
           isStandaloneDisplayMode = window.navigator.standalone === true;
         }
-        var isIosDevice = /iPad|iPhone|iPod/.test(window.navigator.userAgent);
+        var userAgent = window.navigator.userAgent || '';
+        var isClassicIosDevice = /iPad|iPhone|iPod/.test(userAgent);
+        var isIpadOsDesktopUa =
+          /Macintosh/.test(userAgent) &&
+          typeof window.navigator.maxTouchPoints === 'number' &&
+          window.navigator.maxTouchPoints > 1;
+        var isIosDevice = isClassicIosDevice || isIpadOsDesktopUa;
         /* iOS standalone PWAs can reject EmulatorJS auto-start media init unless user-gesture driven. */
         window.EJS_startOnLoaded = !(isStandaloneDisplayMode && isIosDevice);
         /* Do not set EJS_fullscreenOnLoaded: requestFullscreen() must run from a user gesture;

--- a/src/assets/emulatorjs/play.html
+++ b/src/assets/emulatorjs/play.html
@@ -207,7 +207,19 @@
           window.EJS_gameName = title;
         }
         window.EJS_pathtodata = normalizedPathToData;
-        window.EJS_startOnLoaded = true;
+        var isStandaloneDisplayMode = false;
+        try {
+          isStandaloneDisplayMode =
+            (window.matchMedia &&
+              typeof window.matchMedia === 'function' &&
+              window.matchMedia('(display-mode: standalone)').matches) ||
+            window.navigator.standalone === true;
+        } catch (_error) {
+          isStandaloneDisplayMode = window.navigator.standalone === true;
+        }
+        var isIosDevice = /iPad|iPhone|iPod/.test(window.navigator.userAgent);
+        /* iOS standalone PWAs can reject EmulatorJS auto-start media init unless user-gesture driven. */
+        window.EJS_startOnLoaded = !(isStandaloneDisplayMode && isIosDevice);
         /* Do not set EJS_fullscreenOnLoaded: requestFullscreen() must run from a user gesture;
            auto-fullscreen after ROM load is denied in iframes and EmulatorJS throws. */
         /* menu-bar-button: top-right control that toggles the bottom toolbar (EJS class ejs_virtualGamepad_open).

--- a/src/global.scss
+++ b/src/global.scss
@@ -67,7 +67,7 @@ ion-content.gs-safe-bottom-with-offset {
 }
 
 ion-modal.emulator-js-modal {
-  --ion-safe-area-top: 0px !important;
+  --ion-safe-area-top: inherit !important;
   --ion-safe-area-right: 0px !important;
   --ion-safe-area-bottom: 0px !important;
   --ion-safe-area-left: 0px !important;

--- a/src/global.scss
+++ b/src/global.scss
@@ -66,6 +66,13 @@ ion-content.gs-safe-bottom-with-offset {
   );
 }
 
+ion-modal.emulator-js-modal {
+  --ion-safe-area-top: 0px !important;
+  --ion-safe-area-right: 0px !important;
+  --ion-safe-area-bottom: 0px !important;
+  --ion-safe-area-left: 0px !important;
+}
+
 ion-fab-list {
   padding: 6px;
   border-radius: 18px;


### PR DESCRIPTION
## Summary

Fixes EmulatorJS runtime behavior for PWA usage by routing ROM/BIOS requests through the HTTPS proxy and avoiding unsupported auto-start behavior on iOS standalone mode.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [x] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Updated `createHandler` in `scripts/pwa-https-server.mjs` to proxy `/roms/` and `/bios/` paths in addition to existing `/api/` and `/manuals/` routes.
- Added coverage in `scripts/pwa-https-server.test.mjs` with an upstream HTTP server test asserting ROM and BIOS requests are forwarded to proxy origin.
- In `src/assets/emulatorjs/play.html`, changed EmulatorJS startup behavior:
  - Detects standalone display mode (`matchMedia('(display-mode: standalone)')` / `navigator.standalone`)
  - Detects iOS user agents
  - Disables `EJS_startOnLoaded` only for iOS standalone PWAs to avoid media-init/autostart failures.
- Adjusted modal safe-area styling for EmulatorJS fullscreen presentation in:
  - `src/app/features/game-detail/emulator-js-modal.component.scss`
  - `src/global.scss`

## Testing performed

- Ran `npm run lint` from repo root (pass).
- Ran `npm run test` from repo root (pass; 79 test files, 1241 tests).
- Ran `npm run build` from repo root (pass).
- Added/validated test path for proxying:
  - ROM path forwarded to upstream
  - BIOS path forwarded to upstream
  - Both return successful upstream responses.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #