### PR TITLE
fix(popover): remove popoverController.dismiss() to unblock navigation

### DIFF
--- a/src/app/explore/explore.page.spec.ts
+++ b/src/app/explore/explore.page.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, Subject, of, throwError } from 'rxjs';
-import { AlertController, PopoverController, ToastController } from '@ionic/angular/standalone';
+import { AlertController, ToastController } from '@ionic/angular/standalone';
 import { ExplorePage } from './explore.page';
 import { IgdbProxyService } from '../core/api/igdb-proxy.service';
 import type { GameCatalogResult } from '../core/models/game.models';
@@ -23,13 +23,9 @@ vi.mock('@ionic/angular/standalone', () => {
   const ToastControllerToken = function ToastController() {
     return undefined;
   };
-  const PopoverControllerToken = function PopoverController() {
-    return undefined;
-  };
   return {
     AlertController: AlertControllerToken,
     ToastController: ToastControllerToken,
-    PopoverController: PopoverControllerToken,
     IonContent: Dummy,
     IonHeader: Dummy,
     IonGrid: Dummy,
@@ -456,9 +452,6 @@ describe('ExplorePage explore modes UX', () => {
   const toastControllerMock = {
     create: vi.fn().mockResolvedValue({ present: vi.fn().mockResolvedValue(undefined) }),
   };
-  const popoverControllerMock = {
-    dismiss: vi.fn().mockResolvedValue(true),
-  };
   const routerMock = {
     navigateByUrl: vi.fn().mockResolvedValue(true),
   };
@@ -483,7 +476,6 @@ describe('ExplorePage explore modes UX', () => {
     );
     igdbProxyServiceMock.lookupSteamPrice.mockReturnValue(of({ status: 'unavailable' }));
     igdbProxyServiceMock.lookupPsPrices.mockReturnValue(of({ status: 'unavailable' }));
-    popoverControllerMock.dismiss.mockResolvedValue(true);
     routerMock.navigateByUrl.mockResolvedValue(true);
     debugLogServiceMock.trace.mockReset();
 
@@ -496,7 +488,6 @@ describe('ExplorePage explore modes UX', () => {
         { provide: GameShelfService, useValue: gameShelfServiceMock },
         { provide: RecommendationIgnoreService, useValue: recommendationIgnoreServiceMock },
         { provide: AlertController, useValue: alertControllerMock },
-        { provide: PopoverController, useValue: popoverControllerMock },
         { provide: ToastController, useValue: toastControllerMock },
         { provide: Router, useValue: routerMock },
       ],

--- a/src/app/explore/explore.page.spec.ts
+++ b/src/app/explore/explore.page.spec.ts
@@ -2345,39 +2345,19 @@ describe('ExplorePage explore modes UX', () => {
       openSettingsFromPopover: () => Promise<void>;
     };
     const event = { type: 'click' } as unknown as Event;
-    let resolveDismiss: ((value: boolean) => void) | undefined;
-
-    popoverControllerMock.dismiss.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveDismiss = resolve;
-        })
-    );
 
     page.openHeaderActionsPopover(event);
     expect(page.isHeaderActionsPopoverOpen).toBe(true);
     expect(page.headerActionsPopoverEvent).toBe(event);
 
-    const openSettingsPromise = page.openSettingsFromPopover();
+    await page.openSettingsFromPopover();
 
-    await Promise.resolve();
-
-    expect(popoverControllerMock.dismiss).toHaveBeenCalled();
-    expect(routerMock.navigateByUrl).not.toHaveBeenCalled();
-
-    resolveDismiss?.(true);
-    await openSettingsPromise;
-
-    expect(popoverControllerMock.dismiss).toHaveBeenCalled();
     expect(routerMock.navigateByUrl).toHaveBeenCalledWith('/settings');
-    expect(popoverControllerMock.dismiss.mock.invocationCallOrder[0]).toBeLessThan(
-      routerMock.navigateByUrl.mock.invocationCallOrder[0]
-    );
     expect(page.isHeaderActionsPopoverOpen).toBe(false);
     expect(page.headerActionsPopoverEvent).toBeUndefined();
   });
 
-  it('routes settings even when header popover dismissal rejects', async () => {
+  it('closes header popover state synchronously before navigating to settings', async () => {
     const page = createPage() as unknown as {
       isHeaderActionsPopoverOpen: boolean;
       headerActionsPopoverEvent: Event | undefined;
@@ -2386,14 +2366,16 @@ describe('ExplorePage explore modes UX', () => {
     };
     const event = { type: 'click' } as unknown as Event;
 
-    popoverControllerMock.dismiss.mockRejectedValueOnce(new Error('dismiss failed'));
-
     page.openHeaderActionsPopover(event);
+
+    let stateAfterClose: boolean | undefined;
+    routerMock.navigateByUrl.mockImplementationOnce(() => {
+      stateAfterClose = page.isHeaderActionsPopoverOpen;
+    });
+
     await page.openSettingsFromPopover();
 
-    expect(popoverControllerMock.dismiss).toHaveBeenCalled();
-    expect(routerMock.navigateByUrl).toHaveBeenCalledWith('/settings');
-    expect(page.isHeaderActionsPopoverOpen).toBe(false);
+    expect(stateAfterClose).toBe(false);
     expect(page.headerActionsPopoverEvent).toBeUndefined();
   });
 

--- a/src/app/explore/explore.page.spec.ts
+++ b/src/app/explore/explore.page.spec.ts
@@ -2371,6 +2371,7 @@ describe('ExplorePage explore modes UX', () => {
     let stateAfterClose: boolean | undefined;
     routerMock.navigateByUrl.mockImplementationOnce(() => {
       stateAfterClose = page.isHeaderActionsPopoverOpen;
+      return Promise.resolve(true);
     });
 
     await page.openSettingsFromPopover();

--- a/src/app/explore/explore.page.ts
+++ b/src/app/explore/explore.page.ts
@@ -4,7 +4,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
   AlertController,
-  PopoverController,
   ToastController,
   IonContent,
   IonHeader,
@@ -273,7 +272,6 @@ export class ExplorePage implements OnInit {
   private readonly gameShelfService = inject(GameShelfService);
   private readonly recommendationIgnoreService = inject(RecommendationIgnoreService);
   private readonly alertController = inject(AlertController);
-  private readonly popoverController = inject(PopoverController);
   private readonly toastController = inject(ToastController);
   private readonly router = inject(Router);
   private readonly lanesCache = new Map<string, RecommendationLanesResponse>();
@@ -452,13 +450,12 @@ export class ExplorePage implements OnInit {
     this.headerActionsPopoverEvent = undefined;
   }
 
-  async closeHeaderActionsPopover(): Promise<void> {
+  closeHeaderActionsPopover(): void {
     this.onHeaderActionsPopoverDidDismiss();
-    await this.popoverController.dismiss().catch(() => undefined);
   }
 
   async openSettingsFromPopover(): Promise<void> {
-    await this.closeHeaderActionsPopover();
+    this.closeHeaderActionsPopover();
     await this.router.navigateByUrl('/settings');
   }
 

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -693,22 +693,16 @@ describe('ListPageComponent', () => {
     expect(component.filters.collections).toEqual(['Prime']);
   });
 
-  it('closes popovers and tolerates dismiss failures', async () => {
+  it('closes popovers synchronously', () => {
     const component = createComponent();
-    const popoverController = (
-      component as unknown as {
-        popoverController: { dismiss: () => Promise<void> };
-      }
-    ).popoverController;
 
     component.bulkActionsPopoverEvent = new Event('click');
     component.isBulkActionsPopoverOpen = true;
     component.headerActionsPopoverEvent = new Event('click');
     component.isHeaderActionsPopoverOpen = true;
-    vi.spyOn(popoverController, 'dismiss').mockRejectedValueOnce(new Error('dismiss failed'));
 
     component.closeBulkActionsPopover();
-    await component.closeHeaderActionsPopover();
+    component.closeHeaderActionsPopover();
 
     expect(component.isBulkActionsPopoverOpen).toBe(false);
     expect(component.bulkActionsPopoverEvent).toBeUndefined();

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -11,9 +11,6 @@ vi.mock('@ionic/angular/standalone', () => {
   const MenuControllerToken = function MenuController() {
     return undefined;
   };
-  const PopoverControllerToken = function PopoverController() {
-    return undefined;
-  };
   const ToastControllerToken = function ToastController() {
     return undefined;
   };
@@ -21,7 +18,6 @@ vi.mock('@ionic/angular/standalone', () => {
   return {
     AlertController: AlertControllerToken,
     MenuController: MenuControllerToken,
-    PopoverController: PopoverControllerToken,
     ToastController: ToastControllerToken,
     IonHeader: Dummy,
     IonToolbar: Dummy,
@@ -72,12 +68,7 @@ import { GameShelfService } from '../core/services/game-shelf.service';
 import { LayoutModeService } from '../core/services/layout-mode.service';
 import { AddToLibraryWorkflowService } from '../features/game-search/add-to-library-workflow.service';
 import { DEFAULT_GAME_LIST_FILTERS, type GameCatalogResult } from '../core/models/game.models';
-import {
-  AlertController,
-  MenuController,
-  PopoverController,
-  ToastController,
-} from '@ionic/angular/standalone';
+import { AlertController, MenuController, ToastController } from '@ionic/angular/standalone';
 import { serializeListPagePreferences } from './list-page-preferences';
 
 describe('ListPageComponent', () => {
@@ -124,7 +115,6 @@ describe('ListPageComponent', () => {
         { provide: AddToLibraryWorkflowService, useValue: addToLibraryWorkflowMock },
         { provide: AlertController, useValue: { create: vi.fn() } },
         { provide: MenuController, useValue: { open: vi.fn() } },
-        { provide: PopoverController, useValue: { dismiss: vi.fn().mockResolvedValue(undefined) } },
         { provide: ToastController, useValue: { create: vi.fn() } },
       ],
     });

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -6,7 +6,6 @@ import { firstValueFrom } from 'rxjs';
 import {
   AlertController,
   MenuController,
-  PopoverController,
   ToastController,
   IonHeader,
   IonToolbar,
@@ -227,7 +226,6 @@ export class ListPageComponent {
   @ViewChild('headerSearchbar') private headerSearchbar?: IonSearchbar;
   private readonly menuController = inject(MenuController);
   private readonly alertController = inject(AlertController);
-  private readonly popoverController = inject(PopoverController);
   private readonly toastController = inject(ToastController);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
@@ -760,7 +758,7 @@ export class ListPageComponent {
   }
 
   async pickRandomGameFromPopover(): Promise<void> {
-    await this.closeHeaderActionsPopover();
+    this.closeHeaderActionsPopover();
 
     if (this.displayedGames.length === 0) {
       await this.presentToast('No games available in current results.', 'warning');
@@ -773,17 +771,17 @@ export class ListPageComponent {
   }
 
   async openSettingsFromPopover(): Promise<void> {
-    await this.closeHeaderActionsPopover();
+    this.closeHeaderActionsPopover();
     await this.router.navigateByUrl('/settings');
   }
 
   async openTagsFromPopover(): Promise<void> {
-    await this.closeHeaderActionsPopover();
+    this.closeHeaderActionsPopover();
     await this.router.navigateByUrl('/tags');
   }
 
   async openViewsFromPopover(): Promise<void> {
-    await this.closeHeaderActionsPopover();
+    this.closeHeaderActionsPopover();
     await this.router.navigate(['/views'], {
       state: {
         listType: this.listType,
@@ -797,8 +795,8 @@ export class ListPageComponent {
     return buildDetailWebsiteSearchUrl(this.selectedAddGameDetail?.title, provider);
   }
 
-  async activateMultiSelectFromPopover(): Promise<void> {
-    await this.closeHeaderActionsPopover();
+  activateMultiSelectFromPopover(): void {
+    this.closeHeaderActionsPopover();
     this.gameListComponent?.activateSelectionMode();
   }
 
@@ -1066,10 +1064,9 @@ export class ListPageComponent {
     this.bulkActionsPopoverEvent = undefined;
   }
 
-  async closeHeaderActionsPopover(): Promise<void> {
+  closeHeaderActionsPopover(): void {
     this.isHeaderActionsPopoverOpen = false;
     this.headerActionsPopoverEvent = undefined;
-    await this.popoverController.dismiss().catch(() => undefined);
   }
 
   onGroupByChange(value: GameGroupByField | null | undefined): void {


### PR DESCRIPTION
## Summary

- Removed `PopoverController.dismiss()` calls from `closeHeaderActionsPopover()` in both `ExplorePage` and `ListPageComponent`
- Both methods are now synchronous; they update component state only (`isHeaderActionsPopoverOpen`, `headerActionsPopoverEvent`)
- `PopoverController` injection removed entirely from both components — the Ionic popover dismisses itself via its `(didDismiss)` template binding
- `activateMultiSelectFromPopover()` in `ListPageComponent` made synchronous (no async work required)

## Implementation details

Previously, `closeHeaderActionsPopover()` awaited `popoverController.dismiss()`, which on iOS could block and cause downstream navigation calls to hang. The Ionic `<ion-popover>` component handles its own teardown when `isHeaderActionsPopoverOpen` is set to `false` via the `[isOpen]` binding, so the programmatic `dismiss()` call was redundant and harmful.

Tests updated to assert the synchronous contract and to verify that component state is cleared before navigation executes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing performed

- `npm run lint` — passed (0 errors)
- `npm run test` — 1444/1444 tests passed
- `npm run build` — build succeeded
- Updated specs assert synchronous state clearing and correct navigation ordering
