### PR TITLE
ci(ios): use fastlane match for TestFlight signing

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -128,12 +128,16 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: |
           for required in \
             IOS_BACKEND_ORIGIN_PROD \
             APP_STORE_CONNECT_API_KEY_ID \
             APP_STORE_CONNECT_API_ISSUER_ID \
-            APP_STORE_CONNECT_API_KEY
+            APP_STORE_CONNECT_API_KEY \
+            MATCH_PASSWORD \
+            MATCH_GIT_BASIC_AUTHORIZATION
           do
             if [ -z "${!required}" ]; then
               echo "$required is required for TestFlight deploy." >&2
@@ -149,6 +153,16 @@ jobs:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: bundle exec fastlane validate_asc_app
 
+      - name: Validate match signing assets
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        run: bundle exec fastlane validate_match
+
       - name: Upload to TestFlight
         id: testflight_upload
         working-directory: ios
@@ -157,6 +171,8 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: bundle exec fastlane deploy_testflight
 
       - name: Sync IOS_OTA_NATIVE_BUILD_NUMBER

--- a/docs/ios-testflight-ci.md
+++ b/docs/ios-testflight-ci.md
@@ -104,7 +104,7 @@ base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
 Encode match git auth (fine-grained PAT with repo access to `game-shelf-match-certs`):
 
 ```bash
-echo -n 'x-access-token:ghp_xxxxxxxx' | base64 | pbcopy
+echo -n 'x-access-token:github_pat_xxxxxxxx' | base64 | pbcopy
 ```
 
 ### Variables

--- a/docs/ios-testflight-ci.md
+++ b/docs/ios-testflight-ci.md
@@ -14,7 +14,8 @@ flowchart TD
   Gate --> Diff{Native-shell<br/>changes?}
   Diff -->|yes| NodeBuild["npm run sync:ios:prod"]
   Diff -->|no| Skip[Skip macOS job]
-  NodeBuild --> FastlaneBuild["Fastlane build_app<br/>scheme App PROD"]
+  NodeBuild --> MatchRO["match appstore readonly"]
+  MatchRO --> FastlaneBuild["Fastlane build_app<br/>scheme App PROD"]
   FastlaneBuild --> TestFlight["upload_to_testflight"]
   Dispatch[workflow_dispatch] --> NodeBuild
 ```
@@ -22,6 +23,11 @@ flowchart TD
 Workflow file: [`.github/workflows/ios-testflight.yml`](../.github/workflows/ios-testflight.yml)
 
 Fastlane config: [`ios/fastlane/`](../ios/fastlane/)
+
+Signing uses **fastlane match** with an encrypted private repo
+[`thetigeregg/game-shelf-match-certs`](https://github.com/thetigeregg/game-shelf-match-certs)
+(Apple Distribution certificate + App Store profile). CI installs them into a temporary
+keychain before archive/export — similar to Azure DevOps secure files for certs/profiles.
 
 ## Triggers
 
@@ -78,6 +84,8 @@ you prefer):
 | `APP_STORE_CONNECT_API_KEY_ID`    | App Store Connect API key ID                                                                                           |
 | `APP_STORE_CONNECT_API_ISSUER_ID` | App Store Connect issuer ID                                                                                            |
 | `APP_STORE_CONNECT_API_KEY`       | Base64-encoded `.p8` private key contents                                                                              |
+| `MATCH_PASSWORD`                  | Passphrase that encrypts cert/profile files in the match repo                                                          |
+| `MATCH_GIT_BASIC_AUTHORIZATION`   | Base64 of `x-access-token:<PAT>` for read access to `game-shelf-match-certs`                                           |
 | `IOS_FIREBASE_PROD_PLIST_BASE64`  | Base64-encoded prod `GoogleService-Info.plist` (same file as `~/.config/game-shelf/ios/GoogleService-Info.prod.plist`) |
 | `IOS_BACKEND_ORIGIN_PROD`         | HTTPS production edge origin baked into `environment.ios.prod.ts` (same value as local `.env`)                         |
 
@@ -93,6 +101,12 @@ Encode the App Store Connect API key:
 base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
 ```
 
