### PR TITLE
fix(notifications): enforce iOS-safe push copy limits across notification flows

### DIFF
--- a/server/src/notification-copy-policy.test.ts
+++ b/server/src/notification-copy-policy.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { clampTitleWithSuffix, MAX_NOTIFICATION_TITLE } from './notification-copy-policy.js';
+
+void test('clampTitleWithSuffix omits separator when base title is empty or whitespace', () => {
+  assert.equal(
+    clampTitleWithSuffix({ baseTitle: '', suffix: 'on sale', max: MAX_NOTIFICATION_TITLE }),
+    'on sale'
+  );
+  assert.equal(
+    clampTitleWithSuffix({ baseTitle: '   ', suffix: 'on sale', max: MAX_NOTIFICATION_TITLE }),
+    'on sale'
+  );
+  assert.equal(
+    clampTitleWithSuffix({ baseTitle: '\t\n', suffix: 'on sale', max: MAX_NOTIFICATION_TITLE }),
+    'on sale'
+  );
+});
+
+void test('clampTitleWithSuffix clamps suffix-only output within max length', () => {
+  const suffix = 'a'.repeat(MAX_NOTIFICATION_TITLE + 10);
+  const result = clampTitleWithSuffix({ baseTitle: '   ', suffix, max: MAX_NOTIFICATION_TITLE });
+  assert.equal(result.length, MAX_NOTIFICATION_TITLE);
+  assert.ok(result.endsWith('...'));
+  assert.ok(!result.startsWith(' '));
+});

--- a/server/src/notification-copy-policy.ts
+++ b/server/src/notification-copy-policy.ts
@@ -25,7 +25,12 @@ export function clampTitleWithSuffix(args: {
     return clampTextWithEllipsis(args.baseTitle, max);
   }
 
-  const joined = `${args.baseTitle.trim()} ${normalizedSuffix}`;
+  const trimmedBase = args.baseTitle.trim();
+  if (trimmedBase.length === 0) {
+    return clampTextWithEllipsis(normalizedSuffix, max);
+  }
+
+  const joined = `${trimmedBase} ${normalizedSuffix}`;
   if (joined.length <= max) {
     return joined;
   }
@@ -36,6 +41,6 @@ export function clampTitleWithSuffix(args: {
     return clampTextWithEllipsis(joined, max);
   }
 
-  const clampedBase = clampTextWithEllipsis(args.baseTitle, availableBase);
+  const clampedBase = clampTextWithEllipsis(trimmedBase, availableBase);
   return `${clampedBase} ${normalizedSuffix}`;
 }

--- a/server/src/notification-copy-policy.ts
+++ b/server/src/notification-copy-policy.ts
@@ -1,0 +1,41 @@
+export const MAX_NOTIFICATION_TITLE = 40;
+export const MAX_NOTIFICATION_BODY = 90;
+
+export function clampTitleWithEllipsis(title: string, max = MAX_NOTIFICATION_TITLE): string {
+  const normalized = title.trim();
+  if (normalized.length <= max) {
+    return normalized;
+  }
+
+  if (max <= 3) {
+    return '.'.repeat(Math.max(0, max));
+  }
+
+  return `${normalized.slice(0, max - 3).trimEnd()}...`;
+}
+
+export function clampTitleWithSuffix(args: {
+  baseTitle: string;
+  suffix: string;
+  max?: number;
+}): string {
+  const max = args.max ?? MAX_NOTIFICATION_TITLE;
+  const normalizedSuffix = args.suffix.trim();
+  if (normalizedSuffix.length === 0) {
+    return clampTitleWithEllipsis(args.baseTitle, max);
+  }
+
+  const joined = `${args.baseTitle.trim()} ${normalizedSuffix}`;
+  if (joined.length <= max) {
+    return joined;
+  }
+
+  const minimumBaseBudget = 4;
+  const availableBase = max - normalizedSuffix.length - 1;
+  if (availableBase < minimumBaseBudget) {
+    return clampTitleWithEllipsis(joined, max);
+  }
+
+  const clampedBase = clampTitleWithEllipsis(args.baseTitle, availableBase);
+  return `${clampedBase} ${normalizedSuffix}`;
+}

--- a/server/src/notification-copy-policy.ts
+++ b/server/src/notification-copy-policy.ts
@@ -1,8 +1,8 @@
 export const MAX_NOTIFICATION_TITLE = 40;
 export const MAX_NOTIFICATION_BODY = 90;
 
-export function clampTitleWithEllipsis(title: string, max = MAX_NOTIFICATION_TITLE): string {
-  const normalized = title.trim();
+export function clampTextWithEllipsis(text: string, max = MAX_NOTIFICATION_TITLE): string {
+  const normalized = text.trim();
   if (normalized.length <= max) {
     return normalized;
   }
@@ -22,7 +22,7 @@ export function clampTitleWithSuffix(args: {
   const max = args.max ?? MAX_NOTIFICATION_TITLE;
   const normalizedSuffix = args.suffix.trim();
   if (normalizedSuffix.length === 0) {
-    return clampTitleWithEllipsis(args.baseTitle, max);
+    return clampTextWithEllipsis(args.baseTitle, max);
   }
 
   const joined = `${args.baseTitle.trim()} ${normalizedSuffix}`;
@@ -33,9 +33,9 @@ export function clampTitleWithSuffix(args: {
   const minimumBaseBudget = 4;
   const availableBase = max - normalizedSuffix.length - 1;
   if (availableBase < minimumBaseBudget) {
-    return clampTitleWithEllipsis(joined, max);
+    return clampTextWithEllipsis(joined, max);
   }
 
-  const clampedBase = clampTitleWithEllipsis(args.baseTitle, availableBase);
+  const clampedBase = clampTextWithEllipsis(args.baseTitle, availableBase);
   return `${clampedBase} ${normalizedSuffix}`;
 }

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -2,6 +2,11 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import { config } from './config.js';
 import { sendFcmMulticast } from './fcm.js';
+import {
+  clampTitleWithEllipsis,
+  MAX_NOTIFICATION_BODY,
+  MAX_NOTIFICATION_TITLE,
+} from './notification-copy-policy.js';
 import { applyRouteRateLimit } from './rate-limit.js';
 import { isAuthorizedMutatingRequest } from './request-security.js';
 
@@ -191,9 +196,11 @@ export function registerNotificationRoutes(app: FastifyInstance, pool: Pool): vo
         [TEST_ENDPOINT_MAX_ACTIVE_TOKENS]
       );
       const tokens = result.rows.map((row) => row.token);
+      const title = clampTitleWithEllipsis('Game Shelf Test Notification', MAX_NOTIFICATION_TITLE);
+      const body = `Open app to verify delivery at ${new Date().toISOString().slice(11, 16)} UTC.`;
       const sendResult = await sendFcmMulticast(tokens, {
-        title: 'Game Shelf Test Notification',
-        body: `Sent at ${new Date().toISOString()}`,
+        title,
+        body: body.length <= MAX_NOTIFICATION_BODY ? body : 'Open app to verify delivery.',
         data: {
           eventType: 'test',
           route: '/tabs/wishlist',

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -3,7 +3,7 @@ import type { Pool } from 'pg';
 import { config } from './config.js';
 import { sendFcmMulticast } from './fcm.js';
 import {
-  clampTitleWithEllipsis,
+  clampTextWithEllipsis,
   MAX_NOTIFICATION_BODY,
   MAX_NOTIFICATION_TITLE,
 } from './notification-copy-policy.js';
@@ -196,7 +196,7 @@ export function registerNotificationRoutes(app: FastifyInstance, pool: Pool): vo
         [TEST_ENDPOINT_MAX_ACTIVE_TOKENS]
       );
       const tokens = result.rows.map((row) => row.token);
-      const title = clampTitleWithEllipsis('Game Shelf Test Notification', MAX_NOTIFICATION_TITLE);
+      const title = clampTextWithEllipsis('Game Shelf Test Notification', MAX_NOTIFICATION_TITLE);
       const body = `Open app to verify delivery at ${new Date().toISOString().slice(11, 16)} UTC.`;
       const sendResult = await sendFcmMulticast(tokens, {
         title,

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -200,7 +200,7 @@ export function registerNotificationRoutes(app: FastifyInstance, pool: Pool): vo
       const body = `Open app to verify delivery at ${new Date().toISOString().slice(11, 16)} UTC.`;
       const sendResult = await sendFcmMulticast(tokens, {
         title,
-        body: body.length <= MAX_NOTIFICATION_BODY ? body : 'Open app to verify delivery.',
+        body: clampTextWithEllipsis(body, MAX_NOTIFICATION_BODY),
         data: {
           eventType: 'test',
           route: '/tabs/wishlist',

--- a/server/src/price-sale-notifications.test.ts
+++ b/server/src/price-sale-notifications.test.ts
@@ -159,10 +159,55 @@ void test('sends notification for wishlist transition from not-on-sale to on-sal
   );
 
   assert.equal(sends.length, 1);
-  assert.equal(sends[0]?.title, 'Elden Ring is on sale');
+  assert.equal(sends[0]?.title, 'Elden Ring on sale');
+  assert.ok((sends[0]?.title?.length ?? 0) <= 40);
+  assert.ok((sends[0]?.body?.length ?? 0) <= 90);
   assert.equal(sends[0]?.data['eventType'], 'price_on_sale');
   assert.equal(sends[0]?.data['route'], '/tabs/wishlist');
   assert.equal(pool.getLogCount(), 1);
+});
+
+void test('truncates very long sale notification title while preserving body visibility', async () => {
+  const pool = new SaleNotificationPoolMock();
+  pool.setPreferences(true, true);
+  pool.setTokens(['token-a']);
+  const sends: Array<{ title: string; body: string }> = [];
+
+  await maybeSendWishlistSaleNotification(
+    pool as unknown as Pool,
+    {
+      igdbGameId: '101',
+      platformIgdbId: 6,
+      previousPayload: {
+        listType: 'wishlist',
+        title: 'The Extremely Long and Overly Descriptive Title of a Future RPG Adventure',
+        priceAmount: 59.99,
+        priceRegularAmount: 59.99,
+        priceDiscountPercent: 0,
+        priceIsFree: false,
+      },
+      nextPayload: {
+        listType: 'wishlist',
+        title: 'The Extremely Long and Overly Descriptive Title of a Future RPG Adventure',
+        priceAmount: 29.99,
+        priceRegularAmount: 59.99,
+        priceDiscountPercent: 50,
+        priceIsFree: false,
+        priceCurrency: 'USD',
+      },
+    },
+    {
+      sendMulticast: (_tokens, payload) => {
+        sends.push({ title: payload.title, body: payload.body });
+        return Promise.resolve({ successCount: 1, failureCount: 0, invalidTokens: [] });
+      },
+    }
+  );
+
+  assert.equal(sends.length, 1);
+  assert.ok(sends[0]?.title.endsWith('... on sale'));
+  assert.ok((sends[0]?.title.length ?? 0) <= 40);
+  assert.ok((sends[0]?.body.length ?? 0) <= 90);
 });
 
 void test('skips notification when game is already on sale', async () => {

--- a/server/src/price-sale-notifications.test.ts
+++ b/server/src/price-sale-notifications.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { Pool } from 'pg';
+import { MAX_NOTIFICATION_BODY, MAX_NOTIFICATION_TITLE } from './notification-copy-policy.js';
 import { maybeSendWishlistSaleNotification } from './price-sale-notifications.js';
 
 interface NotificationLogRow {
@@ -160,8 +161,8 @@ void test('sends notification for wishlist transition from not-on-sale to on-sal
 
   assert.equal(sends.length, 1);
   assert.equal(sends[0]?.title, 'Elden Ring on sale');
-  assert.ok((sends[0]?.title?.length ?? 0) <= 40);
-  assert.ok((sends[0]?.body?.length ?? 0) <= 90);
+  assert.ok((sends[0]?.title?.length ?? 0) <= MAX_NOTIFICATION_TITLE);
+  assert.ok((sends[0]?.body?.length ?? 0) <= MAX_NOTIFICATION_BODY);
   assert.equal(sends[0]?.data['eventType'], 'price_on_sale');
   assert.equal(sends[0]?.data['route'], '/tabs/wishlist');
   assert.equal(pool.getLogCount(), 1);
@@ -206,8 +207,8 @@ void test('truncates very long sale notification title while preserving body vis
 
   assert.equal(sends.length, 1);
   assert.ok(sends[0]?.title.endsWith('... on sale'));
-  assert.ok((sends[0]?.title.length ?? 0) <= 40);
-  assert.ok((sends[0]?.body.length ?? 0) <= 90);
+  assert.ok((sends[0]?.title.length ?? 0) <= MAX_NOTIFICATION_TITLE);
+  assert.ok((sends[0]?.body.length ?? 0) <= MAX_NOTIFICATION_BODY);
 });
 
 void test('skips notification when game is already on sale', async () => {

--- a/server/src/price-sale-notifications.ts
+++ b/server/src/price-sale-notifications.ts
@@ -1,5 +1,6 @@
 import type { Pool } from 'pg';
 import { sendFcmMulticast, type FcmSendResult } from './fcm.js';
+import { clampTitleWithSuffix, MAX_NOTIFICATION_TITLE } from './notification-copy-policy.js';
 import {
   MAX_ACTIVE_TOKENS_PER_RUN,
   RELEASE_NOTIFICATION_EVENTS_KEY,
@@ -237,7 +238,11 @@ function buildSaleNotificationEvent(args: {
 
   return {
     type: 'price_on_sale',
-    title: `${args.title} is on sale`,
+    title: clampTitleWithSuffix({
+      baseTitle: args.title,
+      suffix: 'on sale',
+      max: MAX_NOTIFICATION_TITLE,
+    }),
     body: `Now ${displayPrice}${discountSuffix}.`,
     eventKey,
     payload: {

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -1900,14 +1900,14 @@ function buildReleaseEventBody(gameTitle: string, detail: string): string {
   }
 
   const titleDetailSeparator = ': ';
-  const minimumTitleBudget = 1;
+  const minimumTitleBudget = 4;
   const maxDetailLength = Math.max(
     1,
     MAX_NOTIFICATION_BODY - titleDetailSeparator.length - minimumTitleBudget
   );
   const clampedDetail = clampTextWithEllipsis(normalizedDetail, maxDetailLength);
   const suffix = `${titleDetailSeparator}${clampedDetail}`;
-  const titleBudget = Math.max(1, MAX_NOTIFICATION_BODY - suffix.length);
+  const titleBudget = Math.max(minimumTitleBudget, MAX_NOTIFICATION_BODY - suffix.length);
   const displayTitle = clampTextWithEllipsis(gameTitle, titleBudget);
   return `${displayTitle}${suffix}`;
 }

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -4,11 +4,7 @@ import { config } from './config.js';
 import { BackgroundJobRepository } from './background-jobs.js';
 import { sendFcmMulticast } from './fcm.js';
 import { fetchMetadataPathFromWorker } from './metadata.js';
-import {
-  clampTitleWithSuffix,
-  MAX_NOTIFICATION_BODY,
-  MAX_NOTIFICATION_TITLE,
-} from './notification-copy-policy.js';
+import { clampTitleWithEllipsis, MAX_NOTIFICATION_BODY } from './notification-copy-policy.js';
 import {
   MAX_ACTIVE_TOKENS_PER_RUN,
   RELEASE_NOTIFICATION_EVENTS_KEY,
@@ -1194,16 +1190,10 @@ function buildReleaseEvents(args: {
   if (!beforeKnown && afterKnown) {
     const afterMarker = after.marker ?? 'unknown';
     const afterDisplay = after.display ?? afterMarker;
-    const title = clampTitleWithSuffix({
-      baseTitle: args.title,
-      suffix: '- date set',
-      max: MAX_NOTIFICATION_TITLE,
-    });
-    const body = `Release timing: ${afterDisplay}.`;
     events.push({
       type: 'release_date_set',
-      title,
-      body: body.length <= MAX_NOTIFICATION_BODY ? body : 'Release timing updated.',
+      title: 'Release date set',
+      body: buildReleaseEventBody(args.title, `Release timing: ${afterDisplay}.`),
       eventKey: `release_date_set:${args.igdbGameId}:${String(args.platformIgdbId)}:${after.precision}:${afterMarker}`,
       releaseMarker: afterMarker,
     });
@@ -1218,16 +1208,10 @@ function buildReleaseEvents(args: {
     const afterMarker = after.marker ?? 'unknown';
     const beforeDisplay = before.display ?? beforeMarker;
     const afterDisplay = after.display ?? afterMarker;
-    const title = clampTitleWithSuffix({
-      baseTitle: args.title,
-      suffix: '- date changed',
-      max: MAX_NOTIFICATION_TITLE,
-    });
-    const body = `${beforeDisplay} -> ${afterDisplay}.`;
     events.push({
       type: 'release_date_changed',
-      title,
-      body: body.length <= MAX_NOTIFICATION_BODY ? body : 'Release date changed.',
+      title: 'Release date changed',
+      body: buildReleaseEventBody(args.title, `${beforeDisplay} -> ${afterDisplay}.`),
       eventKey: `release_date_changed:${args.igdbGameId}:${String(args.platformIgdbId)}:${before.precision}:${beforeMarker}:${after.precision}:${afterMarker}`,
       releaseMarker: afterMarker,
     });
@@ -1235,15 +1219,10 @@ function buildReleaseEvents(args: {
 
   if (beforeKnown && !afterKnown) {
     const beforeMarker = before.marker ?? 'unknown';
-    const title = clampTitleWithSuffix({
-      baseTitle: args.title,
-      suffix: '- date removed',
-      max: MAX_NOTIFICATION_TITLE,
-    });
     events.push({
       type: 'release_date_removed',
-      title,
-      body: 'Release date removed.',
+      title: 'Release date removed',
+      body: buildReleaseEventBody(args.title, 'Release date removed.'),
       eventKey: `release_date_removed:${args.igdbGameId}:${String(args.platformIgdbId)}:${before.precision}:${beforeMarker}`,
       releaseMarker: null,
     });
@@ -1256,15 +1235,10 @@ function buildReleaseEvents(args: {
   ) {
     // This can evaluate true across multiple monitor runs on release day; delivery
     // remains single-shot via event_key reservation in release_notification_log.
-    const title = clampTitleWithSuffix({
-      baseTitle: args.title,
-      suffix: '- releases today',
-      max: MAX_NOTIFICATION_TITLE,
-    });
     events.push({
       type: 'release_day',
-      title,
-      body: 'Scheduled release reached.',
+      title: 'Releases today',
+      body: buildReleaseEventBody(args.title, 'Scheduled release reached.'),
       eventKey: `release_day:${args.igdbGameId}:${String(args.platformIgdbId)}:${after.marker}`,
       releaseMarker: after.marker,
     });
@@ -1904,6 +1878,14 @@ function formatReleaseNotificationDate(dateString: string): string {
   }
 
   return RELEASE_NOTIFICATION_FULL_DATE_FORMATTER.format(parsed);
+}
+
+function buildReleaseEventBody(gameTitle: string, detail: string): string {
+  const normalizedDetail = detail.trim();
+  const suffix = normalizedDetail.length > 0 ? `: ${normalizedDetail}` : '';
+  const titleBudget = Math.max(1, MAX_NOTIFICATION_BODY - suffix.length);
+  const displayTitle = clampTitleWithEllipsis(gameTitle, titleBudget);
+  return `${displayTitle}${suffix}`;
 }
 
 function parseDateOnlyAsLocalDate(value: string): Date | null {

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -5,6 +5,11 @@ import { BackgroundJobRepository } from './background-jobs.js';
 import { sendFcmMulticast } from './fcm.js';
 import { fetchMetadataPathFromWorker } from './metadata.js';
 import {
+  clampTitleWithSuffix,
+  MAX_NOTIFICATION_BODY,
+  MAX_NOTIFICATION_TITLE,
+} from './notification-copy-policy.js';
+import {
   MAX_ACTIVE_TOKENS_PER_RUN,
   RELEASE_NOTIFICATION_EVENTS_KEY,
   RELEASE_NOTIFICATIONS_ENABLED_KEY,
@@ -1189,10 +1194,16 @@ function buildReleaseEvents(args: {
   if (!beforeKnown && afterKnown) {
     const afterMarker = after.marker ?? 'unknown';
     const afterDisplay = after.display ?? afterMarker;
+    const title = clampTitleWithSuffix({
+      baseTitle: args.title,
+      suffix: '- date set',
+      max: MAX_NOTIFICATION_TITLE,
+    });
+    const body = `Release timing: ${afterDisplay}.`;
     events.push({
       type: 'release_date_set',
-      title: `${args.title}: Release date set`,
-      body: `${args.title} now has a release timing (${afterDisplay}).`,
+      title,
+      body: body.length <= MAX_NOTIFICATION_BODY ? body : 'Release timing updated.',
       eventKey: `release_date_set:${args.igdbGameId}:${String(args.platformIgdbId)}:${after.precision}:${afterMarker}`,
       releaseMarker: afterMarker,
     });
@@ -1207,10 +1218,16 @@ function buildReleaseEvents(args: {
     const afterMarker = after.marker ?? 'unknown';
     const beforeDisplay = before.display ?? beforeMarker;
     const afterDisplay = after.display ?? afterMarker;
+    const title = clampTitleWithSuffix({
+      baseTitle: args.title,
+      suffix: '- date changed',
+      max: MAX_NOTIFICATION_TITLE,
+    });
+    const body = `${beforeDisplay} -> ${afterDisplay}.`;
     events.push({
       type: 'release_date_changed',
-      title: `${args.title}: Release date changed`,
-      body: `${args.title} moved from ${beforeDisplay} to ${afterDisplay}.`,
+      title,
+      body: body.length <= MAX_NOTIFICATION_BODY ? body : 'Release date changed.',
       eventKey: `release_date_changed:${args.igdbGameId}:${String(args.platformIgdbId)}:${before.precision}:${beforeMarker}:${after.precision}:${afterMarker}`,
       releaseMarker: afterMarker,
     });
@@ -1218,10 +1235,15 @@ function buildReleaseEvents(args: {
 
   if (beforeKnown && !afterKnown) {
     const beforeMarker = before.marker ?? 'unknown';
+    const title = clampTitleWithSuffix({
+      baseTitle: args.title,
+      suffix: '- date removed',
+      max: MAX_NOTIFICATION_TITLE,
+    });
     events.push({
       type: 'release_date_removed',
-      title: `${args.title}: Release date removed`,
-      body: `${args.title} no longer has a confirmed release date.`,
+      title,
+      body: 'Release date removed.',
       eventKey: `release_date_removed:${args.igdbGameId}:${String(args.platformIgdbId)}:${before.precision}:${beforeMarker}`,
       releaseMarker: null,
     });
@@ -1234,10 +1256,15 @@ function buildReleaseEvents(args: {
   ) {
     // This can evaluate true across multiple monitor runs on release day; delivery
     // remains single-shot via event_key reservation in release_notification_log.
+    const title = clampTitleWithSuffix({
+      baseTitle: args.title,
+      suffix: '- releases today',
+      max: MAX_NOTIFICATION_TITLE,
+    });
     events.push({
       type: 'release_day',
-      title: `${args.title} releases today`,
-      body: `${args.title} has reached its scheduled release date.`,
+      title,
+      body: 'Scheduled release reached.',
       eventKey: `release_day:${args.igdbGameId}:${String(args.platformIgdbId)}:${after.marker}`,
       releaseMarker: after.marker,
     });

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -23,6 +23,10 @@ const RELEASE_NOTIFICATION_FULL_DATE_FORMATTER = new Intl.DateTimeFormat('en-US'
   month: 'short',
   year: 'numeric',
 });
+const RELEASE_NOTIFICATION_MONTH_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+});
 
 type ReleaseEventType =
   | 'release_date_set'
@@ -1726,7 +1730,7 @@ function normalizeReleaseInfoFromPrecision(
       marker: `${monthMatch[1]}-${monthMatch[2]}`,
       date: null,
       year: integerOrNull(monthMatch[1]),
-      display: formatReleaseNotificationDate(`${monthMatch[1]}-${monthMatch[2]}-01`),
+      display: formatReleaseNotificationMonthYear(`${monthMatch[1]}-${monthMatch[2]}`),
     };
   }
 
@@ -1880,12 +1884,47 @@ function formatReleaseNotificationDate(dateString: string): string {
   return RELEASE_NOTIFICATION_FULL_DATE_FORMATTER.format(parsed);
 }
 
+function formatReleaseNotificationMonthYear(monthString: string): string {
+  const parsed = parseMonthOnlyAsLocalDate(monthString);
+  if (!parsed) {
+    return monthString;
+  }
+
+  return RELEASE_NOTIFICATION_MONTH_YEAR_FORMATTER.format(parsed);
+}
+
 function buildReleaseEventBody(gameTitle: string, detail: string): string {
   const normalizedDetail = detail.trim();
-  const suffix = normalizedDetail.length > 0 ? `: ${normalizedDetail}` : '';
+  if (normalizedDetail.length === 0) {
+    return clampTitleWithEllipsis(gameTitle, MAX_NOTIFICATION_BODY);
+  }
+
+  const maxDetailLength = Math.max(1, MAX_NOTIFICATION_BODY - 3);
+  const clampedDetail = clampTitleWithEllipsis(normalizedDetail, maxDetailLength);
+  const suffix = `: ${clampedDetail}`;
   const titleBudget = Math.max(1, MAX_NOTIFICATION_BODY - suffix.length);
   const displayTitle = clampTitleWithEllipsis(gameTitle, titleBudget);
   return `${displayTitle}${suffix}`;
+}
+
+function parseMonthOnlyAsLocalDate(value: string): Date | null {
+  const normalized = value.trim();
+  const match = normalized.match(/^(\d{4})-(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  if (!Number.isFinite(year) || !Number.isFinite(monthIndex)) {
+    return null;
+  }
+  if (monthIndex < 0 || monthIndex > 11) {
+    return null;
+  }
+
+  const date = new Date(year, monthIndex, 1);
+  return date.getFullYear() === year && date.getMonth() === monthIndex ? date : null;
 }
 
 function parseDateOnlyAsLocalDate(value: string): Date | null {

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -4,7 +4,7 @@ import { config } from './config.js';
 import { BackgroundJobRepository } from './background-jobs.js';
 import { sendFcmMulticast } from './fcm.js';
 import { fetchMetadataPathFromWorker } from './metadata.js';
-import { clampTitleWithEllipsis, MAX_NOTIFICATION_BODY } from './notification-copy-policy.js';
+import { clampTextWithEllipsis, MAX_NOTIFICATION_BODY } from './notification-copy-policy.js';
 import {
   MAX_ACTIVE_TOKENS_PER_RUN,
   RELEASE_NOTIFICATION_EVENTS_KEY,
@@ -1896,14 +1896,19 @@ function formatReleaseNotificationMonthYear(monthString: string): string {
 function buildReleaseEventBody(gameTitle: string, detail: string): string {
   const normalizedDetail = detail.trim();
   if (normalizedDetail.length === 0) {
-    return clampTitleWithEllipsis(gameTitle, MAX_NOTIFICATION_BODY);
+    return clampTextWithEllipsis(gameTitle, MAX_NOTIFICATION_BODY);
   }
 
-  const maxDetailLength = Math.max(1, MAX_NOTIFICATION_BODY - 3);
-  const clampedDetail = clampTitleWithEllipsis(normalizedDetail, maxDetailLength);
-  const suffix = `: ${clampedDetail}`;
+  const titleDetailSeparator = ': ';
+  const minimumTitleBudget = 1;
+  const maxDetailLength = Math.max(
+    1,
+    MAX_NOTIFICATION_BODY - titleDetailSeparator.length - minimumTitleBudget
+  );
+  const clampedDetail = clampTextWithEllipsis(normalizedDetail, maxDetailLength);
+  const suffix = `${titleDetailSeparator}${clampedDetail}`;
   const titleBudget = Math.max(1, MAX_NOTIFICATION_BODY - suffix.length);
-  const displayTitle = clampTitleWithEllipsis(gameTitle, titleBudget);
+  const displayTitle = clampTextWithEllipsis(gameTitle, titleBudget);
   return `${displayTitle}${suffix}`;
 }
 

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -1928,7 +1928,7 @@ function parseMonthOnlyAsLocalDate(value: string): Date | null {
     return null;
   }
 
-  const date = new Date(year, monthIndex, 1);
+  const date = createLocalDatePreservingFullYear(year, monthIndex, 1);
   return date.getFullYear() === year && date.getMonth() === monthIndex ? date : null;
 }
 
@@ -1946,10 +1946,17 @@ function parseDateOnlyAsLocalDate(value: string): Date | null {
     return null;
   }
 
-  const date = new Date(year, monthIndex, day);
+  const date = createLocalDatePreservingFullYear(year, monthIndex, day);
   return date.getFullYear() === year && date.getMonth() === monthIndex && date.getDate() === day
     ? date
     : null;
+}
+
+function createLocalDatePreservingFullYear(year: number, monthIndex: number, day: number): Date {
+  const date = new Date(0);
+  date.setHours(0, 0, 0, 0);
+  date.setFullYear(year, monthIndex, day);
+  return date;
 }
 
 function normalizeDateString(value: string | null | undefined): string | null {

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -18,7 +18,7 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_UNRELEASED_NEXT_CHECK_MS = 15 * ONE_DAY_MS;
 const QUEUED_GAME_CONTEXT_CACHE_TTL_MS = 10_000;
 const DUE_SELECTION_SOURCE_ID = 'games_collection_or_wishlist_due';
-const RELEASE_NOTIFICATION_FULL_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const RELEASE_NOTIFICATION_FULL_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
   month: 'short',
   year: 'numeric',

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -1238,7 +1238,7 @@ function buildReleaseEvents(args: {
     events.push({
       type: 'release_day',
       title: 'Releases today',
-      body: buildReleaseEventBody(args.title, 'Scheduled release reached.'),
+      body: buildReleaseEventBody(args.title, 'releases today.'),
       eventKey: `release_day:${args.igdbGameId}:${String(args.platformIgdbId)}:${after.marker}`,
       releaseMarker: after.marker,
     });

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -17,6 +17,11 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_UNRELEASED_NEXT_CHECK_MS = 15 * ONE_DAY_MS;
 const QUEUED_GAME_CONTEXT_CACHE_TTL_MS = 10_000;
 const DUE_SELECTION_SOURCE_ID = 'games_collection_or_wishlist_due';
+const RELEASE_NOTIFICATION_FULL_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
 
 type ReleaseEventType =
   | 'release_date_set'
@@ -1689,7 +1694,7 @@ function normalizeReleaseInfoFromPrecision(
       marker: day,
       date: day,
       year: integerOrNull(day.slice(0, 4)),
-      display: day,
+      display: formatReleaseNotificationDate(day),
     };
   }
 
@@ -1720,7 +1725,7 @@ function normalizeReleaseInfoFromPrecision(
       marker: `${monthMatch[1]}-${monthMatch[2]}`,
       date: null,
       year: integerOrNull(monthMatch[1]),
-      display: `${monthMatch[1]}-${monthMatch[2]}`,
+      display: formatReleaseNotificationDate(`${monthMatch[1]}-${monthMatch[2]}-01`),
     };
   }
 
@@ -1863,6 +1868,35 @@ function normalizeReleasePrecision(value: string | null): ReleasePrecision | nul
 
 function formatDateOnly(value: Date): string {
   return value.toISOString().slice(0, 10);
+}
+
+function formatReleaseNotificationDate(dateString: string): string {
+  const parsed = parseDateOnlyAsLocalDate(dateString);
+  if (!parsed) {
+    return dateString;
+  }
+
+  return RELEASE_NOTIFICATION_FULL_DATE_FORMATTER.format(parsed);
+}
+
+function parseDateOnlyAsLocalDate(value: string): Date | null {
+  const normalized = value.trim();
+  const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  if (!Number.isFinite(year) || !Number.isFinite(monthIndex) || !Number.isFinite(day)) {
+    return null;
+  }
+
+  const date = new Date(year, monthIndex, day);
+  return date.getFullYear() === year && date.getMonth() === monthIndex && date.getDate() === day
+    ? date
+    : null;
 }
 
 function normalizeDateString(value: string | null | undefined): string | null {

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { Pool } from 'pg';
 import { config } from '../config.js';
+import { MAX_NOTIFICATION_BODY, MAX_NOTIFICATION_TITLE } from '../notification-copy-policy.js';
 import { releaseMonitorInternals, startReleaseMonitor } from '../release-monitor.js';
 
 class NotificationSettingsPoolMock {
@@ -39,8 +40,8 @@ void test('release events include set/changed/removed/day transitions', () => {
     setEvents.map((entry) => entry.type),
     ['release_date_set']
   );
-  assert.ok((setEvents[0]?.title.length ?? 0) <= 40);
-  assert.ok((setEvents[0]?.body.length ?? 0) <= 90);
+  assert.ok((setEvents[0]?.title.length ?? 0) <= MAX_NOTIFICATION_TITLE);
+  assert.ok((setEvents[0]?.body.length ?? 0) <= MAX_NOTIFICATION_BODY);
 
   const changedAndDayEvents = releaseMonitorInternals.buildReleaseEvents({
     igdbGameId: '52189',
@@ -69,8 +70,8 @@ void test('release events include set/changed/removed/day transitions', () => {
   assert.equal(changedAndDayEvents[1]?.title, 'Releases today');
   assert.equal(changedAndDayEvents[1]?.body, 'Grand Theft Auto VI: releases today.');
   changedAndDayEvents.forEach((event) => {
-    assert.ok(event.title.length <= 40);
-    assert.ok(event.body.length <= 90);
+    assert.ok(event.title.length <= MAX_NOTIFICATION_TITLE);
+    assert.ok(event.body.length <= MAX_NOTIFICATION_BODY);
   });
 
   const removedEvents = releaseMonitorInternals.buildReleaseEvents({
@@ -97,8 +98,8 @@ void test('release events include set/changed/removed/day transitions', () => {
     removedEvents.map((entry) => entry.type),
     ['release_date_removed']
   );
-  assert.ok((removedEvents[0]?.title.length ?? 0) <= 40);
-  assert.ok((removedEvents[0]?.body.length ?? 0) <= 90);
+  assert.ok((removedEvents[0]?.title.length ?? 0) <= MAX_NOTIFICATION_TITLE);
+  assert.ok((removedEvents[0]?.body.length ?? 0) <= MAX_NOTIFICATION_BODY);
 
   const impreciseChangedEvents = releaseMonitorInternals.buildReleaseEvents({
     igdbGameId: '92550',
@@ -124,8 +125,8 @@ void test('release events include set/changed/removed/day transitions', () => {
     impreciseChangedEvents.map((entry) => entry.type),
     ['release_date_changed']
   );
-  assert.ok((impreciseChangedEvents[0]?.title.length ?? 0) <= 40);
-  assert.ok((impreciseChangedEvents[0]?.body.length ?? 0) <= 90);
+  assert.ok((impreciseChangedEvents[0]?.title.length ?? 0) <= MAX_NOTIFICATION_TITLE);
+  assert.ok((impreciseChangedEvents[0]?.body.length ?? 0) <= MAX_NOTIFICATION_BODY);
 });
 
 void test('release event bodies clamp long title prefixes to iOS-friendly length', () => {
@@ -153,8 +154,8 @@ void test('release event bodies clamp long title prefixes to iOS-friendly length
   assert.equal(events.length, 1);
   assert.equal(events[0]?.title, 'Release date set');
   assert.ok(events[0]?.body.includes(': Release timing: Dec 1, 2026.'));
-  assert.ok((events[0]?.title.length ?? 0) <= 40);
-  assert.ok((events[0]?.body.length ?? 0) <= 90);
+  assert.ok((events[0]?.title.length ?? 0) <= MAX_NOTIFICATION_TITLE);
+  assert.ok((events[0]?.body.length ?? 0) <= MAX_NOTIFICATION_BODY);
 });
 
 void test('release event body clamps very long detail suffix to iOS-safe length', () => {
@@ -183,7 +184,7 @@ void test('release event body clamps very long detail suffix to iOS-safe length'
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, 'release_date_changed');
   assert.ok(events[0]?.body.startsWith('S: '));
-  assert.ok((events[0]?.body.length ?? 0) <= 90);
+  assert.ok((events[0]?.body.length ?? 0) <= MAX_NOTIFICATION_BODY);
 });
 
 void test('unknown release date cadence is weekly for future/unknown year and yearly for past years', () => {

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -39,6 +39,8 @@ void test('release events include set/changed/removed/day transitions', () => {
     setEvents.map((entry) => entry.type),
     ['release_date_set']
   );
+  assert.ok((setEvents[0]?.title.length ?? 0) <= 40);
+  assert.ok((setEvents[0]?.body.length ?? 0) <= 90);
 
   const changedAndDayEvents = releaseMonitorInternals.buildReleaseEvents({
     igdbGameId: '52189',
@@ -64,6 +66,10 @@ void test('release events include set/changed/removed/day transitions', () => {
     changedAndDayEvents.map((entry) => entry.type),
     ['release_date_changed', 'release_day']
   );
+  changedAndDayEvents.forEach((event) => {
+    assert.ok(event.title.length <= 40);
+    assert.ok(event.body.length <= 90);
+  });
 
   const removedEvents = releaseMonitorInternals.buildReleaseEvents({
     igdbGameId: '52189',
@@ -89,6 +95,8 @@ void test('release events include set/changed/removed/day transitions', () => {
     removedEvents.map((entry) => entry.type),
     ['release_date_removed']
   );
+  assert.ok((removedEvents[0]?.title.length ?? 0) <= 40);
+  assert.ok((removedEvents[0]?.body.length ?? 0) <= 90);
 
   const impreciseChangedEvents = releaseMonitorInternals.buildReleaseEvents({
     igdbGameId: '92550',
@@ -114,6 +122,36 @@ void test('release events include set/changed/removed/day transitions', () => {
     impreciseChangedEvents.map((entry) => entry.type),
     ['release_date_changed']
   );
+  assert.ok((impreciseChangedEvents[0]?.title.length ?? 0) <= 40);
+  assert.ok((impreciseChangedEvents[0]?.body.length ?? 0) <= 90);
+});
+
+void test('release event titles clamp long game names to iOS-friendly length', () => {
+  const events = releaseMonitorInternals.buildReleaseEvents({
+    igdbGameId: '99999',
+    platformIgdbId: 167,
+    title: 'A Very Long Upcoming Game Name That Should Be Truncated For Notifications',
+    releaseBefore: {
+      precision: 'unknown',
+      marker: null,
+      date: null,
+      year: null,
+      display: null,
+    },
+    releaseAfter: {
+      precision: 'day',
+      marker: '2026-12-01',
+      date: '2026-12-01',
+      year: 2026,
+      display: 'Dec 1, 2026',
+    },
+    now: new Date('2026-03-06T10:00:00.000Z'),
+  });
+
+  assert.equal(events.length, 1);
+  assert.ok(events[0]?.title.endsWith('... - date set'));
+  assert.ok((events[0]?.title.length ?? 0) <= 40);
+  assert.ok((events[0]?.body.length ?? 0) <= 90);
 });
 
 void test('unknown release date cadence is weekly for future/unknown year and yearly for past years', () => {

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -182,6 +182,7 @@ void test('release event body clamps very long detail suffix to iOS-safe length'
 
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, 'release_date_changed');
+  assert.ok(events[0]?.body.startsWith('S: '));
   assert.ok((events[0]?.body.length ?? 0) <= 90);
 });
 

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -149,7 +149,8 @@ void test('release event titles clamp long game names to iOS-friendly length', (
   });
 
   assert.equal(events.length, 1);
-  assert.ok(events[0]?.title.endsWith('... - date set'));
+  assert.equal(events[0]?.title, 'Release date set');
+  assert.ok(events[0]?.body.includes(': Release timing: Dec 1, 2026.'));
   assert.ok((events[0]?.title.length ?? 0) <= 40);
   assert.ok((events[0]?.body.length ?? 0) <= 90);
 });

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -128,7 +128,7 @@ void test('release events include set/changed/removed/day transitions', () => {
   assert.ok((impreciseChangedEvents[0]?.body.length ?? 0) <= 90);
 });
 
-void test('release event titles clamp long game names to iOS-friendly length', () => {
+void test('release event bodies clamp long title prefixes to iOS-friendly length', () => {
   const events = releaseMonitorInternals.buildReleaseEvents({
     igdbGameId: '99999',
     platformIgdbId: 167,
@@ -776,6 +776,9 @@ void test('normalizers handle invalid marker and precision inputs', () => {
     '2026-11-19'
   );
   assert.equal(releaseMonitorInternals.normalizeDateString('Q4 2026'), null);
+
+  const dayInfo = releaseMonitorInternals.normalizeReleaseInfoFromPrecision('day', '2026-12-01');
+  assert.equal(dayInfo.display, 'Dec 1, 2026');
 
   const monthInfo = releaseMonitorInternals.normalizeReleaseInfoFromPrecision('month', '2026-12');
   assert.equal(monthInfo.display, 'Dec 2026');

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -66,6 +66,8 @@ void test('release events include set/changed/removed/day transitions', () => {
     changedAndDayEvents.map((entry) => entry.type),
     ['release_date_changed', 'release_day']
   );
+  assert.equal(changedAndDayEvents[1]?.title, 'Releases today');
+  assert.equal(changedAndDayEvents[1]?.body, 'Grand Theft Auto VI: releases today.');
   changedAndDayEvents.forEach((event) => {
     assert.ok(event.title.length <= 40);
     assert.ok(event.body.length <= 90);

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -157,6 +157,34 @@ void test('release event titles clamp long game names to iOS-friendly length', (
   assert.ok((events[0]?.body.length ?? 0) <= 90);
 });
 
+void test('release event body clamps very long detail suffix to iOS-safe length', () => {
+  const events = releaseMonitorInternals.buildReleaseEvents({
+    igdbGameId: '99111',
+    platformIgdbId: 6,
+    title: 'S',
+    releaseBefore: {
+      precision: 'day',
+      marker: '2026-01-01',
+      date: '2026-01-01',
+      year: 2026,
+      display: 'Jan 1, 2026',
+    },
+    releaseAfter: {
+      precision: 'day',
+      marker: '2026-12-31',
+      date: '2026-12-31',
+      year: 2026,
+      display:
+        'This is an intentionally huge release timing detail that should be clamped to stay within the body limit',
+    },
+    now: new Date('2026-03-06T10:00:00.000Z'),
+  });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, 'release_date_changed');
+  assert.ok((events[0]?.body.length ?? 0) <= 90);
+});
+
 void test('unknown release date cadence is weekly for future/unknown year and yearly for past years', () => {
   const now = new Date('2026-03-06T10:00:00.000Z');
   const oneDayMs = 24 * 60 * 60 * 1000;
@@ -748,6 +776,9 @@ void test('normalizers handle invalid marker and precision inputs', () => {
     '2026-11-19'
   );
   assert.equal(releaseMonitorInternals.normalizeDateString('Q4 2026'), null);
+
+  const monthInfo = releaseMonitorInternals.normalizeReleaseInfoFromPrecision('month', '2026-12');
+  assert.equal(monthInfo.display, 'Dec 2026');
 });
 
 void test('metacritic merge does not overwrite non-metacritic review source fields', () => {


### PR DESCRIPTION
## Summary

Standardize push notification copy constraints across test, sale, and release flows so notification titles and bodies consistently fit iOS-friendly limits while preserving useful release/sale context. This also makes release date wording deterministic across environments.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [x] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Added `server/src/notification-copy-policy.ts` with shared constants and helpers:
  - `MAX_NOTIFICATION_TITLE` (40)
  - `MAX_NOTIFICATION_BODY` (90)
  - `clampTitleWithEllipsis(...)`
  - `clampTitleWithSuffix(...)`
- Updated `server/src/notifications.ts` test notification payload generation to use clamped title/body-safe copy.
- Updated `server/src/price-sale-notifications.ts` sale event title generation to clamp game titles while preserving the `on sale` suffix.
- Updated `server/src/release-monitor.ts` release event copy to:
  - Use concise titles (`Release date set`, `Release date changed`, `Release date removed`, `Releases today`)
  - Build body text via bounded title budget so body remains <=90 chars
  - Format day/month release text for notification display and pin formatter locale to `en-US` for deterministic output
- Expanded tests in:
  - `server/src/price-sale-notifications.test.ts` (length constraints + long-title truncation behavior)
  - `server/src/tests/release-monitor.logic.test.ts` (length constraints + release-day/body wording + long-title clamp behavior)

## Testing performed

- Ran `npm run lint` (pass)
- Ran `npm run test` (pass; 79 files, 1241 tests)
- Ran `npm run build` (pass)
- Changed tests specifically validate:
  - title/body max-length boundaries for sale and release events
  - suffix-preserving truncation for long sale titles
  - updated release-day wording and release event body composition

## Screenshots (if applicable)

N/A

## Checklist

- [ ] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #