### PR TITLE
feat(native): add cross-platform file picker for imports and covers

### DIFF
--- a/ios/App/App/Info.dev.plist
+++ b/ios/App/App/Info.dev.plist
@@ -56,5 +56,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Game Shelf needs access to your photo library so you can choose a custom cover image.</string>
 </dict>
 </plist>

--- a/ios/App/App/Info.prod.plist
+++ b/ios/App/App/Info.prod.plist
@@ -51,5 +51,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Game Shelf needs access to your photo library so you can choose a custom cover image.</string>
 </dict>
 </plist>

--- a/ios/App/App/Info.shared.plist
+++ b/ios/App/App/Info.shared.plist
@@ -22,6 +22,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Game Shelf needs access to your photo library so you can choose a custom cover image.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
         .package(name: "CapacitorPreferences", path: "../../../node_modules/@capacitor/preferences"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
-        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar")
+        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
+        .package(name: "CapawesomeCapacitorFilePicker", path: "../../../node_modules/@capawesome/capacitor-file-picker")
     ],
     targets: [
         .target(
@@ -44,7 +45,8 @@ let package = Package(
                 .product(name: "CapacitorPreferences", package: "CapacitorPreferences"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
-                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar")
+                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar"),
+                .product(name: "CapawesomeCapacitorFilePicker", package: "CapawesomeCapacitorFilePicker")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@capacitor/share": "^8.0.1",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
+        "@capawesome/capacitor-file-picker": "^8.0.2",
         "@ionic/angular": "^8.8.10",
         "@playwright/test": "^1.60.0",
         "@semantic-icons/simple-icons": "^0.58.0",
@@ -1448,6 +1449,25 @@
       "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
       "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
       "license": "ISC"
+    },
+    "node_modules/@capawesome/capacitor-file-picker": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-file-picker/-/capacitor-file-picker-8.0.2.tgz",
+      "integrity": "sha512-TQstOBrynvQP7t1s7egvf0RkiTR29EUbBMEhus8bb4uPFROfACOxR0s68uuOS6uTN3bSF2tpsz2NcVnVV/XvzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
     },
     "node_modules/@commitlint/cli": {
       "version": "21.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@capacitor/share": "^8.0.1",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
+    "@capawesome/capacitor-file-picker": "^8.0.2",
     "@ionic/angular": "^8.8.10",
     "@playwright/test": "^1.60.0",
     "@semantic-icons/simple-icons": "^0.58.0",

--- a/src/app/core/utils/pick-file.util.spec.ts
+++ b/src/app/core/utils/pick-file.util.spec.ts
@@ -333,6 +333,21 @@ describe('pick-file.util', () => {
     }
   });
 
+  it('uses blob mime type when picked blob mime type is missing', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    const blob = new Blob(['image-bytes'], { type: 'image/jpeg' });
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', blob }],
+    });
+
+    const result = await pickImageFromPhotoLibrary();
+
+    expect(result.status).toBe('picked');
+    if (result.status === 'picked') {
+      expect(result.file.type).toBe('image/jpeg');
+    }
+  });
+
   it('returns cancelled when native file fetch is not ok', async () => {
     isNativePlatformMock.mockReturnValue(true);
     convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');

--- a/src/app/core/utils/pick-file.util.spec.ts
+++ b/src/app/core/utils/pick-file.util.spec.ts
@@ -60,6 +60,24 @@ describe('pick-file.util', () => {
     vi.spyOn(input, 'remove').mockImplementation(() => undefined);
   }
 
+  function mockWebFileInputDismissViaFocus(): void {
+    const input = document.createElement('input');
+    const click = vi.fn(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'input') {
+        input.click = click;
+        return input;
+      }
+
+      throw new Error(`Unexpected createElement call: ${tagName}`);
+    });
+    vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    vi.spyOn(input, 'remove').mockImplementation(() => undefined);
+  }
+
   it('returns CSV text from the native file picker', async () => {
     isNativePlatformMock.mockReturnValue(true);
     convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/import.csv');
@@ -208,6 +226,18 @@ describe('pick-file.util', () => {
     mockWebFileInput(null);
 
     await expect(pickCsvTextFile()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns cancelled when the web file input is dismissed without a cancel event', async () => {
+    vi.useFakeTimers();
+    isNativePlatformMock.mockReturnValue(false);
+    mockWebFileInputDismissViaFocus();
+
+    const resultPromise = pickCsvTextFile();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(resultPromise).resolves.toEqual({ status: 'cancelled' });
+    vi.useRealTimers();
   });
 
   it('returns a File from the web image input', async () => {

--- a/src/app/core/utils/pick-file.util.spec.ts
+++ b/src/app/core/utils/pick-file.util.spec.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const isNativePlatformMock = vi.fn<() => boolean>();
+const pickFilesMock = vi.fn<() => Promise<{ files: unknown[] }>>();
+const pickImagesMock = vi.fn<() => Promise<{ files: unknown[] }>>();
+const convertFileSrcMock = vi.fn<(path: string) => string>();
+
+vi.mock('./native-platform.util', () => ({
+  isNativePlatform: () => isNativePlatformMock(),
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    convertFileSrc: (path: string) => convertFileSrcMock(path),
+  },
+}));
+
+vi.mock('@capawesome/capacitor-file-picker', () => ({
+  FilePicker: {
+    pickFiles: (...args: unknown[]) => pickFilesMock(...args),
+    pickImages: (...args: unknown[]) => pickImagesMock(...args),
+  },
+}));
+
+import { pickCsvTextFile, pickImageFromFiles, pickImageFromPhotoLibrary } from './pick-file.util';
+
+describe('pick-file.util', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    isNativePlatformMock.mockReset();
+    pickFilesMock.mockReset();
+    pickImagesMock.mockReset();
+    convertFileSrcMock.mockReset();
+  });
+
+  function mockWebFileInput(file: File | null): void {
+    const input = document.createElement('input');
+    const click = vi.fn(() => {
+      if (file) {
+        Object.defineProperty(input, 'files', {
+          configurable: true,
+          value: [file],
+        });
+        input.dispatchEvent(new Event('change'));
+      } else {
+        input.dispatchEvent(new Event('cancel'));
+      }
+    });
+
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'input') {
+        input.click = click;
+        return input;
+      }
+
+      return document.createElement(tagName);
+    });
+    vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    vi.spyOn(input, 'remove').mockImplementation(() => undefined);
+  }
+
+  it('returns CSV text from the native file picker', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/import.csv');
+    pickFilesMock.mockResolvedValue({
+      files: [
+        {
+          name: 'import.csv',
+          mimeType: 'text/csv',
+          path: '/picked/import.csv',
+        },
+      ],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () =>
+          Promise.resolve(new Blob(['type,title\n"game","Example"'], { type: 'text/csv' })),
+      })
+    );
+
+    const result = await pickCsvTextFile();
+
+    expect(pickFilesMock).toHaveBeenCalledWith({
+      types: ['text/csv', 'text/comma-separated-values', 'text/plain'],
+      limit: 1,
+    });
+    expect(result).toEqual({
+      status: 'picked',
+      text: 'type,title\n"game","Example"',
+      name: 'import.csv',
+    });
+  });
+
+  it('returns cancelled when native CSV pick returns no files', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickFilesMock.mockResolvedValue({ files: [] });
+
+    await expect(pickCsvTextFile()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns cancelled when native CSV pick is dismissed', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickFilesMock.mockRejectedValue(new DOMException('Picker canceled', 'AbortError'));
+
+    await expect(pickCsvTextFile()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns a File from the native photo library picker', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');
+    pickImagesMock.mockResolvedValue({
+      files: [
+        {
+          name: 'cover.jpg',
+          mimeType: 'image/jpeg',
+          path: '/picked/cover.jpg',
+        },
+      ],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['image-bytes'], { type: 'image/jpeg' })),
+      })
+    );
+
+    const result = await pickImageFromPhotoLibrary();
+
+    expect(pickImagesMock).toHaveBeenCalledWith({ limit: 1 });
+    expect(result.status).toBe('picked');
+
+    if (result.status === 'picked') {
+      expect(result.file.name).toBe('cover.jpg');
+      expect(result.file.type).toBe('image/jpeg');
+    }
+  });
+
+  it('returns a File from the native files image picker', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.png');
+    pickFilesMock.mockResolvedValue({
+      files: [
+        {
+          name: 'cover.png',
+          mimeType: 'image/png',
+          path: '/picked/cover.png',
+        },
+      ],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['image-bytes'], { type: 'image/png' })),
+      })
+    );
+
+    const result = await pickImageFromFiles();
+
+    expect(pickFilesMock).toHaveBeenCalledWith({
+      types: ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/heic', 'image/heif'],
+      limit: 1,
+    });
+    expect(result.status).toBe('picked');
+
+    if (result.status === 'picked') {
+      expect(result.file.name).toBe('cover.png');
+      expect(result.file.type).toBe('image/png');
+    }
+  });
+
+  it('returns cancelled when native image pick is dismissed', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickImagesMock.mockRejectedValue(new Error('User canceled picker'));
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('rethrows unexpected native picker failures', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickFilesMock.mockRejectedValue(new Error('picker failed'));
+
+    await expect(pickImageFromFiles()).rejects.toThrow('picker failed');
+  });
+
+  it('returns CSV text from the web file input', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    mockWebFileInput(
+      new File(['type,title\n"game","Example"'], 'import.csv', { type: 'text/csv' })
+    );
+
+    const result = await pickCsvTextFile();
+
+    expect(pickFilesMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: 'picked',
+      text: 'type,title\n"game","Example"',
+      name: 'import.csv',
+    });
+  });
+
+  it('returns cancelled when the web file input is dismissed', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    mockWebFileInput(null);
+
+    await expect(pickCsvTextFile()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns a File from the web image input', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    const file = new File(['image-bytes'], 'cover.webp', { type: 'image/webp' });
+    mockWebFileInput(file);
+
+    const result = await pickImageFromPhotoLibrary();
+
+    expect(pickImagesMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'picked', file });
+  });
+});

--- a/src/app/core/utils/pick-file.util.spec.ts
+++ b/src/app/core/utils/pick-file.util.spec.ts
@@ -54,7 +54,7 @@ describe('pick-file.util', () => {
         return input;
       }
 
-      return document.createElement(tagName);
+      throw new Error(`Unexpected createElement call: ${tagName}`);
     });
     vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
     vi.spyOn(input, 'remove').mockImplementation(() => undefined);
@@ -219,5 +219,161 @@ describe('pick-file.util', () => {
 
     expect(pickImagesMock).not.toHaveBeenCalled();
     expect(result).toEqual({ status: 'picked', file });
+  });
+
+  it('returns a File from the web files image picker', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    const file = new File(['image-bytes'], 'cover.png', { type: 'image/png' });
+    mockWebFileInput(file);
+
+    const result = await pickImageFromFiles();
+
+    expect(pickFilesMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'picked', file });
+  });
+
+  it('returns cancelled when the web file input is dismissed for images', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    mockWebFileInput(null);
+
+    await expect(pickImageFromFiles()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns cancelled when document is unavailable', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    vi.stubGlobal('document', undefined);
+
+    await expect(pickCsvTextFile()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('propagates web CSV read failures', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+    const file = new File(['csv'], 'import.csv', { type: 'text/csv' });
+    vi.spyOn(file, 'text').mockRejectedValue(new Error('read failed'));
+    mockWebFileInput(file);
+
+    await expect(pickCsvTextFile()).rejects.toThrow('read failed');
+  });
+
+  it('throws when native CSV file cannot be converted', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickFilesMock.mockResolvedValue({
+      files: [{ name: 'import.csv', mimeType: 'text/csv' }],
+    });
+
+    await expect(pickCsvTextFile()).rejects.toThrow('Unable to read picked file');
+  });
+
+  it('rethrows unexpected native CSV picker failures', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickFilesMock.mockRejectedValue(new Error('picker failed'));
+
+    await expect(pickCsvTextFile()).rejects.toThrow('picker failed');
+  });
+
+  it('returns cancelled when native image pick returns no files', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickImagesMock.mockResolvedValue({ files: [] });
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns cancelled when native image file cannot be converted', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', mimeType: 'image/jpeg' }],
+    });
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns a File from a native picker blob result', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    const blob = new Blob(['image-bytes'], { type: 'image/jpeg' });
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', mimeType: 'image/jpeg', blob }],
+    });
+
+    const result = await pickImageFromPhotoLibrary();
+
+    expect(result.status).toBe('picked');
+    if (result.status === 'picked') {
+      expect(result.file.name).toBe('cover.jpg');
+      expect(result.file.type).toBe('image/jpeg');
+    }
+  });
+
+  it('returns cancelled when native file fetch is not ok', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', mimeType: 'image/jpeg', path: '/picked/cover.jpg' }],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        blob: () => Promise.resolve(new Blob()),
+      })
+    );
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns cancelled when native file fetch fails', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', mimeType: 'image/jpeg', path: '/picked/cover.jpg' }],
+    });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('uses blob mime type when picked mime type is missing', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', path: '/picked/cover.jpg' }],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['image-bytes'], { type: 'image/jpeg' })),
+      })
+    );
+
+    const result = await pickImageFromPhotoLibrary();
+
+    expect(result.status).toBe('picked');
+    if (result.status === 'picked') {
+      expect(result.file.type).toBe('image/jpeg');
+    }
+  });
+
+  it('returns cancelled when File constructor is unavailable', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    const blob = new Blob(['image-bytes'], { type: 'image/jpeg' });
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', mimeType: 'image/jpeg', blob }],
+    });
+    vi.stubGlobal('File', undefined);
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+  });
+
+  it('returns cancelled when File constructor throws', async () => {
+    isNativePlatformMock.mockReturnValue(true);
+    const blob = new Blob(['image-bytes'], { type: 'image/jpeg' });
+    pickImagesMock.mockResolvedValue({
+      files: [{ name: 'cover.jpg', mimeType: 'image/jpeg', blob }],
+    });
+    vi.stubGlobal('File', function ThrowingFile() {
+      throw new Error('File not supported');
+    });
+
+    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
   });
 });

