### PR TITLE
fix(ios): resolve sync-ios-version paths from repo root

### DIFF
--- a/docs/ios-testflight-ci.md
+++ b/docs/ios-testflight-ci.md
@@ -180,6 +180,7 @@ The helper [`scripts/sync-ios-version.mjs`](../scripts/sync-ios-version.mjs) upd
 | Build number already used                          | Re-run after a previous upload completed; Fastlane queries ASC for the latest build number              |
 | Wrong backend in app                               | `IOS_BACKEND_ORIGIN_PROD` does not match production edge URL                                            |
 | Tag pushed but no TestFlight build                 | Expected when only backend/src changed; run workflow_dispatch to force a build                          |
+| `ENOENT .../ios/fastlane/ios/App/...`              | `sync-ios-version.mjs` resolved paths from fastlane cwd; fixed by repo-root defaults                    |
 | Setup Ruby fails with `undefined method 'untaint'` | Stale `BUNDLED WITH 1.x` in `ios/Gemfile.lock`; regenerate with `bundle _2.5.23_ lock --update-bundler` |
 
 See also [`ios-multi-environment.md`](ios-multi-environment.md) for local dev/prod side-by-side

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.46.0;
+				MARKETING_VERSION = 1.58.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.thetigeregg.gameshelf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -338,7 +338,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.46.0;
+				MARKETING_VERSION = 1.58.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.thetigeregg.gameshelf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.46.0;
+				MARKETING_VERSION = 1.58.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.thetigeregg.gameshelf.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.46.0;
+				MARKETING_VERSION = 1.58.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.thetigeregg.gameshelf.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -31,7 +31,8 @@ def sync_ios_prod_version(build_number:)
     'node',
     File.join(REPO_ROOT, 'scripts/sync-ios-version.mjs'),
     '--marketing-version', version,
-    '--build-number', build_number.to_s
+    '--build-number', build_number.to_s,
+    '--pbxproj', PBXPROJ_PATH
   )
 end
 

--- a/scripts/sync-ios-version.mjs
+++ b/scripts/sync-ios-version.mjs
@@ -1,10 +1,11 @@
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const PROD_BUNDLE_ID = 'io.github.thetigeregg.gameshelf';
-const DEFAULT_PBXPROJ_PATH = resolve(process.cwd(), 'ios/App/App.xcodeproj/project.pbxproj');
-const DEFAULT_PACKAGE_JSON_PATH = resolve(process.cwd(), 'package.json');
+const DEFAULT_PBXPROJ_PATH = resolve(REPO_ROOT, 'ios/App/App.xcodeproj/project.pbxproj');
+const DEFAULT_PACKAGE_JSON_PATH = resolve(REPO_ROOT, 'package.json');
 
 export function readPackageVersion(packageJsonPath = DEFAULT_PACKAGE_JSON_PATH) {
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
@@ -117,7 +118,7 @@ export function parseSyncIosVersionArgs(argv) {
         throw new Error('--pbxproj requires a path');
       }
 
-      args.pbxprojPath = resolve(process.cwd(), pbxprojArg);
+      args.pbxprojPath = resolve(REPO_ROOT, pbxprojArg);
       index += 1;
     }
   }

--- a/scripts/sync-ios-version.test.mjs
+++ b/scripts/sync-ios-version.test.mjs
@@ -127,3 +127,10 @@ test('parseSyncIosVersionArgs rejects --pbxproj without a path', () => {
     /--pbxproj requires a path/
   );
 });
+
+test('parseSyncIosVersionArgs defaults pbxproj path to repo root', () => {
+  const args = parseSyncIosVersionArgs(['--build-number', '42']);
+
+  assert.match(args.pbxprojPath, /ios\/App\/App\.xcodeproj\/project\.pbxproj$/);
+  assert.doesNotMatch(args.pbxprojPath, /fastlane\/ios/);
+});


### PR DESCRIPTION
## Summary

Fixes TestFlight CI failures where `sync-ios-version.mjs` could not find `project.pbxproj` because default and `--pbxproj` paths were resolved from Fastlane's working directory (`ios/fastlane`) instead of the repository root.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Derive `REPO_ROOT` from the script's own location in `scripts/sync-ios-version.mjs` and use it for `DEFAULT_PBXPROJ_PATH`, `DEFAULT_PACKAGE_JSON_PATH`, and relative `--pbxproj` arguments instead of `process.cwd()`.
- Pass an explicit `--pbxproj` path from `ios/fastlane/Fastfile` when invoking the sync script.
- Add a regression test asserting the default pbxproj path resolves under the repo root and does not include `fastlane/ios`.
- Sync `MARKETING_VERSION` in `project.pbxproj` to `1.58.3` to match `package.json`.
- Document the `ENOENT .../ios/fastlane/ios/App/...` failure mode in `docs/ios-testflight-ci.md`.

## Testing performed

- `npm run lint` — passed
- `npm run test` — passed (1392 tests, including new `parseSyncIosVersionArgs defaults pbxproj path to repo root`)
- `npm run build` — passed

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #