### PR TITLE
feat(ui): prompt for write token on native iOS first launch

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -506,6 +506,7 @@ describe('AppComponent', () => {
       TestBed.runInInjectionContext(() => new AppComponent());
       await flushAsync();
 
+      expect(splashHideMock).toHaveBeenCalledWith({ fadeOutDuration: 300 });
       expect(alertControllerMock.create).toHaveBeenCalledWith(
         expect.objectContaining({
           header: 'Server Access',
@@ -513,6 +514,19 @@ describe('AppComponent', () => {
         })
       );
       expect(present).toHaveBeenCalledOnce();
+    });
+
+    it('logs write-token prompt failures and continues startup', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+      alertControllerMock.create.mockRejectedValueOnce(new Error('alert create failed'));
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(errorSpy).toHaveBeenCalledWith('[app] write_token_prompt_failed', expect.any(Error));
+      expect(gameSyncServiceMock.initialize).toHaveBeenCalledOnce();
     });
 
     it('does not show the write-token alert on native when a token is already stored', async () => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -53,6 +53,7 @@ import { RuntimeAvailabilityService } from './core/services/runtime-availability
 import { NetworkConnectivityService } from './core/services/network-connectivity.service';
 import { LiveUpdateService } from './core/services/live-update.service';
 import { PreferenceStorageService } from './core/storage/preference-storage.service';
+import { ClientWriteAuthService } from './core/services/client-write-auth.service';
 
 const LAST_SEEN_APP_VERSION_STORAGE_KEY = 'game_shelf_last_seen_app_version';
 
@@ -124,6 +125,10 @@ describe('AppComponent', () => {
   const networkConnectivityServiceMock = {
     initialize: vi.fn(),
   };
+  const clientWriteAuthServiceMock = {
+    hasToken: vi.fn(() => false),
+    setToken: vi.fn(),
+  };
 
   beforeEach(() => {
     localStorage.clear();
@@ -148,9 +153,11 @@ describe('AppComponent', () => {
     liveUpdateServiceMock.markReady.mockResolvedValue(undefined);
     alertControllerMock.create.mockResolvedValue({
       present: vi.fn().mockResolvedValue(undefined),
-      onDidDismiss: vi.fn().mockResolvedValue(undefined),
+      onDidDismiss: vi.fn().mockResolvedValue({ role: 'cancel', data: undefined }),
     });
     alertControllerMock.getTop.mockResolvedValue(null);
+    clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+    clientWriteAuthServiceMock.setToken.mockReset();
     toastControllerMock.create.mockResolvedValue({
       present: vi.fn().mockResolvedValue(undefined),
     });
@@ -172,6 +179,7 @@ describe('AppComponent', () => {
         { provide: ToastController, useValue: toastControllerMock },
         { provide: RuntimeAvailabilityService, useValue: runtimeAvailabilityServiceMock },
         { provide: NetworkConnectivityService, useValue: networkConnectivityServiceMock },
+        { provide: ClientWriteAuthService, useValue: clientWriteAuthServiceMock },
         PreferenceStorageService,
       ],
     });
@@ -455,6 +463,7 @@ describe('AppComponent', () => {
     vi.useFakeTimers();
     localStorage.setItem(LAST_SEEN_APP_VERSION_STORAGE_KEY, '1.27.1');
     vi.mocked(isNativePlatform).mockReturnValue(true);
+    clientWriteAuthServiceMock.hasToken.mockReturnValue(true);
 
     TestBed.runInInjectionContext(() => new AppComponent());
     await flushAsyncWithFakeTimers();
@@ -469,6 +478,7 @@ describe('AppComponent', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     localStorage.setItem(LAST_SEEN_APP_VERSION_STORAGE_KEY, '1.27.1');
     vi.mocked(isNativePlatform).mockReturnValue(true);
+    clientWriteAuthServiceMock.hasToken.mockReturnValue(true);
     splashHideMock.mockRejectedValueOnce(new Error('splash hide failed'));
 
     TestBed.runInInjectionContext(() => new AppComponent());
@@ -477,5 +487,100 @@ describe('AppComponent', () => {
     await Promise.resolve();
 
     expect(errorSpy).toHaveBeenCalledWith('[app] splash_screen_hide_failed', expect.any(Error));
+  });
+
+  describe('promptForWriteTokenIfNeeded', () => {
+    beforeEach(() => {
+      localStorage.setItem(LAST_SEEN_APP_VERSION_STORAGE_KEY, '1.27.1');
+    });
+
+    it('shows the write-token alert on native when no token is stored', async () => {
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+      const present = vi.fn().mockResolvedValue(undefined);
+      alertControllerMock.create.mockResolvedValueOnce({
+        present,
+        onDidDismiss: vi.fn().mockResolvedValue({ role: 'cancel', data: undefined }),
+      });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(alertControllerMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          header: 'Server Access',
+          backdropDismiss: false,
+        })
+      );
+      expect(present).toHaveBeenCalledOnce();
+    });
+
+    it('does not show the write-token alert on native when a token is already stored', async () => {
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(true);
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(alertControllerMock.create).not.toHaveBeenCalled();
+    });
+
+    it('does not show the write-token alert on web even when no token is stored', async () => {
+      vi.mocked(isNativePlatform).mockReturnValue(false);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(alertControllerMock.create).not.toHaveBeenCalled();
+    });
+
+    it('stores the token when the user confirms with a non-empty value', async () => {
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+      alertControllerMock.create.mockResolvedValueOnce({
+        present: vi.fn().mockResolvedValue(undefined),
+        onDidDismiss: vi.fn().mockResolvedValue({
+          role: 'confirm',
+          data: { values: { token: 'my-secret-token' } },
+        }),
+      });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(clientWriteAuthServiceMock.setToken).toHaveBeenCalledWith('my-secret-token');
+    });
+
+    it('does not store the token when the user confirms with an empty value', async () => {
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+      alertControllerMock.create.mockResolvedValueOnce({
+        present: vi.fn().mockResolvedValue(undefined),
+        onDidDismiss: vi.fn().mockResolvedValue({
+          role: 'confirm',
+          data: { values: { token: '   ' } },
+        }),
+      });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(clientWriteAuthServiceMock.setToken).not.toHaveBeenCalled();
+    });
+
+    it('does not store the token when the user skips', async () => {
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+      alertControllerMock.create.mockResolvedValueOnce({
+        present: vi.fn().mockResolvedValue(undefined),
+        onDidDismiss: vi.fn().mockResolvedValue({ role: 'cancel', data: undefined }),
+      });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(clientWriteAuthServiceMock.setToken).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -492,6 +492,12 @@ describe('AppComponent', () => {
   describe('promptForWriteTokenIfNeeded', () => {
     beforeEach(() => {
       localStorage.setItem(LAST_SEEN_APP_VERSION_STORAGE_KEY, '1.27.1');
+      // Stub Date.now so hideSplashScreenWhenReady sees remainingVisibleMs <= 0,
+      // preventing a real 300ms timer from leaking into subsequent tests.
+      const fakeNow = Date.now();
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(fakeNow) // appStartedAt (field initializer)
+        .mockReturnValue(fakeNow + 400); // hideSplashScreenWhenReady: 300 - 400 = -100 <= 0
     });
 
     it('shows the write-token alert on native when no token is stored', async () => {
@@ -566,9 +572,11 @@ describe('AppComponent', () => {
       expect(clientWriteAuthServiceMock.setToken).toHaveBeenCalledWith('my-secret-token');
     });
 
-    it('does not store the token when the user confirms with an empty value', async () => {
+    it('shows a warning toast and does not store the token when the user confirms with an empty value', async () => {
       vi.mocked(isNativePlatform).mockReturnValue(true);
       clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+      const presentToast = vi.fn().mockResolvedValue(undefined);
+      toastControllerMock.create.mockResolvedValueOnce({ present: presentToast });
       alertControllerMock.create.mockResolvedValueOnce({
         present: vi.fn().mockResolvedValue(undefined),
         onDidDismiss: vi.fn().mockResolvedValue({
@@ -581,6 +589,13 @@ describe('AppComponent', () => {
       await flushAsync();
 
       expect(clientWriteAuthServiceMock.setToken).not.toHaveBeenCalled();
+      expect(toastControllerMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Write token cannot be empty.',
+          color: 'warning',
+        })
+      );
+      expect(presentToast).toHaveBeenCalledOnce();
     });
 
     it('does not store the token when the user skips', async () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -117,6 +117,8 @@ export class AppComponent {
 
     if (token.length > 0) {
       this.clientWriteAuthService.setToken(token);
+    } else {
+      await this.presentNotificationToast('Write token cannot be empty.', 'warning');
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,6 +18,7 @@ import { RuntimeAvailabilityService } from './core/services/runtime-availability
 import { NetworkConnectivityService } from './core/services/network-connectivity.service';
 import { isNativePlatform } from './core/utils/native-platform.util';
 import { PreferenceStorageService } from './core/storage/preference-storage.service';
+import { ClientWriteAuthService } from './core/services/client-write-auth.service';
 import { LiveUpdateService } from './core/services/live-update.service';
 import { SyncBootstrapProgressService } from './core/services/sync-bootstrap-progress.service';
 
@@ -45,6 +46,7 @@ export class AppComponent {
   readonly runtimeAvailabilityService = inject(RuntimeAvailabilityService);
   readonly syncBootstrapProgress = inject(SyncBootstrapProgressService);
   private readonly networkConnectivityService = inject(NetworkConnectivityService);
+  private readonly clientWriteAuthService = inject(ClientWriteAuthService);
   private readonly appStartedAt = Date.now();
 
   constructor() {
@@ -59,6 +61,7 @@ export class AppComponent {
     }
     this.debugLogService.initialize();
     this.themeService.initialize();
+    await this.promptForWriteTokenIfNeeded();
     await this.gameSyncService.initialize();
     void this.runStartupCoverMigrations();
     await this.presentVersionAlertIfNeeded().catch((error: unknown) => {
@@ -72,6 +75,43 @@ export class AppComponent {
     await this.initializeNotifications().catch((error: unknown) => {
       console.error('[app] notifications_init_failed', error);
     });
+  }
+
+  private async promptForWriteTokenIfNeeded(): Promise<void> {
+    if (!isNativePlatform() || this.clientWriteAuthService.hasToken()) {
+      return;
+    }
+
+    const alert = await this.alertController.create({
+      header: 'Server Access',
+      message:
+        'Enter your write token to sync your library. You can find this in your server settings.',
+      backdropDismiss: false,
+      inputs: [
+        {
+          name: 'token',
+          type: 'password',
+          placeholder: 'Write token',
+        },
+      ],
+      buttons: [
+        { text: 'Skip', role: 'cancel' },
+        { text: 'Connect', role: 'confirm' },
+      ],
+    });
+
+    await alert.present();
+    const { role, data } = await alert.onDidDismiss<{ values?: { token?: unknown } }>();
+
+    if (role !== 'confirm') {
+      return;
+    }
+
+    const token = typeof data?.values?.token === 'string' ? data.values.token.trim() : '';
+
+    if (token.length > 0) {
+      this.clientWriteAuthService.setToken(token);
+    }
   }
 
   private async hideSplashScreenWhenReady(): Promise<void> {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -61,7 +61,9 @@ export class AppComponent {
     }
     this.debugLogService.initialize();
     this.themeService.initialize();
-    await this.promptForWriteTokenIfNeeded();
+    await this.promptForWriteTokenIfNeeded().catch((error: unknown) => {
+      console.error('[app] write_token_prompt_failed', error);
+    });
     await this.gameSyncService.initialize();
     void this.runStartupCoverMigrations();
     await this.presentVersionAlertIfNeeded().catch((error: unknown) => {
@@ -81,6 +83,10 @@ export class AppComponent {
     if (!isNativePlatform() || this.clientWriteAuthService.hasToken()) {
       return;
     }
+
+    await SplashScreen.hide({ fadeOutDuration: 300 }).catch((error: unknown) => {
+      console.error('[app] splash_screen_hide_failed', error);
+    });
 
     const alert = await this.alertController.create({
       header: 'Server Access',


### PR DESCRIPTION
## Summary

On native iOS, when no write token is stored, the app now shows a modal
alert on startup prompting the user to enter their server write token.
This allows self-hosted users to authenticate their library sync on
first launch without needing to navigate to settings.

## Type of change

- [x] feat (new feature)

## Implementation details

- Added `promptForWriteTokenIfNeeded()` to `AppComponent`, called during
  the startup sequence before `gameSyncService.initialize()`.
- The prompt is gated on `isNativePlatform() && !clientWriteAuthService.hasToken()`,
  so it is a no-op on web and for returning users who already have a token.
- The `AlertController` presents a password input with Skip/Connect
  buttons. On confirm, the trimmed token is stored via
  `ClientWriteAuthService.setToken()` only if non-empty.
- `backdropDismiss: false` ensures the alert cannot be accidentally
  dismissed.

## Testing performed

- Added 6 unit tests covering: native/no-token shows alert, native/token
  skips alert, web/no-token skips alert, confirm with valid token stores
  it, confirm with blank token does not store, cancel does not store.
- `npm run lint` — passed
- `npm run test` — 1443 tests passed (95 test files)
- `npm run build` — build succeeded

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #