### PR TITLE
refactor(logging): migrate console calls to DebugLogService across storage and notification layers

### DIFF
--- a/src/app/core/data/image-file-store.spec.ts
+++ b/src/app/core/data/image-file-store.spec.ts
@@ -1,0 +1,151 @@
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const statMock = vi.fn<() => Promise<unknown>>();
+const getUriMock = vi.fn<() => Promise<{ uri: string }>>();
+const writeFileMock = vi.fn<() => Promise<void>>();
+const deleteFileMock = vi.fn<() => Promise<void>>();
+const rmdirMock = vi.fn<() => Promise<void>>();
+const convertFileSrcMock = vi.fn<(path: string) => string>();
+
+vi.mock('@capacitor/filesystem', () => ({
+  Directory: { Cache: 'CACHE' },
+  Filesystem: {
+    stat: (...args: unknown[]) => statMock(...args),
+    getUri: (...args: unknown[]) => getUriMock(...args),
+    writeFile: (...args: unknown[]) => writeFileMock(...args),
+    deleteFile: (...args: unknown[]) => deleteFileMock(...args),
+    rmdir: (...args: unknown[]) => rmdirMock(...args),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    convertFileSrc: (path: string) => convertFileSrcMock(path),
+  },
+}));
+
+import { ImageFileStore } from './image-file-store';
+import { DebugLogService } from '../services/debug-log.service';
+
+function makeDebugLogStub(): DebugLogService {
+  return {
+    trace: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as DebugLogService;
+}
+
+describe('ImageFileStore', () => {
+  let store: ImageFileStore;
+  let debugLog: DebugLogService;
+
+  beforeEach(() => {
+    debugLog = makeDebugLogStub();
+    TestBed.configureTestingModule({
+      providers: [ImageFileStore, { provide: DebugLogService, useValue: debugLog }],
+    });
+    store = TestBed.inject(ImageFileStore);
+    writeFileMock.mockResolvedValue(undefined);
+    deleteFileMock.mockResolvedValue(undefined);
+    rmdirMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  describe('writeImage', () => {
+    it('writes hashed file and returns filePath and sizeBytes', async () => {
+      const traceSpy = vi.spyOn(debugLog, 'trace');
+      const blob = new Blob(['fake-image-data'], { type: 'image/png' });
+
+      const result = await store.writeImage('test-cache-key', blob);
+
+      expect(writeFileMock).toHaveBeenCalledWith(expect.objectContaining({ recursive: true }));
+      expect(result.sizeBytes).toBe(blob.size);
+      expect(result.filePath).toMatch(/^image-cache\//);
+      expect(traceSpy).toHaveBeenCalledWith(
+        'image_store.write',
+        expect.objectContaining({ sizeBytes: blob.size })
+      );
+      expect(traceSpy).toHaveBeenCalledWith('image_store.write_complete', expect.any(Object));
+    });
+  });
+
+  describe('getDisplayUrl', () => {
+    it('returns null and traces file_missing when stat throws', async () => {
+      const traceSpy = vi.spyOn(debugLog, 'trace');
+      statMock.mockRejectedValue(new Error('not found'));
+
+      const result = await store.getDisplayUrl('image-cache/abc');
+
+      expect(result).toBeNull();
+      expect(traceSpy).toHaveBeenCalledWith(
+        'image_store.file_missing',
+        expect.objectContaining({ filePath: 'image-cache/abc' })
+      );
+    });
+
+    it('returns display URL when file exists', async () => {
+      const traceSpy = vi.spyOn(debugLog, 'trace');
+      statMock.mockResolvedValue({});
+      getUriMock.mockResolvedValue({ uri: 'file:///var/cache/image-cache/abc' });
+      convertFileSrcMock.mockReturnValue('capacitor://localhost/image-cache/abc');
+
+      const result = await store.getDisplayUrl('image-cache/abc');
+
+      expect(result).toBe('capacitor://localhost/image-cache/abc');
+      expect(traceSpy).toHaveBeenCalledWith(
+        'image_store.display_url_resolved',
+        expect.objectContaining({ filePath: 'image-cache/abc' })
+      );
+    });
+  });
+
+  describe('deleteImage', () => {
+    it('traces deleted on success', async () => {
+      const traceSpy = vi.spyOn(debugLog, 'trace');
+
+      await store.deleteImage('image-cache/abc');
+
+      expect(deleteFileMock).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'image-cache/abc' })
+      );
+      expect(traceSpy).toHaveBeenCalledWith(
+        'image_store.deleted',
+        expect.objectContaining({ filePath: 'image-cache/abc' })
+      );
+    });
+
+    it('traces delete_failed without throwing when delete errors', async () => {
+      const traceSpy = vi.spyOn(debugLog, 'trace');
+      deleteFileMock.mockRejectedValue(new Error('evicted'));
+
+      await expect(store.deleteImage('image-cache/abc')).resolves.toBeUndefined();
+      expect(traceSpy).toHaveBeenCalledWith(
+        'image_store.delete_failed',
+        expect.objectContaining({ filePath: 'image-cache/abc', error: 'evicted' })
+      );
+    });
+  });
+
+  describe('clear', () => {
+    it('traces cache_dir_cleared on success', async () => {
+      const traceSpy = vi.spyOn(debugLog, 'trace');
+
+      await store.clear();
+
+      expect(rmdirMock).toHaveBeenCalledWith(expect.objectContaining({ recursive: true }));
+      expect(traceSpy).toHaveBeenCalledWith('image_store.cache_dir_cleared');
+    });
+
+    it('silently swallows rmdir errors', async () => {
+      rmdirMock.mockRejectedValue(new Error('dir not found'));
+
+      await expect(store.clear()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/app/core/data/image-file-store.ts
+++ b/src/app/core/data/image-file-store.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
 import { Directory, Filesystem } from '@capacitor/filesystem';
+import { DebugLogService } from '../services/debug-log.service';
 
 const IMAGE_CACHE_DIR = 'image-cache';
 
@@ -14,9 +15,13 @@ const IMAGE_CACHE_DIR = 'image-cache';
  */
 @Injectable({ providedIn: 'root' })
 export class ImageFileStore {
+  private readonly debugLogService = inject(DebugLogService);
+
   async writeImage(cacheKey: string, blob: Blob): Promise<{ filePath: string; sizeBytes: number }> {
     const filePath = `${IMAGE_CACHE_DIR}/${await this.hashCacheKey(cacheKey)}`;
     const data = await this.blobToBase64(blob);
+
+    this.debugLogService.trace('image_store.write', { filePath, sizeBytes: blob.size });
 
     await Filesystem.writeFile({
       path: filePath,
@@ -24,6 +29,8 @@ export class ImageFileStore {
       directory: Directory.Cache,
       recursive: true,
     });
+
+    this.debugLogService.trace('image_store.write_complete', { filePath });
 
     return { filePath, sizeBytes: blob.size };
   }
@@ -33,28 +40,37 @@ export class ImageFileStore {
     try {
       await Filesystem.stat({ path: filePath, directory: Directory.Cache });
     } catch {
+      this.debugLogService.trace('image_store.file_missing', { filePath });
       return null;
     }
 
     const { uri } = await Filesystem.getUri({ path: filePath, directory: Directory.Cache });
-    return Capacitor.convertFileSrc(uri);
+    const displayUrl = Capacitor.convertFileSrc(uri);
+    this.debugLogService.trace('image_store.display_url_resolved', { filePath, displayUrl });
+    return displayUrl;
   }
 
   async deleteImage(filePath: string): Promise<void> {
     try {
       await Filesystem.deleteFile({ path: filePath, directory: Directory.Cache });
-    } catch {
-      // Already gone (e.g. evicted by the OS) — nothing to clean up.
+      this.debugLogService.trace('image_store.deleted', { filePath });
+    } catch (error: unknown) {
+      this.debugLogService.warn('image_store.delete_failed', {
+        filePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
   async clear(): Promise<void> {
+    this.debugLogService.trace('image_store.clearing_cache_dir');
     try {
       await Filesystem.rmdir({
         path: IMAGE_CACHE_DIR,
         directory: Directory.Cache,
         recursive: true,
       });
+      this.debugLogService.trace('image_store.cache_dir_cleared');
     } catch {
       // Directory may not exist yet.
     }

--- a/src/app/core/data/image-file-store.ts
+++ b/src/app/core/data/image-file-store.ts
@@ -55,7 +55,7 @@ export class ImageFileStore {
       await Filesystem.deleteFile({ path: filePath, directory: Directory.Cache });
       this.debugLogService.trace('image_store.deleted', { filePath });
     } catch (error: unknown) {
-      this.debugLogService.warn('image_store.delete_failed', {
+      this.debugLogService.trace('image_store.delete_failed', {
         filePath,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/app/core/data/image-file-store.ts
+++ b/src/app/core/data/image-file-store.ts
@@ -46,7 +46,7 @@ export class ImageFileStore {
 
     const { uri } = await Filesystem.getUri({ path: filePath, directory: Directory.Cache });
     const displayUrl = Capacitor.convertFileSrc(uri);
-    this.debugLogService.trace('image_store.display_url_resolved', { filePath, displayUrl });
+    this.debugLogService.trace('image_store.display_url_resolved', { filePath });
     return displayUrl;
   }
 

--- a/src/app/core/data/sqlite-connection.ts
+++ b/src/app/core/data/sqlite-connection.ts
@@ -1,4 +1,5 @@
 import { CapacitorSQLite, SQLiteConnection, SQLiteDBConnection } from '@capacitor-community/sqlite';
+import type { DebugLogService } from '../services/debug-log.service';
 
 export interface SqliteStatement {
   statement: string;
@@ -136,7 +137,9 @@ class CapacitorSqliteConnection implements SqliteConnection {
  * Opens (and migrates) the native SQLite database via the Capacitor plugin.
  * Only call on native platforms.
  */
-export async function openCapacitorSqliteConnection(): Promise<SqliteConnection> {
+export async function openCapacitorSqliteConnection(
+  debugLogService?: DebugLogService | null
+): Promise<SqliteConnection> {
   const sqlite = new SQLiteConnection(CapacitorSQLite);
 
   await sqlite.addUpgradeStatement(SQLITE_DB_NAME, SQLITE_UPGRADE_STATEMENTS);
@@ -144,18 +147,36 @@ export async function openCapacitorSqliteConnection(): Promise<SqliteConnection>
   const consistency = await sqlite.checkConnectionsConsistency();
   const isConnected = (await sqlite.isConnection(SQLITE_DB_NAME, false)).result ?? false;
 
-  const db =
-    consistency.result && isConnected
-      ? await sqlite.retrieveConnection(SQLITE_DB_NAME, false)
-      : await sqlite.createConnection(
-          SQLITE_DB_NAME,
-          false,
-          'no-encryption',
-          SQLITE_SCHEMA_VERSION,
-          false
-        );
+  debugLogService?.trace('sqlite.connection.consistency_check', {
+    consistent: consistency.result,
+    isConnected,
+    dbName: SQLITE_DB_NAME,
+  });
 
+  let db: SQLiteDBConnection;
+
+  if (consistency.result && isConnected) {
+    debugLogService?.trace('sqlite.connection.retrieving_existing');
+    db = await sqlite.retrieveConnection(SQLITE_DB_NAME, false);
+  } else {
+    debugLogService?.trace('sqlite.connection.creating_new', {
+      schemaVersion: SQLITE_SCHEMA_VERSION,
+    });
+    db = await sqlite.createConnection(
+      SQLITE_DB_NAME,
+      false,
+      'no-encryption',
+      SQLITE_SCHEMA_VERSION,
+      false
+    );
+  }
+
+  debugLogService?.trace('sqlite.connection.opening_db');
   await db.open();
+  debugLogService?.trace('sqlite.connection.ready', {
+    dbName: SQLITE_DB_NAME,
+    schemaVersion: SQLITE_SCHEMA_VERSION,
+  });
 
   return new CapacitorSqliteConnection(sqlite, db, SQLITE_DB_NAME);
 }

--- a/src/app/core/data/sqlite-storage-engine.spec.ts
+++ b/src/app/core/data/sqlite-storage-engine.spec.ts
@@ -5,7 +5,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { SQLITE_UPGRADE_STATEMENTS } from './sqlite-connection';
 import type { SqliteConnection, SqliteRunResult, SqliteStatement } from './sqlite-connection';
 import { SqliteStorageEngine } from './sqlite-storage-engine';
-import { describeStorageEngineContract, makeContractTag } from './storage-engine.contract';
+import {
+  describeStorageEngineContract,
+  makeContractGame,
+  makeContractImageCacheRecord,
+  makeContractTag,
+  makeContractView,
+} from './storage-engine.contract';
 import { isStorageConstraintError } from './storage-engine';
 import type { DebugLogService } from '../services/debug-log.service';
 
@@ -211,5 +217,118 @@ describe('SqliteStorageEngine transaction logging', () => {
     );
 
     await connection.close();
+  });
+});
+
+describe('SqliteStorageEngine coverage gaps', () => {
+  it('countGames returns 0 on empty store and the correct count after inserts', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+
+    expect(await engine.countGames()).toBe(0);
+
+    await engine.addGame(makeContractGame());
+    await engine.addGame(makeContractGame({ igdbGameId: '202', platformIgdbId: 20 }));
+
+    expect(await engine.countGames()).toBe(2);
+    await connection.close();
+  });
+
+  it('putGame inserts when id is undefined', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+
+    const id = await engine.putGame(makeContractGame());
+
+    expect(typeof id).toBe('number');
+    expect(await engine.getGameById(id)).toBeDefined();
+    await connection.close();
+  });
+
+  it('updateGame is a no-op when the game does not exist', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+
+    await expect(engine.updateGame(9999, { title: 'Ghost' })).resolves.toBeUndefined();
+    await connection.close();
+  });
+
+  it('putTag inserts when id is undefined', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+
+    const id = await engine.putTag(makeContractTag());
+
+    expect(typeof id).toBe('number');
+    expect(await engine.getTag(id)).toBeDefined();
+    await connection.close();
+  });
+
+  it('putView inserts when id is undefined', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+
+    const id = await engine.putView(makeContractView());
+
+    expect(typeof id).toBe('number');
+    expect(await engine.getView(id)).toBeDefined();
+    await connection.close();
+  });
+
+  it('putImageCache updates an existing record by id', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+    const record = makeContractImageCacheRecord();
+
+    const id = await engine.putImageCache(record);
+    const updated = { ...record, id, sizeBytes: 2048 };
+    const returnedId = await engine.putImageCache(updated);
+
+    expect(returnedId).toBe(id);
+    await connection.close();
+  });
+
+  it('updateImageCacheLastAccessedAt is a no-op when record does not exist', async () => {
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection);
+
+    await expect(
+      engine.updateImageCacheLastAccessedAt(9999, '2026-06-01T00:00:00.000Z')
+    ).resolves.toBeUndefined();
+    await connection.close();
+  });
+
+  it('propagates non-Error throws from connection as wrapped errors', async () => {
+    const mockRun = vi.fn().mockRejectedValue('sqlite: table locked');
+    const connection = {
+      run: mockRun,
+      query: vi.fn().mockResolvedValue([]),
+      executeSet: vi.fn().mockResolvedValue(undefined),
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commitTransaction: vi.fn().mockResolvedValue(undefined),
+      rollbackTransaction: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SqliteConnection;
+    const engine = new SqliteStorageEngine(connection);
+
+    await expect(engine.addGame(makeContractGame())).rejects.toThrow('sqlite: table locked');
+  });
+
+  it('requireLastId throws when insert returns no lastId', async () => {
+    const mockRun = vi.fn().mockResolvedValue({ changes: 1, lastId: undefined });
+    const connection = {
+      run: mockRun,
+      query: vi.fn().mockResolvedValue([]),
+      executeSet: vi.fn().mockResolvedValue(undefined),
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commitTransaction: vi.fn().mockResolvedValue(undefined),
+      rollbackTransaction: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SqliteConnection;
+    const engine = new SqliteStorageEngine(connection);
+
+    await expect(engine.addGame(makeContractGame())).rejects.toThrow(
+      'SQLite insert did not return a generated id.'
+    );
   });
 });

--- a/src/app/core/data/sqlite-storage-engine.spec.ts
+++ b/src/app/core/data/sqlite-storage-engine.spec.ts
@@ -7,6 +7,7 @@ import type { SqliteConnection, SqliteRunResult, SqliteStatement } from './sqlit
 import { SqliteStorageEngine } from './sqlite-storage-engine';
 import { describeStorageEngineContract, makeContractTag } from './storage-engine.contract';
 import { isStorageConstraintError } from './storage-engine';
+import type { DebugLogService } from '../services/debug-log.service';
 
 vi.mock('./storage-transaction-context', () => import('./storage-transaction-context.node'));
 
@@ -143,6 +144,71 @@ describe('SqliteStorageEngine schema', () => {
     await expect(
       engine.addTag(makeContractTag({ name: 'backlog', color: '#ff0000' }))
     ).rejects.toSatisfy((error: unknown) => isStorageConstraintError(error));
+
+    await connection.close();
+  });
+});
+
+describe('SqliteStorageEngine transaction logging', () => {
+  it('traces begin and committed when a transaction succeeds', async () => {
+    const traceSpy = vi.fn();
+    const debugLog = {
+      trace: traceSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as DebugLogService;
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection, debugLog);
+
+    await engine.runInTransaction(['games'], () => Promise.resolve());
+
+    expect(traceSpy).toHaveBeenCalledWith('sqlite.transaction.begin', expect.any(Object));
+    expect(traceSpy).toHaveBeenCalledWith('sqlite.transaction.committed');
+
+    await connection.close();
+  });
+
+  it('traces rolled_back when the action throws', async () => {
+    const traceSpy = vi.fn();
+    const debugLog = {
+      trace: traceSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as DebugLogService;
+    const connection = await InProcessSqliteConnection.create();
+    const engine = new SqliteStorageEngine(connection, debugLog);
+
+    await expect(
+      engine.runInTransaction(['games'], () => Promise.reject(new Error('action failed')))
+    ).rejects.toThrow('action failed');
+
+    expect(traceSpy).toHaveBeenCalledWith('sqlite.transaction.rolled_back');
+
+    await connection.close();
+  });
+
+  it('warns when rollback itself fails after an action error', async () => {
+    const warnSpy = vi.fn();
+    const debugLog = {
+      trace: vi.fn(),
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+    } as unknown as DebugLogService;
+    const connection = await InProcessSqliteConnection.create();
+    vi.spyOn(connection, 'rollbackTransaction').mockRejectedValueOnce(new Error('rollback failed'));
+    const engine = new SqliteStorageEngine(connection, debugLog);
+
+    await expect(
+      engine.runInTransaction(['games'], () => Promise.reject(new Error('action failed')))
+    ).rejects.toThrow('action failed');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'sqlite.transaction.rollback_failed',
+      expect.objectContaining({ error: 'rollback failed' })
+    );
 
     await connection.close();
   });

--- a/src/app/core/data/sqlite-storage-engine.ts
+++ b/src/app/core/data/sqlite-storage-engine.ts
@@ -1,5 +1,6 @@
 import { GameEntry, GameListView, ListType, SyncEntityType, Tag } from '../models/game.models';
 import { OutboxEntry, SyncMetaEntry } from './app-db';
+import type { DebugLogService } from '../services/debug-log.service';
 import { SqliteConnection, SqliteStatement } from './sqlite-connection';
 import { ImageCacheRecord, StorageEngine, StorageScope } from './storage-engine';
 import {
@@ -41,7 +42,10 @@ function toConstraintError(error: unknown): Error {
 export class SqliteStorageEngine implements StorageEngine {
   private transactionQueue: Promise<unknown> = Promise.resolve();
 
-  constructor(private readonly connection: SqliteConnection) {}
+  constructor(
+    private readonly connection: SqliteConnection,
+    private readonly debugLogService?: DebugLogService | null
+  ) {}
 
   initialize(): Promise<void> {
     // The connection factory opens and migrates the database before the
@@ -61,17 +65,22 @@ export class SqliteStorageEngine implements StorageEngine {
 
     const run = async (): Promise<T> =>
       runInsideStorageTransactionZone(async () => {
+        this.debugLogService?.trace('sqlite.transaction.begin', { scope: _scope });
         await this.connection.beginTransaction();
 
         try {
           const result = await action();
           await this.connection.commitTransaction();
+          this.debugLogService?.trace('sqlite.transaction.committed');
           return result;
         } catch (error: unknown) {
           try {
             await this.connection.rollbackTransaction();
-          } catch {
-            // Surface the original failure even if rollback also fails.
+            this.debugLogService?.trace('sqlite.transaction.rolled_back');
+          } catch (rollbackError: unknown) {
+            this.debugLogService?.warn('sqlite.transaction.rollback_failed', {
+              error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+            });
           }
           throw error;
         }

--- a/src/app/core/data/sqlite-storage-engine.ts
+++ b/src/app/core/data/sqlite-storage-engine.ts
@@ -58,14 +58,14 @@ export class SqliteStorageEngine implements StorageEngine {
    * runInTransaction gets its own begin/commit/rollback boundary. Nested calls
    * join the active transaction instead of starting a new one.
    */
-  runInTransaction<T>(_scope: readonly StorageScope[], action: () => Promise<T>): Promise<T> {
+  runInTransaction<T>(scope: readonly StorageScope[], action: () => Promise<T>): Promise<T> {
     if (isInsideStorageTransaction()) {
       return action();
     }
 
     const run = async (): Promise<T> =>
       runInsideStorageTransactionZone(async () => {
-        this.debugLogService?.trace('sqlite.transaction.begin', { scope: _scope });
+        this.debugLogService?.trace('sqlite.transaction.begin', { scope });
         await this.connection.beginTransaction();
 
         try {

--- a/src/app/core/data/storage-engine.factory.ts
+++ b/src/app/core/data/storage-engine.factory.ts
@@ -27,7 +27,11 @@ export class StorageEngineFactory {
       return;
     }
 
-    if (!isNativePlatform()) {
+    const native = isNativePlatform();
+    this.debugLogService.trace('storage.engine.initializing', { native });
+
+    if (!native) {
+      this.debugLogService.trace('storage.engine.using_dexie');
       await this.dexieEngine.initialize();
       this.engine = this.dexieEngine;
       return;
@@ -36,14 +40,22 @@ export class StorageEngineFactory {
     let connection: SqliteConnection | null = null;
 
     try {
+      this.debugLogService.trace('storage.engine.loading_sqlite_modules');
       const [{ openCapacitorSqliteConnection }, { SqliteStorageEngine }] = await Promise.all([
         import('./sqlite-connection'),
         import('./sqlite-storage-engine'),
       ]);
+      this.debugLogService.trace('storage.engine.sqlite_modules_loaded');
 
-      connection = await openCapacitorSqliteConnection();
-      const sqliteEngine = new SqliteStorageEngine(connection);
+      this.debugLogService.trace('storage.engine.opening_sqlite_connection');
+      connection = await openCapacitorSqliteConnection(this.debugLogService);
+
+      const sqliteEngine = new SqliteStorageEngine(connection, this.debugLogService);
+
+      this.debugLogService.trace('storage.engine.initializing_sqlite_engine');
       await sqliteEngine.initialize();
+
+      this.debugLogService.trace('storage.engine.running_migration_check');
       await this.migrationService.migrateIfNeeded(sqliteEngine);
 
       this.engine = sqliteEngine;
@@ -60,6 +72,7 @@ export class StorageEngineFactory {
       this.debugLogService.error('storage.engine.sqlite_unavailable_falling_back_to_dexie', {
         error: error instanceof Error ? error.message : String(error),
       });
+      this.debugLogService.trace('storage.engine.initializing_dexie_fallback');
       await this.dexieEngine.initialize();
       this.engine = this.dexieEngine;
     }

--- a/src/app/core/services/notification.service.spec.ts
+++ b/src/app/core/services/notification.service.spec.ts
@@ -5,6 +5,15 @@ import { Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { NotificationService } from './notification.service';
 import { DebugLogService } from './debug-log.service';
+
+function makeDebugLogStub(): DebugLogService {
+  return {
+    trace: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as DebugLogService;
+}
 import { SYNC_OUTBOX_WRITER } from '../data/sync-outbox-writer';
 import {
   PreferenceStorageService,
@@ -88,6 +97,7 @@ describe('NotificationService', () => {
           },
         },
         { provide: SYNC_OUTBOX_WRITER, useValue: null },
+        { provide: DebugLogService, useValue: makeDebugLogStub() },
       ],
     });
 
@@ -631,6 +641,38 @@ describe('NotificationService', () => {
     );
   });
 
+  it('registerCurrentDevice returns unsupported when push becomes unavailable before token fetch', async () => {
+    vi.spyOn(service, 'isPushSupported').mockReturnValueOnce(true).mockReturnValue(false);
+
+    const result = await service.requestPermissionAndRegister();
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('not available');
+  });
+
+  it('initialize is idempotent and does not re-attach listeners on subsequent calls', async () => {
+    await service.initialize();
+    await service.initialize();
+
+    expect(addListenerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs notificationActionPerformed listener attach failure without aborting initialization', async () => {
+    addListenerMock
+      .mockResolvedValueOnce({ remove: () => undefined })
+      .mockRejectedValueOnce(new Error('action listener failed'));
+    const errorSpy = vi.spyOn(debugLogService, 'error');
+
+    await service.initialize();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'notifications.listener_attach_failed',
+      expect.objectContaining({
+        listener: 'notificationActionPerformed',
+        error: 'action listener failed',
+      })
+    );
+  });
+
   it('enqueues settings upserts when outbox writer is configured', () => {
     const enqueueOperation = vi.fn();
     const serviceWithOutbox = createService({ enqueueOperation });
@@ -666,6 +708,7 @@ function createService(outboxWriter: {
         },
       },
       { provide: SYNC_OUTBOX_WRITER, useValue: outboxWriter },
+      { provide: DebugLogService, useValue: makeDebugLogStub() },
     ],
   });
 

--- a/src/app/core/services/notification.service.spec.ts
+++ b/src/app/core/services/notification.service.spec.ts
@@ -4,6 +4,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { NotificationService } from './notification.service';
+import { DebugLogService } from './debug-log.service';
 import { SYNC_OUTBOX_WRITER } from '../data/sync-outbox-writer';
 import {
   PreferenceStorageService,
@@ -55,6 +56,7 @@ vi.mock('@capacitor/preferences', () => ({
 describe('NotificationService', () => {
   let service: NotificationService;
   let preferenceStorage: PreferenceStorageService;
+  let debugLogService: DebugLogService;
   let router: { navigateByUrl: ReturnType<typeof vi.fn> };
   let httpClient: HttpClient;
 
@@ -92,6 +94,7 @@ describe('NotificationService', () => {
     preferenceStorage = TestBed.inject(PreferenceStorageService);
     await preferenceStorage.initialize();
     service = TestBed.inject(NotificationService);
+    debugLogService = TestBed.inject(DebugLogService);
     router = TestBed.inject(Router) as unknown as { navigateByUrl: ReturnType<typeof vi.fn> };
     httpClient = TestBed.inject(HttpClient);
 
@@ -144,12 +147,15 @@ describe('NotificationService', () => {
 
   it('treats permission request failures as denied', async () => {
     requestPermissionsMock.mockRejectedValue(new Error('plugin unavailable'));
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(debugLogService, 'error');
 
     const result = await service.requestPermissionAndRegister();
     expect(result.ok).toBe(false);
     expect(result.message).toContain('not granted');
-    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'notifications.permission_request_failed',
+      expect.objectContaining({ error: 'plugin unavailable' })
+    );
   });
 
   it('fails registration when the plugin returns no token', async () => {
@@ -162,13 +168,16 @@ describe('NotificationService', () => {
 
   it('fails registration when backend token save fails', async () => {
     vi.spyOn(httpClient, 'post').mockReturnValue(throwError(() => new Error('backend down')));
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(debugLogService, 'error');
 
     const result = await service.requestPermissionAndRegister();
     expect(result.ok).toBe(false);
     expect(result.message).toContain('server');
     expect(preferenceStorage.getItem('game-shelf:notifications:fcm-token')).toBeNull();
-    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'notifications.backend_register_failed',
+      expect.objectContaining({ error: 'backend down' })
+    );
   });
 
   it('stores token when backend registration succeeds', async () => {
@@ -536,14 +545,17 @@ describe('NotificationService', () => {
 
   it('treats permission check failures as denied', async () => {
     checkPermissionsMock.mockRejectedValue(new Error('plugin unavailable'));
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(debugLogService, 'error');
 
     expect(await service.shouldPromptForReleaseNotifications()).toBe(false);
-    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'notifications.permission_check_failed',
+      expect.objectContaining({ error: 'plugin unavailable' })
+    );
   });
 
   it('logs foreground notification diagnostics from the native listener', async () => {
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(debugLogService, 'info');
     await service.initialize();
 
     const receivedListener = addListenerMock.mock.calls.find(
@@ -556,7 +568,7 @@ describe('NotificationService', () => {
     });
 
     expect(infoSpy).toHaveBeenCalledWith(
-      '[notifications] notification_received',
+      'notifications.notification_received',
       expect.objectContaining({ title: 'Release' })
     );
   });
@@ -595,27 +607,27 @@ describe('NotificationService', () => {
     addListenerMock
       .mockRejectedValueOnce(new Error('listener failed'))
       .mockResolvedValueOnce({ remove: () => undefined });
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(debugLogService, 'error');
 
     await service.initialize();
 
     expect(errorSpy).toHaveBeenCalledWith(
-      '[notifications] listener_attach_failed',
-      expect.any(Error)
+      'notifications.listener_attach_failed',
+      expect.objectContaining({ error: 'listener failed' })
     );
   });
 
   it('reports token registration failures during permitted device registration', async () => {
     preferenceStorage.setItem('game-shelf:notifications:release:enabled', 'true');
     getTokenMock.mockRejectedValueOnce(new Error('token failed'));
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(debugLogService, 'error');
 
     const result = await service.registerCurrentDeviceIfPermitted();
 
     expect(result.ok).toBe(false);
     expect(errorSpy).toHaveBeenCalledWith(
-      '[notifications] token_registration_failed',
-      expect.any(Error)
+      'notifications.token_fetch_failed',
+      expect.objectContaining({ error: 'token failed' })
     );
   });
 

--- a/src/app/core/services/notification.service.spec.ts
+++ b/src/app/core/services/notification.service.spec.ts
@@ -656,6 +656,16 @@ describe('NotificationService', () => {
     expect(addListenerMock).toHaveBeenCalledTimes(2);
   });
 
+  it('attachNativeListeners skips listener registration when already attached', async () => {
+    await service.initialize();
+
+    await (
+      service as unknown as { attachNativeListeners(): Promise<void> }
+    ).attachNativeListeners();
+
+    expect(addListenerMock).toHaveBeenCalledTimes(2);
+  });
+
   it('logs notificationActionPerformed listener attach failure without aborting initialization', async () => {
     addListenerMock
       .mockResolvedValueOnce({ remove: () => undefined })

--- a/src/app/core/services/notification.service.ts
+++ b/src/app/core/services/notification.service.ts
@@ -10,6 +10,7 @@ import { SYNC_OUTBOX_WRITER, SyncOutboxWriter } from '../data/sync-outbox-writer
 import { coercePreferenceBoolean, isDisabledPreferenceValue } from '../utils/preference-bool';
 import { getNativePlatform, isNativePlatform } from '../utils/native-platform.util';
 import { PreferenceStorageService } from '../storage/preference-storage.service';
+import { DebugLogService } from './debug-log.service';
 
 export const RELEASE_NOTIFICATIONS_ENABLED_STORAGE_KEY = 'game-shelf:notifications:release:enabled';
 export const RELEASE_NOTIFICATION_EVENTS_STORAGE_KEY = 'game-shelf:notifications:release:events';
@@ -32,6 +33,7 @@ export class NotificationService {
   private readonly httpClient = inject(HttpClient);
   private readonly router = inject(Router);
   private readonly preferenceStorage = inject(PreferenceStorageService);
+  private readonly debugLogService = inject(DebugLogService);
   private readonly outboxWriter = inject<SyncOutboxWriter | null>(SYNC_OUTBOX_WRITER, {
     optional: true,
   });
@@ -64,17 +66,24 @@ export class NotificationService {
   }
 
   private async initializeInternal(): Promise<void> {
+    this.debugLogService.trace('notifications.init.start');
+
     if (!this.isPushSupported()) {
+      this.debugLogService.trace('notifications.init.push_not_supported');
       return;
     }
 
     await this.attachNativeListeners();
 
-    if (!this.isReleaseNotificationsEnabled()) {
+    const releaseEnabled = this.isReleaseNotificationsEnabled();
+    this.debugLogService.trace('notifications.init.release_enabled', { releaseEnabled });
+
+    if (!releaseEnabled) {
       return;
     }
 
     const permission = await this.checkNativePermission();
+    this.debugLogService.trace('notifications.init.permission_state', { permission });
 
     if (permission === 'granted') {
       await this.registerCurrentDevice();
@@ -129,12 +138,18 @@ export class NotificationService {
       return { ok: false, message: 'Notifications are not supported on this device.' };
     }
 
+    this.debugLogService.trace('notifications.permission_request.start');
+
     const permission = await FirebaseMessaging.requestPermissions()
       .then((status) => status.receive)
       .catch((error: unknown) => {
-        console.error('[notifications] permission_request_failed', error);
+        this.debugLogService.error('notifications.permission_request_failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
         return 'denied' as const;
       });
+
+    this.debugLogService.trace('notifications.permission_request.result', { permission });
 
     if (permission !== 'granted') {
       return { ok: false, message: 'Notification permission was not granted.' };
@@ -219,6 +234,10 @@ export class NotificationService {
 
   async unregisterCurrentDevice(): Promise<{ ok: boolean; message: string }> {
     const storedToken = this.readStoredToken();
+    this.debugLogService.trace('notifications.unregister.start', {
+      hasToken: storedToken !== null,
+    });
+
     const backendUnregisterOk = storedToken
       ? await firstValueFrom(
           this.httpClient.post(`${environment.gameApiBaseUrl}/v1/notifications/fcm/unregister`, {
@@ -229,11 +248,17 @@ export class NotificationService {
           .catch(() => false)
       : true;
 
+    this.debugLogService.trace('notifications.unregister.backend_result', { backendUnregisterOk });
+
     const firebaseDeleteOk = this.isPushSupported()
       ? await FirebaseMessaging.deleteToken()
           .then(() => true)
           .catch(() => false)
       : true;
+
+    this.debugLogService.trace('notifications.unregister.firebase_delete_result', {
+      firebaseDeleteOk,
+    });
 
     try {
       this.preferenceStorage.removeItem(FCM_DEVICE_TOKEN_STORAGE_KEY);
@@ -258,20 +283,29 @@ export class NotificationService {
       return { ok: false, message: 'Notifications are not available in this app session.' };
     }
 
+    this.debugLogService.trace('notifications.register_device.fetching_token');
+
     const token = await FirebaseMessaging.getToken()
       .then((result) => result.token)
       .catch((error: unknown) => {
-        console.error('[notifications] token_registration_failed', error);
+        this.debugLogService.error('notifications.token_fetch_failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
         return null;
       });
 
     if (!token || token.trim().length === 0) {
+      this.debugLogService.warn('notifications.register_device.token_empty');
       return {
         ok: false,
         message:
           'Unable to register the device for notifications. Check the Firebase iOS configuration.',
       };
     }
+
+    this.debugLogService.trace('notifications.register_device.token_fetched', {
+      tokenPrefix: token.slice(0, 8),
+    });
 
     const registeredOnBackend = await firstValueFrom(
       this.httpClient.post(`${environment.gameApiBaseUrl}/v1/notifications/fcm/register`, {
@@ -282,7 +316,9 @@ export class NotificationService {
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       })
     ).catch((error: unknown) => {
-      console.error('[notifications] backend_register_failed', error);
+      this.debugLogService.error('notifications.backend_register_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     });
 
@@ -293,8 +329,11 @@ export class NotificationService {
       };
     }
 
+    this.debugLogService.trace('notifications.register_device.backend_registered');
+
     try {
       this.preferenceStorage.setItem(FCM_DEVICE_TOKEN_STORAGE_KEY, token);
+      this.debugLogService.trace('notifications.register_device.token_stored');
     } catch {
       // Ignore storage failures.
     }
@@ -304,9 +343,16 @@ export class NotificationService {
 
   private async checkNativePermission(): Promise<string> {
     return FirebaseMessaging.checkPermissions()
-      .then((status) => status.receive)
+      .then((status) => {
+        this.debugLogService.trace('notifications.permission_check.result', {
+          permission: status.receive,
+        });
+        return status.receive;
+      })
       .catch((error: unknown) => {
-        console.error('[notifications] permission_check_failed', error);
+        this.debugLogService.error('notifications.permission_check_failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
         return 'denied';
       });
   }
@@ -317,22 +363,32 @@ export class NotificationService {
     }
 
     this.nativeListenersAttached = true;
+    this.debugLogService.trace('notifications.listeners.attaching');
 
     // Foreground presentation is handled natively via the FirebaseMessaging
     // `presentationOptions` in capacitor.config.ts; this listener is for diagnostics.
     await FirebaseMessaging.addListener(
       'notificationReceived',
       (event: FirebaseNotificationListenerEvent) => {
-        console.info('[notifications] notification_received', event.notification);
+        this.debugLogService.info('notifications.notification_received', {
+          title: event.notification.title,
+        });
       }
     ).catch((error: unknown) => {
-      console.error('[notifications] listener_attach_failed', error);
+      this.debugLogService.error('notifications.listener_attach_failed', {
+        listener: 'notificationReceived',
+        error: error instanceof Error ? error.message : String(error),
+      });
     });
 
     await FirebaseMessaging.addListener(
       'notificationActionPerformed',
       (event: FirebaseNotificationListenerEvent) => {
         const route = this.extractRoute(event.notification.data);
+        this.debugLogService.trace('notifications.action_performed', {
+          hasRoute: route !== null,
+          route,
+        });
         if (route !== null) {
           void this.router.navigateByUrl(route).catch(() => {
             window.location.assign(route);
@@ -340,8 +396,13 @@ export class NotificationService {
         }
       }
     ).catch((error: unknown) => {
-      console.error('[notifications] listener_attach_failed', error);
+      this.debugLogService.error('notifications.listener_attach_failed', {
+        listener: 'notificationActionPerformed',
+        error: error instanceof Error ? error.message : String(error),
+      });
     });
+
+    this.debugLogService.trace('notifications.listeners.attached');
   }
 
   private extractRoute(data: unknown): string | null {

--- a/src/app/core/services/notification.service.ts
+++ b/src/app/core/services/notification.service.ts
@@ -387,7 +387,7 @@ export class NotificationService {
         const route = this.extractRoute(event.notification.data);
         this.debugLogService.trace('notifications.action_performed', {
           hasRoute: route !== null,
-          route,
+          route: route?.replace(/[?#].*$/, '') ?? null,
         });
         if (route !== null) {
           void this.router.navigateByUrl(route).catch(() => {

--- a/src/app/core/storage/preference-storage.service.spec.ts
+++ b/src/app/core/storage/preference-storage.service.spec.ts
@@ -4,6 +4,8 @@ import { E2E_FIXTURE_STORAGE_KEY, DEBUG_LOGS_STORAGE_KEY } from './preference-ke
 import {
   PreferenceStorageService,
   readPreference,
+  writePreference,
+  removePreference,
   resetPreferenceStorageForTesting,
 } from './preference-storage.service';
 
@@ -530,5 +532,42 @@ describe('PreferenceStorageService', () => {
     localStorage.setItem('game-shelf:runtime-config:v1', '{"appVersion":"pre-init"}');
 
     expect(readPreference('game-shelf:runtime-config:v1')).toBe('{"appVersion":"pre-init"}');
+  });
+
+  it('initialize is idempotent when called twice', async () => {
+    await service.initialize();
+    await service.initialize();
+
+    expect(service.getItem('game-shelf:test')).toBeNull();
+  });
+
+  it('writePreference delegates to the service instance after initialization', async () => {
+    await service.initialize();
+
+    writePreference('game-shelf:test-key', 'test-value');
+    expect(service.getItem('game-shelf:test-key')).toBe('test-value');
+  });
+
+  it('removePreference delegates to the service instance after initialization', async () => {
+    await service.initialize();
+    service.setItem('game-shelf:test-key', 'some-value');
+
+    removePreference('game-shelf:test-key');
+    expect(service.getItem('game-shelf:test-key')).toBeNull();
+  });
+
+  it('falls back to localStorage when native preferences initialization fails', async () => {
+    nativePlatformState.value = true;
+    preferencesGet.mockRejectedValue(new Error('native unavailable'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await service.initialize();
+
+    service.setItem('game-shelf:fallback-key', 'fallback-value');
+    expect(localStorage.getItem('game-shelf:fallback-key')).toBe('fallback-value');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[preference-storage] native_preferences_init_failed, falling back to localStorage',
+      expect.objectContaining({ error: 'native unavailable' })
+    );
   });
 });

--- a/src/app/core/storage/preference-storage.service.spec.ts
+++ b/src/app/core/storage/preference-storage.service.spec.ts
@@ -582,12 +582,6 @@ describe('PreferenceStorageService', () => {
 
   it('keys returns from cache when native preferences are enabled', async () => {
     nativePlatformState.value = true;
-    preferencesGet.mockImplementation(({ key }: { key: string }) => {
-      if (key === 'game-shelf:preference-storage-migration-v1') {
-        return Promise.resolve({ value: '1' });
-      }
-      return Promise.resolve({ value: null });
-    });
     preferencesKeys.mockResolvedValue({
       keys: ['game-shelf:preference-storage-migration-v1', 'game-shelf:theme'],
     });

--- a/src/app/core/storage/preference-storage.service.spec.ts
+++ b/src/app/core/storage/preference-storage.service.spec.ts
@@ -46,6 +46,7 @@ describe('PreferenceStorageService', () => {
     nativePlatformState.value = false;
     localStorage.clear();
     resetPreferenceStorageForTesting();
+    vi.restoreAllMocks();
   });
 
   it('delegates get/set/remove to localStorage on web', async () => {
@@ -569,5 +570,36 @@ describe('PreferenceStorageService', () => {
       '[preference-storage] native_preferences_init_failed, falling back to localStorage',
       expect.objectContaining({ error: 'native unavailable' })
     );
+  });
+
+  it('removePreference falls back to localStorage when service is not initialized', () => {
+    localStorage.setItem('game-shelf:test-key', 'stored-value');
+
+    removePreference('game-shelf:test-key');
+
+    expect(localStorage.getItem('game-shelf:test-key')).toBeNull();
+  });
+
+  it('keys returns from cache when native preferences are enabled', async () => {
+    nativePlatformState.value = true;
+    preferencesGet.mockImplementation(({ key }: { key: string }) => {
+      if (key === 'game-shelf:preference-storage-migration-v1') {
+        return Promise.resolve({ value: '1' });
+      }
+      return Promise.resolve({ value: null });
+    });
+    preferencesKeys.mockResolvedValue({
+      keys: ['game-shelf:preference-storage-migration-v1', 'game-shelf:theme'],
+    });
+    preferencesGet.mockImplementation(({ key }: { key: string }) => {
+      if (key === 'game-shelf:theme') return Promise.resolve({ value: 'dark' });
+      if (key === 'game-shelf:preference-storage-migration-v1')
+        return Promise.resolve({ value: '1' });
+      return Promise.resolve({ value: null });
+    });
+
+    await service.initialize();
+
+    expect(service.keys()).toContain('game-shelf:theme');
   });
 });

--- a/src/app/core/storage/preference-storage.service.ts
+++ b/src/app/core/storage/preference-storage.service.ts
@@ -99,6 +99,8 @@ export class PreferenceStorageService {
       return;
     }
 
+    console.info('[preference-storage] initializing native preferences');
+
     let migratedKeys: string[] = [];
     let migrationPending = false;
 
@@ -106,13 +108,32 @@ export class PreferenceStorageService {
       const migrationResult = await this.migrateFromLocalStorageIfNeeded();
       migratedKeys = migrationResult.migratedKeys;
       migrationPending = migrationResult.migrationPending;
+
+      if (migrationResult.migrationPending) {
+        console.info('[preference-storage] migrating_from_localstorage', {
+          keyCount: migratedKeys.length,
+        });
+      }
+
       await this.reclaimExcludedKeysFromPreferences();
       await this.hydrateCacheFromPreferences();
       this.nativePreferencesEnabled = true;
+
+      console.info('[preference-storage] native_preferences_ready', {
+        cachedKeyCount: this.cache.size,
+        migrationPending,
+      });
+
       await this.finalizeMigration(migratedKeys, migrationPending);
-    } catch {
+    } catch (error: unknown) {
       this.nativePreferencesEnabled = false;
       this.cache.clear();
+      console.warn(
+        '[preference-storage] native_preferences_init_failed, falling back to localStorage',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
     }
 
     this.initialized = true;


### PR DESCRIPTION
## Summary

Replaces raw `console.error/info` calls in `NotificationService`, `ImageFileStore`, `SqliteStorageEngine`, and `StorageEngineFactory` with structured `DebugLogService` calls. Adds trace points throughout the storage engine init flow (Dexie vs SQLite path selection, connection lifecycle, transaction begin/commit/rollback) and the notification flow (permission check/request, token fetch, device register/unregister, listener attach). `PreferenceStorageService` intentionally retains raw `console.*` to avoid a circular dependency (DebugLogService → PreferenceStorageService).

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `openCapacitorSqliteConnection(debugLogService?)` and `SqliteStorageEngine(connection, debugLogService?)` gain optional nullable `DebugLogService` parameters so the factory can inject it at call sites without breaking existing callers
- All structured log calls use namespaced dot-separated keys (e.g. `sqlite.transaction.committed`, `notifications.token_fetch_failed`)
- Error payloads normalise to `{ error: string }` via `instanceof Error ? .message : String(error)`, keeping the logger's interface consistent
- Token value is truncated to an 8-char prefix before logging to avoid accidental credential exposure in traces
- `NotificationService` tests now spy on `debugLogService.error/info` instead of `console.*` and assert on the exact structured key and payload shape

## Testing performed

- `npm run lint` — passed (no ESLint errors)
- `npm run test` — 1453/1453 tests passed, 95/95 test files passed
- `npm run build` — build succeeded (budget warning is pre-existing, not introduced by this patch)

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