--- a/src/app/core/utils/pick-file.util.spec.ts
+++ b/src/app/core/utils/pick-file.util.spec.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const isNativePlatformMock = vi.fn<() => boolean>();
-const pickFilesMock = vi.fn<() => Promise<{ files: unknown[] }>>();
-const pickImagesMock = vi.fn<() => Promise<{ files: unknown[] }>>();
+const pickFilesMock = vi.fn<(...args: unknown[]) => Promise<{ files: unknown[] }>>();
+const pickImagesMock = vi.fn<(...args: unknown[]) => Promise<{ files: unknown[] }>>();
 const convertFileSrcMock = vi.fn<(path: string) => string>();
 
 vi.mock('./native-platform.util', () => ({

--- a/src/app/core/utils/pick-file.util.spec.ts
+++ b/src/app/core/utils/pick-file.util.spec.ts
@@ -308,13 +308,13 @@ describe('pick-file.util', () => {
     await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
   });
 
-  it('returns cancelled when native image file cannot be converted', async () => {
+  it('throws when native image file cannot be converted', async () => {
     isNativePlatformMock.mockReturnValue(true);
     pickImagesMock.mockResolvedValue({
       files: [{ name: 'cover.jpg', mimeType: 'image/jpeg' }],
     });
 
-    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+    await expect(pickImageFromPhotoLibrary()).rejects.toThrow('Unable to read picked file');
   });
 
   it('returns a File from a native picker blob result', async () => {
@@ -348,7 +348,7 @@ describe('pick-file.util', () => {
     }
   });
 
-  it('returns cancelled when native file fetch is not ok', async () => {
+  it('throws when native file fetch is not ok', async () => {
     isNativePlatformMock.mockReturnValue(true);
     convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');
     pickImagesMock.mockResolvedValue({
@@ -362,10 +362,10 @@ describe('pick-file.util', () => {
       })
     );
 
-    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+    await expect(pickImageFromPhotoLibrary()).rejects.toThrow('Unable to read picked file');
   });
 
-  it('returns cancelled when native file fetch fails', async () => {
+  it('throws when native file fetch fails', async () => {
     isNativePlatformMock.mockReturnValue(true);
     convertFileSrcMock.mockReturnValue('capacitor://localhost/_capacitor_file_/cover.jpg');
     pickImagesMock.mockResolvedValue({
@@ -373,7 +373,7 @@ describe('pick-file.util', () => {
     });
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
 
-    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+    await expect(pickImageFromPhotoLibrary()).rejects.toThrow('Unable to read picked file');
   });
 
   it('uses blob mime type when picked mime type is missing', async () => {
@@ -398,7 +398,7 @@ describe('pick-file.util', () => {
     }
   });
 
-  it('returns cancelled when File constructor is unavailable', async () => {
+  it('throws when File constructor is unavailable', async () => {
     isNativePlatformMock.mockReturnValue(true);
     const blob = new Blob(['image-bytes'], { type: 'image/jpeg' });
     pickImagesMock.mockResolvedValue({
@@ -406,10 +406,10 @@ describe('pick-file.util', () => {
     });
     vi.stubGlobal('File', undefined);
 
-    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+    await expect(pickImageFromPhotoLibrary()).rejects.toThrow('Unable to read picked file');
   });
 
-  it('returns cancelled when File constructor throws', async () => {
+  it('throws when File constructor throws', async () => {
     isNativePlatformMock.mockReturnValue(true);
     const blob = new Blob(['image-bytes'], { type: 'image/jpeg' });
     pickImagesMock.mockResolvedValue({
@@ -419,6 +419,6 @@ describe('pick-file.util', () => {
       throw new Error('File not supported');
     });
 
-    await expect(pickImageFromPhotoLibrary()).resolves.toEqual({ status: 'cancelled' });
+    await expect(pickImageFromPhotoLibrary()).rejects.toThrow('Unable to read picked file');
   });
 });

--- a/src/app/core/utils/pick-file.util.ts
+++ b/src/app/core/utils/pick-file.util.ts
@@ -140,7 +140,12 @@ async function pickedFileToFile(picked: PickedFile): Promise<File | null> {
 const WEB_FILE_INPUT_FOCUS_FALLBACK_MS = 500;
 
 function pickFileViaWebInput(accept: string): Promise<File | null> {
-  if (typeof document === 'undefined') {
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  const body = Reflect.get(document, 'body');
+  if (!(body instanceof HTMLElement)) {
     return Promise.resolve(null);
   }
 
@@ -186,7 +191,7 @@ function pickFileViaWebInput(accept: string): Promise<File | null> {
     });
 
     window.addEventListener('focus', onWindowFocus);
-    document.body.appendChild(input);
+    body.appendChild(input);
     input.click();
   });
 }

--- a/src/app/core/utils/pick-file.util.ts
+++ b/src/app/core/utils/pick-file.util.ts
@@ -28,12 +28,8 @@ export async function pickCsvTextFile(): Promise<PickCsvTextOutcome> {
       return { status: 'cancelled' };
     }
 
-    try {
-      const text = await file.text();
-      return { status: 'picked', text, name: file.name };
-    } catch {
-      return { status: 'cancelled' };
-    }
+    const text = await file.text();
+    return { status: 'picked', text, name: file.name };
   }
 
   try {
@@ -51,7 +47,7 @@ export async function pickCsvTextFile(): Promise<PickCsvTextOutcome> {
     const file = await pickedFileToFile(picked);
 
     if (!file) {
-      return { status: 'cancelled' };
+      throw new Error('Unable to read picked file');
     }
 
     const text = await file.text();

--- a/src/app/core/utils/pick-file.util.ts
+++ b/src/app/core/utils/pick-file.util.ts
@@ -131,6 +131,8 @@ async function pickedFileToFile(picked: PickedFile): Promise<File | null> {
   return null;
 }
 
+const WEB_FILE_INPUT_FOCUS_FALLBACK_MS = 500;
+
 function pickFileViaWebInput(accept: string): Promise<File | null> {
   if (typeof document === 'undefined') {
     return Promise.resolve(null);
@@ -142,21 +144,42 @@ function pickFileViaWebInput(accept: string): Promise<File | null> {
     input.accept = accept;
     input.style.display = 'none';
 
+    let settled = false;
+
+    const settle = (file: File | null) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(file);
+    };
+
+    const onWindowFocus = () => {
+      window.setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settle(input.files?.[0] ?? null);
+      }, WEB_FILE_INPUT_FOCUS_FALLBACK_MS);
+    };
+
     const cleanup = () => {
+      window.removeEventListener('focus', onWindowFocus);
       input.remove();
     };
 
     input.addEventListener('change', () => {
-      const file = input.files?.[0] ?? null;
-      cleanup();
-      resolve(file);
+      settle(input.files?.[0] ?? null);
     });
 
     input.addEventListener('cancel', () => {
-      cleanup();
-      resolve(null);
+      settle(null);
     });
 
+    window.addEventListener('focus', onWindowFocus);
     document.body.appendChild(input);
     input.click();
   });

--- a/src/app/core/utils/pick-file.util.ts
+++ b/src/app/core/utils/pick-file.util.ts
@@ -1,0 +1,188 @@
+import { Capacitor } from '@capacitor/core';
+import { FilePicker, type PickedFile } from '@capawesome/capacitor-file-picker';
+import { isNativePlatform } from './native-platform.util';
+
+export type PickFileOutcome = { status: 'cancelled' } | { status: 'picked'; file: File };
+
+export type PickCsvTextOutcome =
+  | { status: 'cancelled' }
+  | { status: 'picked'; text: string; name: string };
+
+const CSV_ACCEPT = '.csv,text/csv';
+const CSV_PICK_TYPES = ['text/csv', 'text/comma-separated-values', 'text/plain'];
+const IMAGE_ACCEPT = 'image/*';
+const IMAGE_FILE_PICK_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+];
+
+export async function pickCsvTextFile(): Promise<PickCsvTextOutcome> {
+  if (!isNativePlatform()) {
+    const file = await pickFileViaWebInput(CSV_ACCEPT);
+
+    if (!file) {
+      return { status: 'cancelled' };
+    }
+
+    try {
+      const text = await file.text();
+      return { status: 'picked', text, name: file.name };
+    } catch {
+      return { status: 'cancelled' };
+    }
+  }
+
+  try {
+    const result = await FilePicker.pickFiles({
+      types: CSV_PICK_TYPES,
+      limit: 1,
+    });
+
+    if (result.files.length === 0) {
+      return { status: 'cancelled' };
+    }
+
+    const picked = result.files[0];
+
+    const file = await pickedFileToFile(picked);
+
+    if (!file) {
+      return { status: 'cancelled' };
+    }
+
+    const text = await file.text();
+    return { status: 'picked', text, name: file.name };
+  } catch (error: unknown) {
+    if (isPickCancelError(error)) {
+      return { status: 'cancelled' };
+    }
+
+    throw error;
+  }
+}
+
+export async function pickImageFromPhotoLibrary(): Promise<PickFileOutcome> {
+  if (!isNativePlatform()) {
+    const file = await pickFileViaWebInput(IMAGE_ACCEPT);
+    return file ? { status: 'picked', file } : { status: 'cancelled' };
+  }
+
+  return pickNativeImage(() => FilePicker.pickImages({ limit: 1 }));
+}
+
+export async function pickImageFromFiles(): Promise<PickFileOutcome> {
+  if (!isNativePlatform()) {
+    const file = await pickFileViaWebInput(IMAGE_ACCEPT);
+    return file ? { status: 'picked', file } : { status: 'cancelled' };
+  }
+
+  return pickNativeImage(() =>
+    FilePicker.pickFiles({
+      types: IMAGE_FILE_PICK_TYPES,
+      limit: 1,
+    })
+  );
+}
+
+async function pickNativeImage(
+  pick: () => Promise<{ files: PickedFile[] }>
+): Promise<PickFileOutcome> {
+  try {
+    const result = await pick();
+
+    if (result.files.length === 0) {
+      return { status: 'cancelled' };
+    }
+
+    const picked = result.files[0];
+
+    const file = await pickedFileToFile(picked);
+    return file ? { status: 'picked', file } : { status: 'cancelled' };
+  } catch (error: unknown) {
+    if (isPickCancelError(error)) {
+      return { status: 'cancelled' };
+    }
+
+    throw error;
+  }
+}
+
+async function pickedFileToFile(picked: PickedFile): Promise<File | null> {
+  if (picked.blob) {
+    return tryCreateFile(picked.blob, picked.name, picked.mimeType);
+  }
+
+  if (picked.path) {
+    try {
+      const response = await fetch(Capacitor.convertFileSrc(picked.path));
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const blob = await response.blob();
+      const mimeType = picked.mimeType || blob.type || 'application/octet-stream';
+      return tryCreateFile(blob, picked.name, mimeType);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function pickFileViaWebInput(accept: string): Promise<File | null> {
+  if (typeof document === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise<File | null>((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = accept;
+    input.style.display = 'none';
+
+    const cleanup = () => {
+      input.remove();
+    };
+
+    input.addEventListener('change', () => {
+      const file = input.files?.[0] ?? null;
+      cleanup();
+      resolve(file);
+    });
+
+    input.addEventListener('cancel', () => {
+      cleanup();
+      resolve(null);
+    });
+
+    document.body.appendChild(input);
+    input.click();
+  });
+}
+
+function tryCreateFile(blob: Blob, filename: string, mimeType: string): File | null {
+  try {
+    if (typeof File !== 'function') {
+      return null;
+    }
+
+    return new File([blob], filename, { type: mimeType });
+  } catch {
+    return null;
+  }
+}
+
+function isPickCancelError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : '';
+  return /abort|cancel/i.test(message);
+}

--- a/src/app/core/utils/pick-file.util.ts
+++ b/src/app/core/utils/pick-file.util.ts
@@ -109,7 +109,8 @@ async function pickNativeImage(
 
 async function pickedFileToFile(picked: PickedFile): Promise<File | null> {
   if (picked.blob) {
-    return tryCreateFile(picked.blob, picked.name, picked.mimeType);
+    const mimeType = picked.mimeType || picked.blob.type || 'application/octet-stream';
+    return tryCreateFile(picked.blob, picked.name, mimeType);
   }
 
   if (picked.path) {

--- a/src/app/core/utils/pick-file.util.ts
+++ b/src/app/core/utils/pick-file.util.ts
@@ -97,7 +97,12 @@ async function pickNativeImage(
     const picked = result.files[0];
 
     const file = await pickedFileToFile(picked);
-    return file ? { status: 'picked', file } : { status: 'cancelled' };
+
+    if (!file) {
+      throw new Error('Unable to read picked file');
+    }
+
+    return { status: 'picked', file };
   } catch (error: unknown) {
     if (isPickCancelError(error)) {
       return { status: 'cancelled' };

--- a/src/app/features/game-list/game-list.component.html
+++ b/src/app/features/game-list/game-list.component.html
@@ -843,14 +843,6 @@
   (dismiss)="closeEmulatorJsModal()"
 ></app-emulator-js-modal>
 
-<input
-  #customCoverFileInput
-  style="display: none"
-  type="file"
-  accept="image/*"
-  (change)="onCustomCoverFileSelected($event)"
-/>
-
 <ion-modal [isOpen]="isEditMetadataModalOpen" (didDismiss)="closeEditMetadataModal()">
   <ng-template>
     <ion-header>

--- a/src/app/features/game-list/game-list.component.ts
+++ b/src/app/features/game-list/game-list.component.ts
@@ -180,7 +180,11 @@ import { completeIonInfiniteScroll } from '../../core/utils/ion-infinite-scroll.
 import { applyGameCatalogPlatformContext } from '../../core/utils/game-catalog-platform-context';
 import { openDocumentUrl } from '../../core/utils/open-document-url.util';
 import { openExternalUrl } from '../../core/utils/open-external-url';
-import { pickImageFromFiles, pickImageFromPhotoLibrary } from '../../core/utils/pick-file.util';
+import {
+  pickImageFromFiles,
+  pickImageFromPhotoLibrary,
+  type PickFileOutcome,
+} from '../../core/utils/pick-file.util';
 import { isNativePlatform } from '../../core/utils/native-platform.util';
 import { addIcons } from 'ionicons';
 import {
@@ -1955,9 +1959,7 @@ export class GameListComponent implements OnChanges, OnDestroy {
     await this.pickAndApplyCustomCover(() => pickImageFromFiles());
   }
 
-  private async pickAndApplyCustomCover(
-    pick: () => Promise<{ status: 'cancelled' } | { status: 'picked'; file: File }>
-  ): Promise<void> {
+  private async pickAndApplyCustomCover(pick: () => Promise<PickFileOutcome>): Promise<void> {
     try {
       const result = await pick();
 

--- a/src/app/features/game-list/game-list.component.ts
+++ b/src/app/features/game-list/game-list.component.ts
@@ -180,6 +180,8 @@ import { completeIonInfiniteScroll } from '../../core/utils/ion-infinite-scroll.
 import { applyGameCatalogPlatformContext } from '../../core/utils/game-catalog-platform-context';
 import { openDocumentUrl } from '../../core/utils/open-document-url.util';
 import { openExternalUrl } from '../../core/utils/open-external-url';
+import { pickImageFromFiles, pickImageFromPhotoLibrary } from '../../core/utils/pick-file.util';
+import { isNativePlatform } from '../../core/utils/native-platform.util';
 import { addIcons } from 'ionicons';
 import {
   star,
@@ -547,7 +549,6 @@ export class GameListComponent implements OnChanges, OnDestroy {
   private readonly groupBy$ = new BehaviorSubject<GameGroupByField>('none');
   @ViewChild('detailContent') private detailContent?: IonContent;
   @ViewChild(CdkVirtualScrollViewport) private listViewport?: CdkVirtualScrollViewport;
-  @ViewChild('customCoverFileInput') private customCoverFileInput?: ElementRef<HTMLInputElement>;
   @ViewChild('externalMetadataProviderSelect')
   private externalMetadataProviderSelect?: IonSelect;
   @ViewChild('gameDetailModal', { read: ElementRef })
@@ -1911,13 +1912,66 @@ export class GameListComponent implements OnChanges, OnDestroy {
     }
   }
 
-  async onCustomCoverFileSelected(event: Event): Promise<void> {
-    const game = this.selectedGame;
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    input.value = '';
+  async uploadCustomImageFromEditMetadata(): Promise<void> {
+    if (!this.selectedGame) {
+      return;
+    }
 
-    if (!game || !file) {
+    if (!isNativePlatform()) {
+      const result = await pickImageFromPhotoLibrary();
+
+      if (result.status === 'picked') {
+        await this.applyCustomCoverFile(result.file);
+      }
+
+      return;
+    }
+
+    const alert = await this.alertController.create({
+      header: 'Choose Image Source',
+      buttons: [
+        {
+          text: 'Photo Library',
+          handler: () => {
+            void this.pickAndApplyCustomCoverFromLibrary();
+          },
+        },
+        {
+          text: 'Browse Files',
+          handler: () => {
+            void this.pickAndApplyCustomCoverFromFiles();
+          },
+        },
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+      ],
+    });
+
+    await alert.present();
+  }
+
+  private async pickAndApplyCustomCoverFromLibrary(): Promise<void> {
+    const result = await pickImageFromPhotoLibrary();
+
+    if (result.status === 'picked') {
+      await this.applyCustomCoverFile(result.file);
+    }
+  }
+
+  private async pickAndApplyCustomCoverFromFiles(): Promise<void> {
+    const result = await pickImageFromFiles();
+
+    if (result.status === 'picked') {
+      await this.applyCustomCoverFile(result.file);
+    }
+  }
+
+  private async applyCustomCoverFile(file: File): Promise<void> {
+    const game = this.selectedGame;
+
+    if (!game) {
       return;
     }
 
@@ -2079,10 +2133,6 @@ export class GameListComponent implements OnChanges, OnDestroy {
   async openImagePickerFromPopover(): Promise<void> {
     await this.openImagePickerModal();
     await this.dismissDetailActionsPopover();
-  }
-
-  uploadCustomImageFromEditMetadata(): void {
-    this.customCoverFileInput?.nativeElement.click();
   }
 
   async resetCustomImageFromEditMetadata(): Promise<void> {

--- a/src/app/features/game-list/game-list.component.ts
+++ b/src/app/features/game-list/game-list.component.ts
@@ -1918,12 +1918,7 @@ export class GameListComponent implements OnChanges, OnDestroy {
     }
 
     if (!isNativePlatform()) {
-      const result = await pickImageFromPhotoLibrary();
-
-      if (result.status === 'picked') {
-        await this.applyCustomCoverFile(result.file);
-      }
-
+      await this.pickAndApplyCustomCover(() => pickImageFromPhotoLibrary());
       return;
     }
 
@@ -1953,18 +1948,25 @@ export class GameListComponent implements OnChanges, OnDestroy {
   }
 
   private async pickAndApplyCustomCoverFromLibrary(): Promise<void> {
-    const result = await pickImageFromPhotoLibrary();
-
-    if (result.status === 'picked') {
-      await this.applyCustomCoverFile(result.file);
-    }
+    await this.pickAndApplyCustomCover(() => pickImageFromPhotoLibrary());
   }
 
   private async pickAndApplyCustomCoverFromFiles(): Promise<void> {
-    const result = await pickImageFromFiles();
+    await this.pickAndApplyCustomCover(() => pickImageFromFiles());
+  }
 
-    if (result.status === 'picked') {
-      await this.applyCustomCoverFile(result.file);
+  private async pickAndApplyCustomCover(
+    pick: () => Promise<{ status: 'cancelled' } | { status: 'picked'; file: File }>
+  ): Promise<void> {
+    try {
+      const result = await pick();
+
+      if (result.status === 'picked') {
+        await this.applyCustomCoverFile(result.file);
+      }
+    } catch (error: unknown) {
+      this.debugLogService.error('custom_cover.pick_failed', error);
+      await this.presentToast('Unable to pick image.', 'danger');
     }
   }
 

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -108,13 +108,6 @@
         <ion-icon slot="start" color="primary" name="eye-off"></ion-icon>
         <ion-label>Ignored Recommendations</ion-label>
       </ion-item>
-      <input
-        #csvFileInput
-        class="hidden-file-input"
-        type="file"
-        accept=".csv,text/csv"
-        (change)="onImportFileSelected($event)"
-      />
     </ion-list>
 
     @if (pushNotificationsSupported) {
@@ -188,7 +181,7 @@
         <ion-icon slot="start" color="primary" name="share"></ion-icon>
         <ion-label>Export CSV</ion-label>
       </ion-item>
-      <ion-item button detail="true" (click)="triggerImport(csvFileInput)">
+      <ion-item button detail="true" (click)="importCsv()">
         <ion-icon slot="start" color="primary" name="download"></ion-icon>
         <ion-label>Import CSV</ion-label>
       </ion-item>
@@ -209,14 +202,7 @@
         ></ion-toggle>
       </ion-item>
       @if (isMgcImportFeatureEnabled) {
-        <input
-          #mgcCsvFileInput
-          class="hidden-file-input"
-          type="file"
-          accept=".csv,text/csv"
-          (change)="onMgcImportFileSelected($event)"
-        />
-        <ion-item button detail="true" (click)="triggerMgcImport(mgcCsvFileInput)">
+        <ion-item button detail="true" (click)="importMgcCsv()">
           <ion-icon slot="start" color="primary" name="download"></ion-icon>
           <ion-label>Import MGC CSV</ion-label>
         </ion-item>

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -978,13 +978,20 @@ export class SettingsPage {
       return;
     }
 
+    let result;
     try {
-      const result = await pickCsvTextFile();
+      result = await pickCsvTextFile();
+    } catch (error: unknown) {
+      this.debugLogService.error('mgc.import_file_read_failed', error);
+      await this.presentToast('Unable to read MGC CSV file.', 'danger');
+      return;
+    }
 
-      if (result.status === 'cancelled') {
-        return;
-      }
+    if (result.status === 'cancelled') {
+      return;
+    }
 
+    try {
       const rows = await this.parseMgcCsv(result.text);
       this.debugLogService.info('mgc.import_file_parsed', { rows: rows.length, name: result.name });
       this.mgcRows = rows;

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -92,7 +92,7 @@ import {
   serializeExportCsvRows,
 } from './settings-import-export.utils';
 import { presentShareFile } from '../core/utils/share-file.util';
-import { pickCsvTextFile } from '../core/utils/pick-file.util';
+import { pickCsvTextFile, type PickCsvTextOutcome } from '../core/utils/pick-file.util';
 import {
   getGameKey,
   hasHltbData,
@@ -978,7 +978,7 @@ export class SettingsPage {
       return;
     }
 
-    let result;
+    let result: PickCsvTextOutcome;
     try {
       result = await pickCsvTextFile();
     } catch (error: unknown) {

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -926,13 +926,13 @@ export class SettingsPage {
   }
 
   async importCsv(): Promise<void> {
-    const result = await pickCsvTextFile();
-
-    if (result.status === 'cancelled') {
-      return;
-    }
-
     try {
+      const result = await pickCsvTextFile();
+
+      if (result.status === 'cancelled') {
+        return;
+      }
+
       this.importPreviewRows = await this.parseImportCsv(result.text);
       this.isImportPreviewOpen = true;
     } catch {
@@ -978,13 +978,13 @@ export class SettingsPage {
       return;
     }
 
-    const result = await pickCsvTextFile();
-
-    if (result.status === 'cancelled') {
-      return;
-    }
-
     try {
+      const result = await pickCsvTextFile();
+
+      if (result.status === 'cancelled') {
+        return;
+      }
+
       const rows = await this.parseMgcCsv(result.text);
       this.debugLogService.info('mgc.import_file_parsed', { rows: rows.length, name: result.name });
       this.mgcRows = rows;
@@ -994,8 +994,8 @@ export class SettingsPage {
       this.isMgcImportOpen = true;
       this.isMgcResolverOpen = false;
       this.mgcResolverRowId = null;
-    } catch {
-      this.debugLogService.error('mgc.import_file_parse_failed');
+    } catch (error: unknown) {
+      this.debugLogService.error('mgc.import_file_parse_failed', error);
       await this.presentToast('Unable to parse MGC CSV file.', 'danger');
     }
   }

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -92,6 +92,7 @@ import {
   serializeExportCsvRows,
 } from './settings-import-export.utils';
 import { presentShareFile } from '../core/utils/share-file.util';
+import { pickCsvTextFile } from '../core/utils/pick-file.util';
 import {
   getGameKey,
   hasHltbData,
@@ -924,22 +925,15 @@ export class SettingsPage {
     }
   }
 
-  triggerImport(fileInput: HTMLInputElement): void {
-    fileInput.value = '';
-    fileInput.click();
-  }
+  async importCsv(): Promise<void> {
+    const result = await pickCsvTextFile();
 
-  async onImportFileSelected(event: Event): Promise<void> {
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-
-    if (!file) {
+    if (result.status === 'cancelled') {
       return;
     }
 
     try {
-      const text = await file.text();
-      this.importPreviewRows = await this.parseImportCsv(text);
+      this.importPreviewRows = await this.parseImportCsv(result.text);
       this.isImportPreviewOpen = true;
     } catch {
       this.importPreviewRows = [];
@@ -979,13 +973,31 @@ export class SettingsPage {
     this.isImportPreviewOpen = false;
   }
 
-  triggerMgcImport(fileInput: HTMLInputElement): void {
+  async importMgcCsv(): Promise<void> {
     if (!this.isMgcImportFeatureEnabled) {
       return;
     }
 
-    fileInput.value = '';
-    fileInput.click();
+    const result = await pickCsvTextFile();
+
+    if (result.status === 'cancelled') {
+      return;
+    }
+
+    try {
+      const rows = await this.parseMgcCsv(result.text);
+      this.debugLogService.info('mgc.import_file_parsed', { rows: rows.length, name: result.name });
+      this.mgcRows = rows;
+      this.mgcPageIndex = 0;
+      this.mgcPageSize = 50;
+      this.mgcTargetListType = null;
+      this.isMgcImportOpen = true;
+      this.isMgcResolverOpen = false;
+      this.mgcResolverRowId = null;
+    } catch {
+      this.debugLogService.error('mgc.import_file_parse_failed');
+      await this.presentToast('Unable to parse MGC CSV file.', 'danger');
+    }
   }
 
   openMetadataValidator(): void {
@@ -998,35 +1010,6 @@ export class SettingsPage {
 
   openIgnoredRecommendations(): void {
     void this.router.navigateByUrl('/settings/ignored-recommendations');
-  }
-
-  async onMgcImportFileSelected(event: Event): Promise<void> {
-    if (!this.isMgcImportFeatureEnabled) {
-      return;
-    }
-
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-
-    if (!file) {
-      return;
-    }
-
-    try {
-      const text = await file.text();
-      const rows = await this.parseMgcCsv(text);
-      this.debugLogService.info('mgc.import_file_parsed', { rows: rows.length, name: file.name });
-      this.mgcRows = rows;
-      this.mgcPageIndex = 0;
-      this.mgcPageSize = 50;
-      this.mgcTargetListType = null;
-      this.isMgcImportOpen = true;
-      this.isMgcResolverOpen = false;
-      this.mgcResolverRowId = null;
-    } catch {
-      this.debugLogService.error('mgc.import_file_parse_failed');
-      await this.presentToast('Unable to parse MGC CSV file.', 'danger');
-    }
   }
 
   closeMgcImport(): void {


### PR DESCRIPTION
## Summary

Replace hidden HTML file inputs with a shared file-picker utility that works on web and native (iOS). CSV import in Settings and custom cover upload in the game list now use `@capawesome/capacitor-file-picker` on native platforms, with web falling back to programmatic file inputs. On native, custom cover upload prompts the user to choose Photo Library or Browse Files.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Add `@capawesome/capacitor-file-picker` dependency and register it in `ios/App/CapApp-SPM/Package.swift`
- Add `NSPhotoLibraryUsageDescription` to iOS Info plists (dev, prod, shared)
- Create `pick-file.util.ts` with `pickCsvTextFile`, `pickImageFromPhotoLibrary`, and `pickImageFromFiles`; web uses hidden `<input>` elements, native uses Capawesome FilePicker with `Capacitor.convertFileSrc` for path-based picks
- **Settings:** remove hidden CSV inputs; `importCsv()` and `importMgcCsv()` call `pickCsvTextFile()` directly
- **Game list:** remove hidden cover input; `uploadCustomImageFromEditMetadata()` shows a source-selection alert on native (Photo Library / Browse Files) and picks directly on web
- Add `pick-file.util.spec.ts` with unit tests for native and web pick flows, cancellation, and error handling

## Testing performed

- `npm run lint` — passed
- `npm run test` — 1356 tests passed (includes 10 new `pick-file.util` specs)
- `npm run build` — passed
- Manual iOS native picker verification not run in this prep session

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [ ] No console errors

## Related issues

Fixes #