+Encode match git auth (fine-grained PAT with repo access to `game-shelf-match-certs`):
+
+```bash
+echo -n 'x-access-token:ghp_xxxxxxxx' | base64 | pbcopy
+```
+
 ### Variables
 
 | Name                          | Description                                                                 |
@@ -102,13 +116,42 @@ base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
 ## One-time Apple setup
 
 1. Create an App Store Connect API key with **App Manager** (or Admin) access.
-2. Ensure the key can manage **Certificates, Identifiers & Profiles** (required for
-   automatic signing with `-allowProvisioningUpdates` on CI).
-3. Create the App Store Connect app record (**Apps → + → New App**) with bundle ID
+2. Create the App Store Connect app record (**Apps → + → New App**) with bundle ID
    `io.github.thetigeregg.gameshelf` on team `6V392K7X46` (must match
    [`ios/fastlane/Appfile`](../ios/fastlane/Appfile)).
-4. Confirm the prod app ID `io.github.thetigeregg.gameshelf` has Push Notifications
-   enabled (see [`App.prod.entitlements`](../ios/App/App/App.prod.entitlements)).
+3. In the **Developer** portal, keep the App ID `io.github.thetigeregg.gameshelf` with
+   **Push Notifications** enabled (see [`App.prod.entitlements`](../ios/App/App/App.prod.entitlements)).
+4. **Revoke** any manually created iOS Distribution certificate and App Store profile for
+   this bundle ID before bootstrapping match (match will recreate them).
+5. Do **not** create new distribution certs or App Store profiles manually after match is
+   bootstrapped — let match manage them.
+
+## One-time match bootstrap (local Mac)
+
+Create a private empty repo `thetigeregg/game-shelf-match-certs`, add GitHub secrets above,
+then run once on a Mac:
+
+```bash
+cd ios
+gem install bundler -v 2.5.23
+bundle _2.5.23_ install
+
+export MATCH_PASSWORD='...'
+export MATCH_GIT_BASIC_AUTHORIZATION='...'   # base64 x-access-token:PAT
+export APP_STORE_CONNECT_API_KEY_ID='...'
+export APP_STORE_CONNECT_API_ISSUER_ID='...'
+export APP_STORE_CONNECT_API_KEY='...'     # base64 p8
+
+bundle exec fastlane match appstore
+```
+
+Match creates an Apple Distribution certificate and App Store profile for
+`io.github.thetigeregg.gameshelf`, encrypts them, and pushes to the private repo.
+
+Verify in the Developer portal:
+
+- **Certificates**: iOS Distribution entry
+- **Profiles**: App Store profile named `match AppStore io.github.thetigeregg.gameshelf`
 
 ## What the workflow does
 
@@ -117,14 +160,15 @@ base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
 3. If gated off, writes a skip summary and exits without macOS minutes.
 4. Otherwise installs Node and Ruby/Fastlane dependencies.
 5. Decodes the Firebase prod plist into `IOS_FIREBASE_PROD_PLIST_PATH`.
-6. Validates required secrets and runs `bundle exec fastlane validate_asc_app` to confirm
-   the App Store Connect app exists before building.
+6. Validates required secrets, runs `bundle exec fastlane validate_asc_app`, then
+   `bundle exec fastlane validate_match` (readonly install of cert + profile).
 7. Runs `bundle exec fastlane deploy_testflight` from `ios/`, which:
    - Reads semver from root [`package.json`](../package.json)
    - Queries App Store Connect for the latest TestFlight build number and increments it
    - Updates **App PROD** `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` in Xcode
+   - Runs `match appstore` (readonly on CI) to install signing assets
    - Runs `npm run sync:ios:prod` (Angular ios-prod build + Capacitor sync)
-   - Archives **App PROD** (Release) with automatic signing
+   - Archives and exports **App PROD** (Release) with the match App Store profile
    - Uploads to TestFlight (does not wait for Apple processing)
 
 ## Native dependencies
@@ -152,22 +196,23 @@ gem install bundler -v 2.5.23
 bundle _2.5.23_ install
 ```
 
-Build without uploading (requires local signing setup):
+Build without uploading (requires match bootstrap and env vars):
 
 ```bash
+export MATCH_PASSWORD=...
+export MATCH_GIT_BASIC_AUTHORIZATION=...   # or use SSH/git credential helper locally
+export APP_STORE_CONNECT_API_KEY_ID=...
+export APP_STORE_CONNECT_API_ISSUER_ID=...
+export APP_STORE_CONNECT_API_KEY=...     # base64 p8
 export IOS_BACKEND_ORIGIN_PROD=https://your-prod-host
+export IOS_FIREBASE_PROD_PLIST_PATH=/path/to/GoogleService-Info.prod.plist
 export IOS_BUILD_NUMBER=1
 bundle exec fastlane build_only
 ```
 
-Upload manually from a Mac with API key env vars set:
+Upload manually from a Mac with all env vars set:
 
 ```bash
-export APP_STORE_CONNECT_API_KEY_ID=...
-export APP_STORE_CONNECT_API_ISSUER_ID=...
-export APP_STORE_CONNECT_API_KEY=...   # base64 p8
-export IOS_BACKEND_ORIGIN_PROD=https://your-prod-host
-export IOS_FIREBASE_PROD_PLIST_PATH=/path/to/GoogleService-Info.prod.plist
 bundle exec fastlane deploy_testflight
 ```
 
@@ -189,20 +234,33 @@ The helper [`scripts/sync-ios-version.mjs`](../scripts/sync-ios-version.mjs) sup
 TestFlight gating ignores marketing-only `project.pbxproj` diffs so release version bumps do
 not force a native rebuild when no other shell files changed.
 
+## Match maintenance
+
+| Task                                             | Command                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------ |
+| Distribution cert expired (~1 year)              | `bundle exec fastlane match appstore --force_for_new_certificates` |
+| App ID capability changed (e.g. new entitlement) | `bundle exec fastlane match appstore --force`                      |
+| CI cannot clone certs repo                       | Verify `MATCH_GIT_BASIC_AUTHORIZATION` PAT has repo read access    |
+| Wrong passphrase                                 | `MATCH_PASSWORD` must match the value used at bootstrap            |
+
+After renewal, commit to the match repo is automatic; no workflow changes needed.
+
 ## Troubleshooting
 
-| Symptom                                             | Likely cause                                                                                                                                                                                                                                                                                             |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Could not find an app on App Store Connect          | ASC app record not created yet, or bundle ID / team mismatch vs `ios/fastlane/Appfile`                                                                                                                                                                                                                   |
-| Missing Firebase plist                              | `IOS_FIREBASE_PROD_PLIST_BASE64` secret not set or invalid base64                                                                                                                                                                                                                                        |
-| Missing backend origin                              | `IOS_BACKEND_ORIGIN_PROD` secret not set                                                                                                                                                                                                                                                                 |
-| Signing / provisioning failure                      | ASC API key lacks cert/profile access; first CI run may need Admin to approve profile creation                                                                                                                                                                                                           |
-| `No Accounts` / development profile not found on CI | Fastlane must pass `-authenticationKeyPath`, `-authenticationKeyID`, and `-authenticationKeyIssuerID` to `xcodebuild` alongside `-allowProvisioningUpdates` (see `ios/fastlane/Fastfile`); project-level `CODE_SIGN_IDENTITY = iPhone Developer` also forces the wrong profile type for Release archives |
-| Build number already used                           | Re-run after a previous upload completed; Fastlane queries ASC for the latest build number                                                                                                                                                                                                               |
-| Wrong backend in app                                | `IOS_BACKEND_ORIGIN_PROD` does not match production edge URL                                                                                                                                                                                                                                             |
-| Tag pushed but no TestFlight build                  | Expected when only backend/src changed; run workflow_dispatch to force a build                                                                                                                                                                                                                           |
-| `ENOENT .../ios/fastlane/ios/App/...`               | `sync-ios-version.mjs` resolved paths from fastlane cwd; fixed by repo-root defaults                                                                                                                                                                                                                     |
-| Setup Ruby fails with `undefined method 'untaint'`  | Stale `BUNDLED WITH 1.x` in `ios/Gemfile.lock`; regenerate with `bundle _2.5.23_ lock --update-bundler`                                                                                                                                                                                                  |
+| Symptom                                            | Likely cause                                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Could not find an app on App Store Connect         | ASC app record not created yet, or bundle ID / team mismatch vs `ios/fastlane/Appfile`                  |
+| Missing Firebase plist                             | `IOS_FIREBASE_PROD_PLIST_BASE64` secret not set or invalid base64                                       |
+| Missing backend origin                             | `IOS_BACKEND_ORIGIN_PROD` secret not set                                                                |
+| `validate_match` fails / cannot clone match repo   | `MATCH_GIT_BASIC_AUTHORIZATION` or `MATCH_PASSWORD` missing or wrong; PAT lacks repo access             |
+| `No signing certificate "iOS Distribution" found`  | Match not bootstrapped — run `fastlane match appstore` locally first                                    |
+| `No profile for io.github.thetigeregg.gameshelf`   | Match profile missing or name mismatch; re-run `match appstore`                                         |
+| Export fails after manual portal cert changes      | Revoke manual certs/profiles and let match regenerate; avoid mixing manual + match                      |
+| Build number already used                          | Re-run after a previous upload completed; Fastlane queries ASC for the latest build number              |
+| Wrong backend in app                               | `IOS_BACKEND_ORIGIN_PROD` does not match production edge URL                                            |
+| Tag pushed but no TestFlight build                 | Expected when only backend/src changed; run workflow_dispatch to force a build                          |
+| `ENOENT .../ios/fastlane/ios/App/...`              | `sync-ios-version.mjs` resolved paths from fastlane cwd; fixed by repo-root defaults                    |
+| Setup Ruby fails with `undefined method 'untaint'` | Stale `BUNDLED WITH 1.x` in `ios/Gemfile.lock`; regenerate with `bundle _2.5.23_ lock --update-bundler` |
 
 See also [`ios-multi-environment.md`](ios-multi-environment.md) for local dev/prod side-by-side
 setup and [`notifications-troubleshooting.md`](notifications-troubleshooting.md) for push

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -2,9 +2,6 @@
 
 require 'base64'
 require 'json'
-require 'shellwords'
-require 'tempfile'
-require 'tmpdir'
 
 opt_out_usage
 
@@ -15,15 +12,7 @@ PBXPROJ_PATH = File.join(REPO_ROOT, 'ios/App/App.xcodeproj/project.pbxproj')
 XCODE_PROJECT = File.join(REPO_ROOT, 'ios/App/App.xcodeproj')
 APP_IDENTIFIER = 'io.github.thetigeregg.gameshelf'
 TEAM_ID = '6V392K7X46'
-ASC_API_KEY_ENV_VARS = %w[
-  APP_STORE_CONNECT_API_KEY_ID
-  APP_STORE_CONNECT_API_ISSUER_ID
-  APP_STORE_CONNECT_API_KEY
-].freeze
-
-def app_store_connect_api_key_configured?
-  ASC_API_KEY_ENV_VARS.all? { |var| ENV[var] && !ENV[var].empty? }
-end
+MATCH_PROFILE_NAME = "match AppStore #{APP_IDENTIFIER}".freeze
 
 def load_app_store_connect_api_key
   app_store_connect_api_key(
@@ -56,37 +45,23 @@ def sync_capacitor_prod_assets
   end
 end
 
-def write_app_store_connect_api_key_file
-  @app_store_connect_api_key_path ||= begin
-    key_content = Base64.decode64(ENV.fetch('APP_STORE_CONNECT_API_KEY'))
-    key_file = Tempfile.new(['asc_api_key_', '.p8'], ENV.fetch('RUNNER_TEMP', Dir.tmpdir))
-    key_file.write(key_content)
-    key_file.chmod(0o600)
-    key_file.close
-    at_exit { key_file.unlink if key_file }
-    key_file.path
-  end
-end
-
-def xcode_automatic_signing_xcargs
-  args = ['-allowProvisioningUpdates']
-  if app_store_connect_api_key_configured?
-    key_path = write_app_store_connect_api_key_file
-    args.concat(
-      [
-        '-authenticationKeyIssuerID', ENV.fetch('APP_STORE_CONNECT_API_ISSUER_ID'),
-        '-authenticationKeyID', ENV.fetch('APP_STORE_CONNECT_API_KEY_ID'),
-        '-authenticationKeyPath', key_path
-      ]
-    )
-  end
-  args.map { |arg| Shellwords.escape(arg) }.join(' ')
+def sync_appstore_signing(api_key:, readonly:)
+  match(
+    type: 'appstore',
+    readonly: readonly,
+    api_key: api_key,
+    git_basic_authorization: ENV['MATCH_GIT_BASIC_AUTHORIZATION']
+  )
 end
 
 def app_store_export_options
   {
-    signingStyle: 'automatic',
-    teamID: TEAM_ID
+    method: 'app-store-connect',
+    signingStyle: 'manual',
+    teamID: TEAM_ID,
+    provisioningProfiles: {
+      APP_IDENTIFIER => MATCH_PROFILE_NAME
+    }
   }
 end
 
@@ -95,9 +70,8 @@ def prod_build_app(**extra)
     project: XCODE_PROJECT,
     scheme: 'App PROD',
     configuration: 'Release',
-    export_method: 'app-store',
+    export_method: 'app-store-connect',
     export_options: app_store_export_options,
-    xcargs: xcode_automatic_signing_xcargs,
     clean: true
   }
   build_app(**defaults.merge(extra))
@@ -105,7 +79,7 @@ end
 
 platform :ios do
   before_all do
-    setup_ci if ENV['CI']
+    setup_ci(require_create: true) if ENV['CI']
   end
 
   desc 'Verify App Store Connect app exists and API key can read build numbers'
@@ -116,6 +90,13 @@ platform :ios do
       app_identifier: APP_IDENTIFIER,
       initial_build_number: 0
     )
+  end
+
+  desc 'Verify match can install App Store cert and profile from encrypted repo'
+  lane :validate_match do
+    api_key = load_app_store_connect_api_key
+    sync_appstore_signing(api_key: api_key, readonly: true)
+    UI.success("Installed profile #{MATCH_PROFILE_NAME}")
   end
 
   desc 'Build App PROD and upload to TestFlight'
@@ -131,6 +112,9 @@ platform :ios do
 
     UI.message("Syncing App PROD version to #{read_package_version} (#{next_build_number})")
     sync_ios_prod_version(build_number: next_build_number)
+
+    UI.message('Installing App Store signing assets via match')
+    sync_appstore_signing(api_key: api_key, readonly: ENV['CI'] == 'true')
 
     UI.message('Building Capacitor web assets for ios-prod')
     sync_capacitor_prod_assets
@@ -151,7 +135,10 @@ platform :ios do
 
   desc 'Archive App PROD without uploading (local debugging)'
   lane :build_only do
+    api_key = load_app_store_connect_api_key
+
     sync_ios_prod_version(build_number: ENV.fetch('IOS_BUILD_NUMBER', '1'))
+    sync_appstore_signing(api_key: api_key, readonly: ENV['CI'] == 'true')
     sync_capacitor_prod_assets
 
     prod_build_app

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -56,7 +56,7 @@ end
 
 def app_store_export_options
   {
-    method: 'app-store-connect',
+    method: 'app-store',
     signingStyle: 'manual',
     teamID: TEAM_ID,
     provisioningProfiles: {
@@ -70,7 +70,7 @@ def prod_build_app(**extra)
     project: XCODE_PROJECT,
     scheme: 'App PROD',
     configuration: 'Release',
-    export_method: 'app-store-connect',
+    export_method: 'app-store',
     export_options: app_store_export_options,
     clean: true
   }
@@ -114,7 +114,7 @@ platform :ios do
     sync_ios_prod_version(build_number: next_build_number)
 
     UI.message('Installing App Store signing assets via match')
-    sync_appstore_signing(api_key: api_key, readonly: ENV['CI'] == 'true')
+    sync_appstore_signing(api_key: api_key, readonly: Helper.ci?)
 
     UI.message('Building Capacitor web assets for ios-prod')
     sync_capacitor_prod_assets
@@ -138,7 +138,7 @@ platform :ios do
     api_key = load_app_store_connect_api_key
 
     sync_ios_prod_version(build_number: ENV.fetch('IOS_BUILD_NUMBER', '1'))
-    sync_appstore_signing(api_key: api_key, readonly: ENV['CI'] == 'true')
+    sync_appstore_signing(api_key: api_key, readonly: Helper.ci?)
     sync_capacitor_prod_assets
 
     prod_build_app

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,0 +1,6 @@
+git_url("https://github.com/thetigeregg/game-shelf-match-certs.git")
+storage_mode("git")
+type("appstore")
+app_identifier(["io.github.thetigeregg.gameshelf"])
+team_id("6V392K7X46")
+clone_branch_directly(true)


### PR DESCRIPTION
## Summary

Replace automatic App Store Connect provisioning on the TestFlight CI job with **fastlane match**. Distribution certificate and App Store profile are stored in an encrypted private repo and installed into a temporary CI keychain before archive/export.

Motivation: automatic signing with `-allowProvisioningUpdates` was unreliable on GitHub Actions; match gives deterministic manual signing similar to Azure DevOps secure-file workflows.

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [x] ci
- [ ] chore
- [ ] style

## Implementation details

- Add `ios/fastlane/Matchfile` targeting `thetigeregg/game-shelf-match-certs` (App Store type, prod bundle ID, team `6V392K7X46`).
- Refactor `ios/fastlane/Fastfile`:
  - Remove automatic-signing `xcargs` and temp ASC `.p8` file helpers.
  - Add `sync_appstore_signing` via `match` (readonly on CI).
  - Switch export to manual signing with profile `match AppStore io.github.thetigeregg.gameshelf`.
  - Add `validate_match` lane; call match before build in `deploy_testflight` and `build_only`.
  - Use `setup_ci(require_create: true)` for CI keychain creation.
- Update `.github/workflows/ios-testflight.yml`:
  - Require `MATCH_PASSWORD` and `MATCH_GIT_BASIC_AUTHORIZATION` secrets.
  - Add `Validate match signing assets` step before TestFlight upload.
- Expand `docs/ios-testflight-ci.md` with match bootstrap, new secrets, maintenance table, and updated troubleshooting.

**Deploy prerequisite:** one-time local `fastlane match appstore` bootstrap and GitHub secrets for match must be configured before CI succeeds.

## Testing performed

- [x] `npm run lint`
- [x] `npm run test` (1392 tests passed)
- [x] `npm run build`
- [ ] macOS TestFlight workflow (requires match bootstrap + secrets on runner)

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes (pending match bootstrap + secrets)
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #