### PR TITLE
chore(deps): bump Playwright Docker base image to v1.60.0

### DIFF
--- a/hltb-scraper/Dockerfile
+++ b/hltb-scraper/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 
 WORKDIR /app/hltb-scraper
 

--- a/metacritic-scraper/Dockerfile
+++ b/metacritic-scraper/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 
 WORKDIR /app/metacritic-scraper
 

--- a/psprices-scraper/Dockerfile
+++ b/psprices-scraper/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 
 WORKDIR /app/psprices-scraper
 


### PR DESCRIPTION
## Summary

Aligns the Playwright browser base image in scraper Docker builds with the `playwright@1.60.0` npm dependency already used by `hltb-scraper`, `metacritic-scraper`, and `psprices-scraper`.

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [x] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

Updates the `FROM` line in each scraper Dockerfile from `mcr.microsoft.com/playwright:v1.59.1-jammy` to `mcr.microsoft.com/playwright:v1.60.0-jammy`:

- `hltb-scraper/Dockerfile`
- `metacritic-scraper/Dockerfile`
- `psprices-scraper/Dockerfile`

No application code, API, or config changes. `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` remains unchanged; browsers continue to come from the base image.

## Testing performed

- `npm run lint` — pass
- `npm run test` — pass (79 files, 1241 tests)
- `npm run build` — pass

Docker image rebuilds for the three scrapers were not run in this prep (infra-only change; recommend verifying in CI or local `docker build` before deploy).

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #