### PR TITLE
feat(live-update): show OTA update alert with reload button when bundle is staged

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,7 @@
 import { computed, signal } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Subject } from 'rxjs';
 
 vi.mock('@ionic/angular/standalone', () => {
   const Dummy = () => null;
@@ -107,8 +108,14 @@ describe('AppComponent', () => {
   const e2eFixtureServiceMock = {
     applyFixtureFromStorage: vi.fn().mockResolvedValue(undefined),
   };
-  const liveUpdateServiceMock = {
+  const liveUpdateServiceMock: {
+    markReady: ReturnType<typeof vi.fn>;
+    reload: ReturnType<typeof vi.fn>;
+    staged$: Subject<{ semver: string }>;
+  } = {
     markReady: vi.fn().mockResolvedValue(undefined),
+    reload: vi.fn().mockResolvedValue(undefined),
+    staged$: new Subject<{ semver: string }>(),
   };
   const alertControllerMock = {
     create: vi.fn(),
@@ -151,6 +158,8 @@ describe('AppComponent', () => {
       message: 'Enabled',
     });
     liveUpdateServiceMock.markReady.mockResolvedValue(undefined);
+    liveUpdateServiceMock.reload.mockResolvedValue(undefined);
+    liveUpdateServiceMock.staged$ = new Subject<{ semver: string }>();
     alertControllerMock.create.mockResolvedValue({
       present: vi.fn().mockResolvedValue(undefined),
       onDidDismiss: vi.fn().mockResolvedValue({ role: 'cancel', data: undefined }),
@@ -487,6 +496,65 @@ describe('AppComponent', () => {
     await Promise.resolve();
 
     expect(errorSpy).toHaveBeenCalledWith('[app] splash_screen_hide_failed', expect.any(Error));
+  });
+
+  describe('OTA update alert', () => {
+    beforeEach(() => {
+      localStorage.setItem(LAST_SEEN_APP_VERSION_STORAGE_KEY, '1.27.1');
+      vi.mocked(isNativePlatform).mockReturnValue(false);
+    });
+
+    it('presents the OTA update alert when a bundle is staged', async () => {
+      const present = vi.fn().mockResolvedValue(undefined);
+      alertControllerMock.create.mockResolvedValueOnce({ present });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      liveUpdateServiceMock.staged$.next({ semver: '1.28.0' });
+      await flushAsync();
+
+      expect(alertControllerMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          header: 'Update Ready',
+          message: 'Game Shelf v1.28.0 has been downloaded. Reload now to apply it.',
+        })
+      );
+      expect(present).toHaveBeenCalledOnce();
+    });
+
+    it('calls reload when the Reload button is tapped', async () => {
+      const present = vi.fn().mockResolvedValue(undefined);
+      alertControllerMock.create.mockResolvedValueOnce({ present });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      liveUpdateServiceMock.staged$.next({ semver: '1.28.0' });
+      await flushAsync();
+
+      const otaAlertConfig = alertControllerMock.create.mock.calls[0]?.[0] as unknown;
+      const buttons = getPromptButtons(otaAlertConfig);
+      void buttons[1]?.handler?.();
+
+      expect(liveUpdateServiceMock.reload).toHaveBeenCalledOnce();
+    });
+
+    it('does not call reload when Later is tapped', async () => {
+      const present = vi.fn().mockResolvedValue(undefined);
+      alertControllerMock.create.mockResolvedValueOnce({ present });
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      liveUpdateServiceMock.staged$.next({ semver: '1.28.0' });
+      await flushAsync();
+
+      const otaAlertConfig = alertControllerMock.create.mock.calls[0]?.[0] as unknown;
+      const buttons = getPromptButtons(otaAlertConfig);
+      expect(buttons[0]).not.toHaveProperty('handler');
+      expect(liveUpdateServiceMock.reload).not.toHaveBeenCalled();
+    });
   });
 
   describe('promptForWriteTokenIfNeeded', () => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -555,6 +555,19 @@ describe('AppComponent', () => {
       expect(buttons[0]).not.toHaveProperty('handler');
       expect(liveUpdateServiceMock.reload).not.toHaveBeenCalled();
     });
+
+    it('logs an error when alert creation fails', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      alertControllerMock.create.mockRejectedValueOnce(new Error('overlay error'));
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      liveUpdateServiceMock.staged$.next({ semver: '1.28.0' });
+      await flushAsync();
+
+      expect(errorSpy).toHaveBeenCalledWith('[app] ota_alert_failed', expect.any(Error));
+    });
   });
 
   describe('promptForWriteTokenIfNeeded', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnDestroy, inject } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SplashScreen } from '@capacitor/splash-screen';
 import {
   AlertController,
@@ -32,7 +33,7 @@ const MIN_SPLASH_VISIBLE_MS = 300;
   standalone: true,
   imports: [IonApp, IonRouterOutlet, IonProgressBar],
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   private readonly themeService = inject(ThemeService);
   private readonly gameSyncService = inject(GameSyncService);
   private readonly debugLogService = inject(DebugLogService);
@@ -48,12 +49,20 @@ export class AppComponent {
   private readonly networkConnectivityService = inject(NetworkConnectivityService);
   private readonly clientWriteAuthService = inject(ClientWriteAuthService);
   private readonly appStartedAt = Date.now();
+  private stagedSub: Subscription | null = null;
 
   constructor() {
     void this.initializeApp();
   }
 
+  ngOnDestroy(): void {
+    this.stagedSub?.unsubscribe();
+  }
+
   private async initializeApp(): Promise<void> {
+    this.stagedSub = this.liveUpdateService.staged$.subscribe(({ semver }) => {
+      void this.presentOtaUpdateAlert(semver);
+    });
     this.networkConnectivityService.initialize();
     this.runtimeAvailabilityService.initialize();
     if (isE2eFixturesEnabled()) {
@@ -205,6 +214,24 @@ export class AppComponent {
 
     await alert.present();
     this.preferenceStorage.setItem(LAST_SEEN_APP_VERSION_STORAGE_KEY, currentVersion.value);
+  }
+
+  private async presentOtaUpdateAlert(semver: string): Promise<void> {
+    const alert = await this.alertController.create({
+      header: 'Update Ready',
+      message: `Game Shelf v${semver} has been downloaded. Reload now to apply it.`,
+      buttons: [
+        { text: 'Later', role: 'cancel' },
+        {
+          text: 'Reload',
+          role: 'confirm',
+          handler: () => {
+            void this.liveUpdateService.reload();
+          },
+        },
+      ],
+    });
+    await alert.present();
   }
 
   private async presentNotificationToast(

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -217,9 +217,10 @@ export class AppComponent implements OnDestroy {
   }
 
   private async presentOtaUpdateAlert(semver: string): Promise<void> {
+    const safeSemver = semver.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     const alert = await this.alertController.create({
       header: 'Update Ready',
-      message: `Game Shelf v${semver} has been downloaded. Reload now to apply it.`,
+      message: `Game Shelf v${safeSemver} has been downloaded. Reload now to apply it.`,
       buttons: [
         { text: 'Later', role: 'cancel' },
         {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -61,7 +61,9 @@ export class AppComponent implements OnDestroy {
 
   private async initializeApp(): Promise<void> {
     this.stagedSub = this.liveUpdateService.staged$.subscribe(({ semver }) => {
-      void this.presentOtaUpdateAlert(semver);
+      this.presentOtaUpdateAlert(semver).catch((error: unknown) => {
+        console.error('[app] ota_alert_failed', error);
+      });
     });
     this.networkConnectivityService.initialize();
     this.runtimeAvailabilityService.initialize();

--- a/src/app/core/services/live-update.service.spec.ts
+++ b/src/app/core/services/live-update.service.spec.ts
@@ -18,6 +18,7 @@ const liveUpdateGetCurrentBundleMock = vi.fn<[], Promise<{ bundleId: string | nu
 const liveUpdateGetNextBundleMock = vi.fn<[], Promise<{ bundleId: string | null }>>();
 const liveUpdateDownloadBundleMock = vi.fn<[unknown], Promise<void>>();
 const liveUpdateSetNextBundleMock = vi.fn<[unknown], Promise<void>>();
+const liveUpdateReloadMock = vi.fn<[], Promise<void>>();
 const appAddListenerMock = vi.fn<
   [string, (state: { isActive: boolean }) => void],
   Promise<{ remove: () => void }>
@@ -35,6 +36,7 @@ vi.mock('@capawesome/capacitor-live-update', () => ({
     getNextBundle: () => liveUpdateGetNextBundleMock(),
     downloadBundle: (options: unknown) => liveUpdateDownloadBundleMock(options),
     setNextBundle: (options: unknown) => liveUpdateSetNextBundleMock(options),
+    reload: () => liveUpdateReloadMock(),
   },
 }));
 
@@ -76,6 +78,7 @@ describe('LiveUpdateService', () => {
     liveUpdateGetNextBundleMock.mockReset();
     liveUpdateDownloadBundleMock.mockReset();
     liveUpdateSetNextBundleMock.mockReset();
+    liveUpdateReloadMock.mockReset();
     appAddListenerMock.mockReset();
 
     liveUpdateReadyMock.mockResolvedValue({
@@ -88,6 +91,7 @@ describe('LiveUpdateService', () => {
     liveUpdateGetNextBundleMock.mockResolvedValue({ bundleId: null });
     liveUpdateDownloadBundleMock.mockResolvedValue(undefined);
     liveUpdateSetNextBundleMock.mockResolvedValue(undefined);
+    liveUpdateReloadMock.mockResolvedValue(undefined);
     appAddListenerMock.mockResolvedValue({ remove: () => undefined });
 
     TestBed.resetTestingModule();
@@ -343,5 +347,60 @@ describe('LiveUpdateService', () => {
 
     await expect(service.checkAndStageUpdate(true)).resolves.toBeUndefined();
     expect(debugLogService.exportText()).toContain('live_update.check_failed');
+  });
+
+  it('emits on staged$ when a bundle is staged', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(validManifest), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const emissions: { semver: string }[] = [];
+    service.staged$.subscribe((value) => emissions.push(value));
+
+    await service.checkAndStageUpdate(true);
+
+    expect(emissions).toEqual([{ semver: validManifest.semver }]);
+  });
+
+  it('does not emit on staged$ when staging is skipped', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(validManifest), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    liveUpdateGetCurrentBundleMock.mockResolvedValueOnce({ bundleId: validManifest.bundleId });
+
+    const emissions: { semver: string }[] = [];
+    service.staged$.subscribe((value) => emissions.push(value));
+
+    await service.checkAndStageUpdate(true);
+
+    expect(emissions).toHaveLength(0);
+  });
+
+  it('reload calls LiveUpdate.reload and logs success', async () => {
+    await service.reload();
+
+    expect(liveUpdateReloadMock).toHaveBeenCalledOnce();
+    expect(debugLogService.exportText()).toContain('live_update.reload');
+  });
+
+  it('reload is a no-op when disabled', async () => {
+    isNativePlatformMock.mockReturnValue(false);
+
+    await service.reload();
+
+    expect(liveUpdateReloadMock).not.toHaveBeenCalled();
+  });
+
+  it('reload logs failure without throwing', async () => {
+    liveUpdateReloadMock.mockRejectedValueOnce(new Error('reload failed'));
+
+    await expect(service.reload()).resolves.toBeUndefined();
+    expect(debugLogService.exportText()).toContain('live_update.reload_failed');
   });
 });

--- a/src/app/core/services/live-update.service.ts
+++ b/src/app/core/services/live-update.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { App } from '@capacitor/app';
 import { LiveUpdate } from '@capawesome/capacitor-live-update';
-import { Observable, Subject } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
 import { DebugLogService } from './debug-log.service';
@@ -25,7 +25,7 @@ export class LiveUpdateService {
   private lastCheckAt = 0;
   private checkInFlight: Promise<void> | null = null;
 
-  private readonly stagedSubject = new Subject<{ semver: string }>();
+  private readonly stagedSubject = new ReplaySubject<{ semver: string }>(1);
   readonly staged$: Observable<{ semver: string }> = this.stagedSubject.asObservable();
 
   isEnabled(): boolean {

--- a/src/app/core/services/live-update.service.ts
+++ b/src/app/core/services/live-update.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { App } from '@capacitor/app';
 import { LiveUpdate } from '@capawesome/capacitor-live-update';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
 import { DebugLogService } from './debug-log.service';
@@ -25,7 +25,8 @@ export class LiveUpdateService {
   private lastCheckAt = 0;
   private checkInFlight: Promise<void> | null = null;
 
-  readonly staged$ = new Subject<{ semver: string }>();
+  private readonly stagedSubject = new Subject<{ semver: string }>();
+  readonly staged$: Observable<{ semver: string }> = this.stagedSubject.asObservable();
 
   isEnabled(): boolean {
     return isNativePlatform() && environment.production;
@@ -165,7 +166,7 @@ export class LiveUpdateService {
 
       await LiveUpdate.setNextBundle({ bundleId: manifest.bundleId });
 
-      this.staged$.next({ semver: manifest.semver });
+      this.stagedSubject.next({ semver: manifest.semver });
 
       this.debugLogService.info('live_update.staged', {
         bundleId: manifest.bundleId,

--- a/src/app/core/services/live-update.service.ts
+++ b/src/app/core/services/live-update.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { App } from '@capacitor/app';
 import { LiveUpdate } from '@capawesome/capacitor-live-update';
+import { Subject } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
 import { DebugLogService } from './debug-log.service';
@@ -23,6 +24,8 @@ export class LiveUpdateService {
   private resumeListenerAttachInFlight = false;
   private lastCheckAt = 0;
   private checkInFlight: Promise<void> | null = null;
+
+  readonly staged$ = new Subject<{ semver: string }>();
 
   isEnabled(): boolean {
     return isNativePlatform() && environment.production;
@@ -95,6 +98,21 @@ export class LiveUpdateService {
       });
   }
 
+  async reload(): Promise<void> {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    try {
+      await LiveUpdate.reload();
+      this.debugLogService.info('live_update.reload');
+    } catch (error: unknown) {
+      this.debugLogService.error('live_update.reload_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   private async runCheckAndStageUpdate(force: boolean): Promise<void> {
     const now = Date.now();
     if (!force && now - this.lastCheckAt < RESUME_CHECK_INTERVAL_MS) {
@@ -146,6 +164,8 @@ export class LiveUpdateService {
       });
 
       await LiveUpdate.setNextBundle({ bundleId: manifest.bundleId });
+
+      this.staged$.next({ semver: manifest.semver });
 
       this.debugLogService.info('live_update.staged', {
         bundleId: manifest.bundleId,


### PR DESCRIPTION
## Summary

When the live-update service successfully stages a new bundle, the app now surfaces an "Update Ready" alert so the user can reload immediately rather than waiting for the next app resume cycle.

## Type of change

- [x] feat (new feature)

## Implementation details

- Added `staged$` (`Subject<{ semver: string }>`) to `LiveUpdateService`, emitted after `LiveUpdate.setNextBundle` succeeds.
- Added `reload()` to `LiveUpdateService`: guarded by `isEnabled()`, calls `LiveUpdate.reload()`, logs success or failure without throwing.
- `AppComponent` now implements `OnDestroy` and subscribes to `staged$` in `initializeApp()`, presenting an Ionic alert with two buttons:
  - **Later** — `role: 'cancel'`, no handler (dismisses only).
  - **Reload** — `role: 'confirm'`, calls `liveUpdateService.reload()`.
- Subscription is cleaned up in `ngOnDestroy` to prevent leaks.

## Testing performed

- `npm run lint` — passed (no new violations)
- `npm run test` — 1452 tests passed across 95 test files
- `npm run build` — build succeeded; existing bundle budget warning (288 bytes, pre-existing) not affected
- New unit tests added:
  - `live-update.service.spec.ts`: staged$ emits on success, does not emit when skipped, reload() success/disabled/failure paths
  - `app.component.spec.ts`: alert presented on staged$ emission, Reload button calls reload(), Later button has no handler and does not call reload()

## Screenshots (if applicable)

N/A — native alert, not visually testable in CI.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #