### PR TITLE
fix(auth,ui): skip write-token prompt when auth disabled; defer popover navigation to didDismiss

### DIFF
--- a/scripts/generate-runtime-config.mjs
+++ b/scripts/generate-runtime-config.mjs
@@ -44,6 +44,7 @@ const envValues = loadProjectEnv();
 const showMgcImport = parseBoolean(envValues.FEATURE_MGC_IMPORT, false);
 const e2eFixtures = parseBoolean(envValues.FEATURE_E2E_FIXTURES, false);
 const tasEnabled = parseBoolean(envValues.FEATURE_TAS, false);
+const requireAuth = parseBoolean(envValues.REQUIRE_AUTH, true);
 
 const output = `globalThis.__GAME_SHELF_RUNTIME_CONFIG__ = Object.assign(
   {},
@@ -54,6 +55,7 @@ const output = `globalThis.__GAME_SHELF_RUNTIME_CONFIG__ = Object.assign(
       showMgcImport: ${showMgcImport},
       e2eFixtures: ${e2eFixtures},
       tasEnabled: ${tasEnabled},
+      requireAuth: ${requireAuth},
     },
   },
 );

--- a/scripts/write-environment-ios.mjs
+++ b/scripts/write-environment-ios.mjs
@@ -140,6 +140,15 @@ export function resolveBackendOrigin(variant, envValues, options = {}) {
   return null;
 }
 
+function parseBoolean(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return fallback;
+  const n = value.trim().toLowerCase();
+  if (n === '1' || n === 'true' || n === 'yes' || n === 'on') return true;
+  if (n === '0' || n === 'false' || n === 'no' || n === 'off') return false;
+  return fallback;
+}
+
 function escapeTsString(value) {
   return value
     .replace(/\\/g, '\\\\')
@@ -191,6 +200,8 @@ export function buildEnvironmentIosSource(variant, envValues, options = {}) {
     );
   }
 
+  const requireAuth = parseBoolean(envValues.REQUIRE_AUTH, true);
+
   return `import {
   EMULATORJS_DEFAULT_PATH_TO_DATA,
   EMULATORJS_PINNED_LOADER_INTEGRITY,
@@ -215,6 +226,7 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
+    requireAuth: ${requireAuth},
   },
 };
 `;

--- a/scripts/write-environment-prod.sh
+++ b/scripts/write-environment-prod.sh
@@ -55,6 +55,7 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
+    requireAuth: true,
   },
 };
 EOF

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -24,6 +24,7 @@ vi.mock('@ionic/angular/standalone', () => {
 vi.mock('./core/config/runtime-config', () => ({
   getAppVersionInfo: vi.fn(() => ({ value: '1.27.1', source: 'live', isFallback: false })),
   isE2eFixturesEnabled: vi.fn(() => false),
+  isAuthRequired: vi.fn(() => true),
 }));
 
 const { splashHideMock } = vi.hoisted(() => ({
@@ -42,7 +43,11 @@ vi.mock('./core/utils/native-platform.util', () => ({
 
 import { AlertController, ToastController } from '@ionic/angular/standalone';
 import { AppComponent } from './app.component';
-import { getAppVersionInfo, isE2eFixturesEnabled } from './core/config/runtime-config';
+import {
+  getAppVersionInfo,
+  isAuthRequired,
+  isE2eFixturesEnabled,
+} from './core/config/runtime-config';
 import { isNativePlatform } from './core/utils/native-platform.util';
 import { ThemeService } from './core/services/theme.service';
 import { GameSyncService } from './core/services/game-sync.service';
@@ -691,6 +696,17 @@ describe('AppComponent', () => {
       await flushAsync();
 
       expect(clientWriteAuthServiceMock.setToken).not.toHaveBeenCalled();
+    });
+
+    it('does not show the write-token alert when auth is not required', async () => {
+      vi.mocked(isAuthRequired).mockReturnValue(false);
+      vi.mocked(isNativePlatform).mockReturnValue(true);
+      clientWriteAuthServiceMock.hasToken.mockReturnValue(false);
+
+      TestBed.runInInjectionContext(() => new AppComponent());
+      await flushAsync();
+
+      expect(alertControllerMock.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,7 +14,11 @@ import { DebugLogService } from './core/services/debug-log.service';
 import { GameShelfService } from './core/services/game-shelf.service';
 import { NotificationService } from './core/services/notification.service';
 import { E2eFixtureService } from './core/services/e2e-fixture.service';
-import { getAppVersionInfo, isE2eFixturesEnabled } from './core/config/runtime-config';
+import {
+  getAppVersionInfo,
+  isAuthRequired,
+  isE2eFixturesEnabled,
+} from './core/config/runtime-config';
 import { RuntimeAvailabilityService } from './core/services/runtime-availability.service';
 import { NetworkConnectivityService } from './core/services/network-connectivity.service';
 import { isNativePlatform } from './core/utils/native-platform.util';
@@ -91,7 +95,7 @@ export class AppComponent implements OnDestroy {
   }
 
   private async promptForWriteTokenIfNeeded(): Promise<void> {
-    if (!isNativePlatform() || this.clientWriteAuthService.hasToken()) {
+    if (!isNativePlatform() || !isAuthRequired() || this.clientWriteAuthService.hasToken()) {
       return;
     }
 

--- a/src/app/core/config/runtime-config.spec.ts
+++ b/src/app/core/config/runtime-config.spec.ts
@@ -4,6 +4,7 @@ import {
   getAppVersionInfo,
   getRuntimeConfigSource,
   hasLiveRuntimeConfig,
+  isAuthRequired,
   isE2eFixturesEnabled,
   isMgcImportFeatureEnabled,
   isRecommendationsExploreEnabled,
@@ -212,6 +213,38 @@ describe('runtime-config', () => {
       };
 
       expect(isRecommendationsExploreEnabled()).toBe(true);
+    });
+  });
+
+  describe('isAuthRequired()', () => {
+    it('returns the environment default (true) when no runtime config is set', () => {
+      expect(isAuthRequired()).toBe(true);
+    });
+
+    it('returns false when runtime config sets requireAuth to boolean false', () => {
+      window.__GAME_SHELF_RUNTIME_CONFIG__ = { featureFlags: { requireAuth: false } };
+      expect(isAuthRequired()).toBe(false);
+    });
+
+    it('returns true when runtime config sets requireAuth to boolean true', () => {
+      window.__GAME_SHELF_RUNTIME_CONFIG__ = { featureFlags: { requireAuth: true } };
+      expect(isAuthRequired()).toBe(true);
+    });
+
+    it('parses "false" and "0" string values as false', () => {
+      for (const val of ['false', '0', 'no', 'off']) {
+        window.__GAME_SHELF_RUNTIME_CONFIG__ = {
+          featureFlags: { requireAuth: val as unknown as boolean },
+        };
+        expect(isAuthRequired()).toBe(false);
+      }
+    });
+
+    it('falls back to environment default for non-boolean, non-string values', () => {
+      window.__GAME_SHELF_RUNTIME_CONFIG__ = {
+        featureFlags: { requireAuth: 42 as unknown as boolean },
+      };
+      expect(isAuthRequired()).toBe(true);
     });
   });
 

--- a/src/app/core/config/runtime-config.ts
+++ b/src/app/core/config/runtime-config.ts
@@ -8,6 +8,7 @@ interface RuntimeFeatureFlags {
   e2eFixtures?: boolean;
   recommendationsExploreEnabled?: boolean;
   tasEnabled?: boolean;
+  requireAuth?: boolean;
 }
 
 interface RuntimeConfig {
@@ -85,6 +86,9 @@ function normalizeRuntimeConfig(value: unknown): RuntimeConfig | null {
             : {}),
           ...(parseBoolean(featureFlagsCandidate.tasEnabled) !== null
             ? { tasEnabled: parseBoolean(featureFlagsCandidate.tasEnabled) ?? undefined }
+            : {}),
+          ...(parseBoolean(featureFlagsCandidate.requireAuth) !== null
+            ? { requireAuth: parseBoolean(featureFlagsCandidate.requireAuth) ?? undefined }
             : {}),
         }
       : undefined;
@@ -234,4 +238,14 @@ export function isTasFeatureEnabled(): boolean {
   }
 
   return environment.featureFlags.tasEnabled;
+}
+
+export function isAuthRequired(): boolean {
+  const runtimeValue = parseBoolean(resolveRuntimeConfig().config?.featureFlags?.requireAuth);
+
+  if (runtimeValue !== null) {
+    return runtimeValue;
+  }
+
+  return environment.featureFlags.requireAuth;
 }

--- a/src/app/core/config/runtime-config.ts
+++ b/src/app/core/config/runtime-config.ts
@@ -242,10 +242,5 @@ export function isTasFeatureEnabled(): boolean {
 
 export function isAuthRequired(): boolean {
   const runtimeValue = parseBoolean(resolveRuntimeConfig().config?.featureFlags?.requireAuth);
-
-  if (runtimeValue !== null) {
-    return runtimeValue;
-  }
-
-  return environment.featureFlags.requireAuth;
+  return runtimeValue ?? true;
 }

--- a/src/app/core/config/runtime-config.ts
+++ b/src/app/core/config/runtime-config.ts
@@ -242,5 +242,10 @@ export function isTasFeatureEnabled(): boolean {
 
 export function isAuthRequired(): boolean {
   const runtimeValue = parseBoolean(resolveRuntimeConfig().config?.featureFlags?.requireAuth);
-  return runtimeValue ?? true;
+
+  if (runtimeValue !== null) {
+    return runtimeValue;
+  }
+
+  return environment.featureFlags.requireAuth;
 }

--- a/src/app/core/services/runtime-availability.service.spec.ts
+++ b/src/app/core/services/runtime-availability.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getAppVersion, getRuntimeConfigSource } from '../config/runtime-config';
+import { getAppVersion, getRuntimeConfigSource, isAuthRequired } from '../config/runtime-config';
 import { NetworkConnectivityService } from './network-connectivity.service';
 import { RuntimeAvailabilityService } from './runtime-availability.service';
 
@@ -146,6 +146,21 @@ describe('RuntimeAvailabilityService', () => {
     delete window.__GAME_SHELF_RUNTIME_CONFIG__;
     expect(getRuntimeConfigSource()).toBe('persisted');
     expect(getAppVersion()).toBe('2.3.4');
+  });
+
+  it('parses requireAuth from the runtime config script', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          `globalThis.__GAME_SHELF_RUNTIME_CONFIG__ = { featureFlags: { requireAuth: false } };`
+        ),
+    });
+
+    await service.refresh();
+
+    expect(isAuthRequired()).toBe(false);
   });
 
   it('probes the API health endpoint instead of runtime config on native platforms', async () => {

--- a/src/app/core/services/runtime-availability.service.ts
+++ b/src/app/core/services/runtime-availability.service.ts
@@ -174,13 +174,15 @@ export class RuntimeAvailabilityService {
       'recommendationsExploreEnabled'
     );
     const tasEnabled = this.matchLastBoolean(script, 'tasEnabled');
+    const requireAuth = this.matchLastBoolean(script, 'requireAuth');
 
     if (
       appVersion === null &&
       showMgcImport === null &&
       e2eFixtures === null &&
       recommendationsExploreEnabled === null &&
-      tasEnabled === null
+      tasEnabled === null &&
+      requireAuth === null
     ) {
       return null;
     }
@@ -190,13 +192,15 @@ export class RuntimeAvailabilityService {
       ...(showMgcImport !== null ||
       e2eFixtures !== null ||
       recommendationsExploreEnabled !== null ||
-      tasEnabled !== null
+      tasEnabled !== null ||
+      requireAuth !== null
         ? {
             featureFlags: {
               ...(showMgcImport !== null ? { showMgcImport } : {}),
               ...(e2eFixtures !== null ? { e2eFixtures } : {}),
               ...(recommendationsExploreEnabled !== null ? { recommendationsExploreEnabled } : {}),
               ...(tasEnabled !== null ? { tasEnabled } : {}),
+              ...(requireAuth !== null ? { requireAuth } : {}),
             },
           }
         : {}),

--- a/src/app/list-page/list-page.component.html
+++ b/src/app/list-page/list-page.component.html
@@ -132,7 +132,7 @@
     [arrow]="false"
     side="bottom"
     alignment="end"
-    (didDismiss)="closeHeaderActionsPopover()"
+    (didDismiss)="onHeaderActionsPopoverDidDismiss()"
   >
     <ng-template>
       <ion-content>

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -84,6 +84,7 @@ describe('ListPageComponent', () => {
   };
   const routerMock = {
     navigate: vi.fn().mockResolvedValue(true),
+    navigateByUrl: vi.fn().mockResolvedValue(true),
   };
   const routeMock = {
     snapshot: { data: { listType: 'collection' } },
@@ -698,6 +699,67 @@ describe('ListPageComponent', () => {
     expect(component.bulkActionsPopoverEvent).toBeUndefined();
     expect(component.isHeaderActionsPopoverOpen).toBe(false);
     expect(component.headerActionsPopoverEvent).toBeUndefined();
+  });
+
+  it('openViewsFromPopover closes popover and defers navigation to didDismiss', () => {
+    const component = createComponent();
+    const navigateSpy = vi.spyOn(routerMock, 'navigate');
+    component.isHeaderActionsPopoverOpen = true;
+
+    component.openViewsFromPopover();
+
+    expect(component.isHeaderActionsPopoverOpen).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+
+    component.onHeaderActionsPopoverDidDismiss();
+
+    expect(navigateSpy).toHaveBeenCalledOnce();
+    const [path, extras] = navigateSpy.mock.calls[0] as [string[], { state: { listType: string } }];
+    expect(path).toEqual(['/views']);
+    expect(extras.state.listType).toBe('collection');
+  });
+
+  it('openTagsFromPopover closes popover and defers navigation to didDismiss', () => {
+    const component = createComponent();
+    const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
+    component.isHeaderActionsPopoverOpen = true;
+
+    component.openTagsFromPopover();
+
+    expect(component.isHeaderActionsPopoverOpen).toBe(false);
+    expect(navigateByUrlSpy).not.toHaveBeenCalled();
+
+    component.onHeaderActionsPopoverDidDismiss();
+
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/tags');
+  });
+
+  it('openSettingsFromPopover closes popover and defers navigation to didDismiss', () => {
+    const component = createComponent();
+    const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
+    component.isHeaderActionsPopoverOpen = true;
+
+    component.openSettingsFromPopover();
+
+    expect(component.isHeaderActionsPopoverOpen).toBe(false);
+    expect(navigateByUrlSpy).not.toHaveBeenCalled();
+
+    component.onHeaderActionsPopoverDidDismiss();
+
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/settings');
+  });
+
+  it('onHeaderActionsPopoverDidDismiss without pending action only closes popover', () => {
+    const component = createComponent();
+    const navigateSpy = vi.spyOn(routerMock, 'navigate');
+    const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
+    component.isHeaderActionsPopoverOpen = true;
+
+    component.onHeaderActionsPopoverDidDismiss();
+
+    expect(component.isHeaderActionsPopoverOpen).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+    expect(navigateByUrlSpy).not.toHaveBeenCalled();
   });
 
   it('exportSelectedGamesFromPopover closes bulk menu and exports selected games', async () => {

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -219,6 +219,7 @@ export class ListPageComponent {
   bulkActionsPopoverEvent: Event | undefined = undefined;
   isHeaderActionsPopoverOpen = false;
   headerActionsPopoverEvent: Event | undefined = undefined;
+  private _pendingHeaderAction: (() => void) | null = null;
   isDesktop = false;
   @ViewChild(GameListComponent) private gameListComponent?: GameListComponent;
   @ViewChild('quickActionsFab') private quickActionsFab?: IonFab;
@@ -770,25 +771,26 @@ export class ListPageComponent {
     this.gameListComponent?.openGameDetail(randomGame);
   }
 
-  async openSettingsFromPopover(): Promise<void> {
+  openSettingsFromPopover(): void {
+    this._pendingHeaderAction = () => void this.router.navigateByUrl('/settings');
     this.closeHeaderActionsPopover();
-    await this.router.navigateByUrl('/settings');
   }
 
-  async openTagsFromPopover(): Promise<void> {
+  openTagsFromPopover(): void {
+    this._pendingHeaderAction = () => void this.router.navigateByUrl('/tags');
     this.closeHeaderActionsPopover();
-    await this.router.navigateByUrl('/tags');
   }
 
-  async openViewsFromPopover(): Promise<void> {
+  openViewsFromPopover(): void {
+    this._pendingHeaderAction = () =>
+      void this.router.navigate(['/views'], {
+        state: {
+          listType: this.listType,
+          filters: this.filters,
+          groupBy: this.groupBy,
+        },
+      });
     this.closeHeaderActionsPopover();
-    await this.router.navigate(['/views'], {
-      state: {
-        listType: this.listType,
-        filters: this.filters,
-        groupBy: this.groupBy,
-      },
-    });
   }
 
   private openAddGameDetailShortcutSearchUrl(provider: DetailWebsiteSearchProvider): string | null {
@@ -1067,6 +1069,13 @@ export class ListPageComponent {
   closeHeaderActionsPopover(): void {
     this.isHeaderActionsPopoverOpen = false;
     this.headerActionsPopoverEvent = undefined;
+  }
+
+  onHeaderActionsPopoverDidDismiss(): void {
+    this.closeHeaderActionsPopover();
+    const action = this._pendingHeaderAction;
+    this._pendingHeaderAction = null;
+    action?.();
   }
 
   onGroupByChange(value: GameGroupByField | null | undefined): void {

--- a/src/environments/environment.local.example.ts
+++ b/src/environments/environment.local.example.ts
@@ -20,5 +20,6 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
+    requireAuth: true,
   },
 };

--- a/src/environments/environment.local.example.ts
+++ b/src/environments/environment.local.example.ts
@@ -20,6 +20,5 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
-    requireAuth: true,
   },
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -14,6 +14,5 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
-    requireAuth: true,
   },
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -14,5 +14,6 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
+    requireAuth: true,
   },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -25,6 +25,7 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
+    requireAuth: true,
   },
 };
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -25,7 +25,6 @@ export const environment = {
     e2eFixtures: false,
     recommendationsExploreEnabled: true,
     tasEnabled: false,
-    requireAuth: true,
   },
 };
 


### PR DESCRIPTION
## Summary

Two targeted fixes:

1. Adds a `requireAuth` runtime feature flag (controlled via `REQUIRE_AUTH` env var) that skips the native write-token alert when set to `false`. The flag defaults to `true` in all environments, preserving existing behaviour unless explicitly overridden.
2. Fixes a popover navigation race condition in `ListPageComponent` — navigation to Settings, Tags, and Views is now deferred until the `(didDismiss)` event fires, ensuring the popover animation completes before the route changes.

## Type of change

- [x] feat (new feature)
- [x] fix (bug fix)

## Implementation details

- `REQUIRE_AUTH` env var parsed in both `generate-runtime-config.mjs` and `write-environment-ios.mjs` (default `true`).
- `isAuthRequired()` exported from `runtime-config.ts`, following the same `parseBoolean` + environment-fallback pattern used by other feature flags.
- `AppComponent.promptForWriteTokenIfNeeded()` returns early when `isAuthRequired()` is `false`.
- `openSettingsFromPopover`, `openTagsFromPopover`, `openViewsFromPopover` now store a `_pendingHeaderAction` closure and close the popover; `onHeaderActionsPopoverDidDismiss()` executes the action after dismissal.
- HTML binding updated from `(didDismiss)="closeHeaderActionsPopover()"` to `(didDismiss)="onHeaderActionsPopoverDidDismiss()"`.
- `requireAuth: true` added to all environment files (`environment.ts`, `environment.prod.ts`, `environment.local.example.ts`).

## Testing performed

- `npm run lint` — passed
- `npm run test` — 1492/1492 passed
- `npm run build` — succeeded (pre-existing budget warning, not introduced by this branch)
- New unit tests: `isAuthRequired()` (5 cases), skip-auth-prompt path (1 case), all three popover-deferral flows + no-pending-action dismiss (4 cases)

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #