### PR TITLE
fix(ios): unblock TestFlight CI signing and export compliance

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -175,9 +175,16 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: bundle exec fastlane deploy_testflight
 
+      - name: Create GitHub App token
+        id: variable_sync_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.AUTOCOMMIT_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOCOMMIT_APP_PRIVATE_KEY }}
+
       - name: Sync IOS_OTA_NATIVE_BUILD_NUMBER
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.variable_sync_token.outputs.token }}
         run: |
           BUILD_NUMBER="${{ steps.testflight_upload.outputs.ios_native_build_number }}"
           if [ -z "$BUILD_NUMBER" ]; then

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -99,7 +99,7 @@ jobs:
         run: npm ci
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/docs/ios-testflight-ci.md
+++ b/docs/ios-testflight-ci.md
@@ -88,6 +88,7 @@ you prefer):
 | `MATCH_GIT_BASIC_AUTHORIZATION`   | Base64 of `x-access-token:<PAT>` for read access to `game-shelf-match-certs`                                           |
 | `IOS_FIREBASE_PROD_PLIST_BASE64`  | Base64-encoded prod `GoogleService-Info.plist` (same file as `~/.config/game-shelf/ios/GoogleService-Info.prod.plist`) |
 | `IOS_BACKEND_ORIGIN_PROD`         | HTTPS production edge origin baked into `environment.ios.prod.ts` (same value as local `.env`)                         |
+| `AUTOCOMMIT_APP_PRIVATE_KEY`      | GitHub App private key (PEM) used to mint a token that can update repository variables after TestFlight upload         |
 
 Encode the Firebase plist locally:
 
@@ -111,6 +112,7 @@ echo -n 'x-access-token:github_pat_xxxxxxxx' | base64 | pbcopy
 
 | Name                          | Description                                                                 |
 | ----------------------------- | --------------------------------------------------------------------------- |
+| `AUTOCOMMIT_CLIENT_ID`        | GitHub App **Client ID** (from app settings; not the numeric App ID)        |
 | `IOS_OTA_NATIVE_BUILD_NUMBER` | Latest App PROD `CFBundleVersion` used for OTA manifest paths (see OTA doc) |
 
 ## One-time Apple setup
@@ -166,10 +168,14 @@ Verify in the Developer portal:
    - Reads semver from root [`package.json`](../package.json)
    - Queries App Store Connect for the latest TestFlight build number and increments it
    - Updates **App PROD** `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` in Xcode
-   - Runs `match appstore` (readonly on CI) to install signing assets
+   - Runs `match appstore` (readonly on CI) to install signing assets, then applies manual
+     signing settings for the **App PROD** target
    - Runs `npm run sync:ios:prod` (Angular ios-prod build + Capacitor sync)
    - Archives and exports **App PROD** (Release) with the match App Store profile
-   - Uploads to TestFlight (does not wait for Apple processing)
+   - Uploads to TestFlight with `uses_non_exempt_encryption: false` (does not wait for Apple
+     processing)
+8. Mints a GitHub App token and sets `IOS_OTA_NATIVE_BUILD_NUMBER` to the uploaded native build
+   number so edge OTA manifests stay aligned with the latest TestFlight shell.
 
 ## Native dependencies
 

--- a/ios/App/App/Info.dev.plist
+++ b/ios/App/App/Info.dev.plist
@@ -22,6 +22,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/App/App/Info.prod.plist
+++ b/ios/App/App/Info.prod.plist
@@ -22,6 +22,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/ios/App/App/Info.shared.plist
+++ b/ios/App/App/Info.shared.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -136,7 +136,8 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true
+      skip_waiting_for_build_processing: true,
+      uses_non_exempt_encryption: false
     )
 
     if ENV['GITHUB_OUTPUT']

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -54,6 +54,18 @@ def sync_appstore_signing(api_key:, readonly:)
   )
 end
 
+def apply_prod_manual_signing
+  update_code_signing_settings(
+    use_automatic_signing: false,
+    path: XCODE_PROJECT,
+    targets: ['App PROD'],
+    code_sign_identity: 'Apple Distribution',
+    bundle_identifier: APP_IDENTIFIER,
+    profile_name: MATCH_PROFILE_NAME,
+    team_id: TEAM_ID
+  )
+end
+
 def app_store_export_options
   {
     method: 'app-store',
@@ -115,6 +127,7 @@ platform :ios do
 
     UI.message('Installing App Store signing assets via match')
     sync_appstore_signing(api_key: api_key, readonly: Helper.ci?)
+    apply_prod_manual_signing
 
     UI.message('Building Capacitor web assets for ios-prod')
     sync_capacitor_prod_assets
@@ -139,6 +152,7 @@ platform :ios do
 
     sync_ios_prod_version(build_number: ENV.fetch('IOS_BUILD_NUMBER', '1'))
     sync_appstore_signing(api_key: api_key, readonly: Helper.ci?)
+    apply_prod_manual_signing
     sync_capacitor_prod_assets
 
     prod_build_app

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -79,7 +79,7 @@ end
 
 platform :ios do
   before_all do
-    setup_ci(require_create: true) if ENV['CI']
+    setup_ci if ENV['CI']
   end
 
   desc 'Verify App Store Connect app exists and API key can read build numbers'

--- a/scripts/generate-ios-info-plists.mjs
+++ b/scripts/generate-ios-info-plists.mjs
@@ -28,6 +28,7 @@ export const INFO_PLIST_KEY_ORDER = [
   'CFBundlePackageType',
   'CFBundleShortVersionString',
   'CFBundleVersion',
+  'ITSAppUsesNonExemptEncryption',
   'LSRequiresIPhoneOS',
   'NSAppTransportSecurity',
   'UIBackgroundModes',

--- a/scripts/generate-ios-info-plists.test.mjs
+++ b/scripts/generate-ios-info-plists.test.mjs
@@ -69,6 +69,7 @@ test('mergeInfoPlistVariant merges shared and overlay plists from repo', () => {
   });
 
   assert.equal(merged.CFBundleDisplayName, 'GameShelf Dev');
+  assert.equal(merged.ITSAppUsesNonExemptEncryption, false);
   assert.equal(merged.NSAppTransportSecurity.NSAllowsLocalNetworking, true);
   assert.equal(merged.CAPACITOR_DEBUG, '$(CAPACITOR_DEBUG)');
 });


### PR DESCRIPTION
## Summary

Repairs iOS TestFlight CI failures around code signing, export compliance, and post-upload OTA build-number sync.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [x] ci
- [ ] chore
- [ ] style

## Implementation details

- **Fastlane:** Add `apply_prod_manual_signing` after match to pin the App PROD target to the match App Store profile (`Apple Distribution`, manual signing). Call it from `deploy_testflight` and `build_only`. Drop `require_create: true` from `setup_ci`. Pass `uses_non_exempt_encryption: false` to `upload_to_testflight`.
- **Info plists:** Add `ITSAppUsesNonExemptEncryption` = `false` to `Info.shared.plist` (generated into dev/prod). Include the key in `INFO_PLIST_KEY_ORDER`.
- **CI workflow:** Select `Xcode_26.3` on the macOS runner. Mint a GitHub App token (`actions/create-github-app-token@v3`) so `gh variable set IOS_OTA_NATIVE_BUILD_NUMBER` succeeds after upload (default `GITHUB_TOKEN` lacks variable write access).
- **Docs:** Document `AUTOCOMMIT_CLIENT_ID`, `AUTOCOMMIT_APP_PRIVATE_KEY`, manual signing, export compliance, and OTA variable sync in `docs/ios-testflight-ci.md`.

## Testing performed

- `npm run lint`
- `npm run test` (1392 tests; includes updated `generate-ios-info-plists` assertion)
- `npm run build`
- `node scripts/generate-ios-info-plists.mjs --check`
- Fastlane/Xcode signing path not exercised locally (requires match + macOS)

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #