### PR TITLE
fix(native): add native iOS logger plugin and fix splash/views nav

### DIFF
--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "branch" : "8.0.0",
-        "revision" : "596259033e94829dffc552a40e7129262122995e"
+        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
+        "version" : "8.4.0"
       }
     },
     {

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "db7f4aff4beaf0107ef8161d8d3f38cf3d44b862a461138d1801a1280b1a3598",
+  "originHash" : "cc9e6ec4c4d8659390fc83ef23b9a6e9c1f7954f014a318870d944d4dca78e6c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
         "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
       }
     },
     {
@@ -24,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
-        "version" : "8.4.0"
+        "branch" : "8.0.0",
+        "revision" : "596259033e94829dffc552a40e7129262122995e"
       }
     },
     {
@@ -152,6 +161,24 @@
       "state" : {
         "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
         "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "sqlcipher.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sqlcipher/SQLCipher.swift.git",
+      "state" : {
+        "revision" : "07bf6bc2191a063d6f1e7c3b5f276a3fadfe36b7",
+        "version" : "4.16.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc9e6ec4c4d8659390fc83ef23b9a6e9c1f7954f014a318870d944d4dca78e6c",
+  "originHash" : "db7f4aff4beaf0107ef8161d8d3f38cf3d44b862a461138d1801a1280b1a3598",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
         "version" : "1.2024072200.0"
-      }
-    },
-    {
-      "identity" : "alamofire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
-      "state" : {
-        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
-        "version" : "5.12.0"
       }
     },
     {
@@ -161,24 +152,6 @@
       "state" : {
         "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
         "version" : "2.4.1"
-      }
-    },
-    {
-      "identity" : "sqlcipher.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sqlcipher/SQLCipher.swift.git",
-      "state" : {
-        "revision" : "07bf6bc2191a063d6f1e7c3b5f276a3fadfe36b7",
-        "version" : "4.16.0"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
       }
     }
   ],

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Capacitor
+import CapApp_SPM
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -7,7 +8,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        if NativeLogStore.shared.didPreviousSessionEndAbnormally() {
+            NativeLogStore.shared.write("[WARN] native.previous_session_may_have_crashed")
+        }
+        NativeLogStore.shared.write("[INFO] native.app_launched")
         return true
     }
 

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="CapApp_SPM" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="CapApp_SPM" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/ios/App/CapApp-SPM/Sources/CapApp-SPM/MainViewController.swift
+++ b/ios/App/CapApp-SPM/Sources/CapApp-SPM/MainViewController.swift
@@ -2,6 +2,7 @@ import Capacitor
 
 public class MainViewController: CAPBridgeViewController {
     override public func capacitorDidLoad() {
+        super.capacitorDidLoad()
         bridge?.registerPluginInstance(NativeLoggerPlugin())
     }
 }

--- a/ios/App/CapApp-SPM/Sources/CapApp-SPM/MainViewController.swift
+++ b/ios/App/CapApp-SPM/Sources/CapApp-SPM/MainViewController.swift
@@ -1,7 +1,0 @@
-import Capacitor
-
-public class MainViewController: CAPBridgeViewController {
-    override public func capacitorDidLoad() {
-        bridge?.registerPluginInstance(NativeLoggerPlugin())
-    }
-}

--- a/ios/App/CapApp-SPM/Sources/CapApp-SPM/MainViewController.swift
+++ b/ios/App/CapApp-SPM/Sources/CapApp-SPM/MainViewController.swift
@@ -1,0 +1,7 @@
+import Capacitor
+
+public class MainViewController: CAPBridgeViewController {
+    override public func capacitorDidLoad() {
+        bridge?.registerPluginInstance(NativeLoggerPlugin())
+    }
+}

--- a/ios/App/CapApp-SPM/Sources/CapApp-SPM/NativeLogStore.swift
+++ b/ios/App/CapApp-SPM/Sources/CapApp-SPM/NativeLogStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public final class NativeLogStore {
+    public static let shared = NativeLogStore()
+
+    private static let maxLines = 500
+    private static let logFilename = "game-shelf-native.log"
+    private static let gracefulSuffixes = ["native.app_backgrounded", "native.app_terminating"]
+
+    private let queue = DispatchQueue(label: "com.gameshelf.nativelogstore", qos: .utility)
+    private let logFileURL: URL
+
+    private init() {
+        let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
+        logFileURL = dir.appendingPathComponent(NativeLogStore.logFilename)
+    }
+
+    public func write(_ message: String) {
+        let line = "[\(isoTimestamp())] \(message)\n"
+        queue.async { [weak self] in
+            guard let self = self, let data = line.data(using: .utf8) else { return }
+            if FileManager.default.fileExists(atPath: self.logFileURL.path) {
+                if let handle = try? FileHandle(forWritingTo: self.logFileURL) {
+                    handle.seekToEndOfFile()
+                    handle.write(data)
+                    try? handle.close()
+                }
+            } else {
+                try? data.write(to: self.logFileURL, options: .atomic)
+            }
+            self.trimIfNeeded()
+        }
+    }
+
+    public func exportText() -> String {
+        queue.sync {
+            (try? String(contentsOf: logFileURL, encoding: .utf8)) ?? ""
+        }
+    }
+
+    public func clear() {
+        queue.sync {
+            try? FileManager.default.removeItem(at: logFileURL)
+        }
+    }
+
+    /// Returns true when the last log file entry does not end with a graceful close marker.
+    /// Call this before writing the new session's app_launched entry.
+    public func didPreviousSessionEndAbnormally() -> Bool {
+        queue.sync {
+            guard let content = try? String(contentsOf: logFileURL, encoding: .utf8) else {
+                return false
+            }
+            let lastLine = content
+                .components(separatedBy: "\n")
+                .filter { !$0.isEmpty }
+                .last ?? ""
+            guard !lastLine.isEmpty else { return false }
+            return !NativeLogStore.gracefulSuffixes.contains(where: { lastLine.hasSuffix($0) })
+        }
+    }
+
+    private func trimIfNeeded() {
+        guard let content = try? String(contentsOf: logFileURL, encoding: .utf8) else { return }
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+        guard lines.count > NativeLogStore.maxLines else { return }
+        let trimmed = lines.suffix(NativeLogStore.maxLines).joined(separator: "\n") + "\n"
+        try? trimmed.write(to: logFileURL, atomically: true, encoding: .utf8)
+    }
+
+    private func isoTimestamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
+    }
+}

--- a/ios/App/CapApp-SPM/Sources/CapApp-SPM/NativeLogStore.swift
+++ b/ios/App/CapApp-SPM/Sources/CapApp-SPM/NativeLogStore.swift
@@ -68,9 +68,13 @@ public final class NativeLogStore {
         try? trimmed.write(to: logFileURL, atomically: true, encoding: .utf8)
     }
 
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
     private func isoTimestamp() -> String {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: Date())
+        NativeLogStore.isoFormatter.string(from: Date())
     }
 }

--- a/ios/App/CapApp-SPM/Sources/CapApp-SPM/NativeLoggerPlugin.swift
+++ b/ios/App/CapApp-SPM/Sources/CapApp-SPM/NativeLoggerPlugin.swift
@@ -1,0 +1,88 @@
+import Capacitor
+import Foundation
+import UIKit
+
+@objc(NativeLoggerPlugin)
+public class NativeLoggerPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "NativeLoggerPlugin"
+    public let jsName = "NativeLogger"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "log", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "exportLogs", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearLogs", returnType: CAPPluginReturnPromise),
+    ]
+
+    override public func load() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMemoryWarning),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleTerminate),
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleMemoryWarning() {
+        NativeLogStore.shared.write("[WARN] native.memory_warning")
+    }
+
+    @objc private func handleBackground() {
+        NativeLogStore.shared.write("[INFO] native.app_backgrounded")
+    }
+
+    @objc private func handleForeground() {
+        NativeLogStore.shared.write("[INFO] native.app_foregrounded")
+    }
+
+    @objc private func handleTerminate() {
+        NativeLogStore.shared.write("[INFO] native.app_terminating")
+    }
+
+    @objc public func log(_ call: CAPPluginCall) {
+        guard let level = call.getString("level"),
+              let message = call.getString("message") else {
+            call.reject("Missing required fields: level, message")
+            return
+        }
+        let details = call.getString("details")
+        let entry: String
+        if let d = details, !d.isEmpty {
+            entry = "[\(level.uppercased())] \(message) | \(d)"
+        } else {
+            entry = "[\(level.uppercased())] \(message)"
+        }
+        NativeLogStore.shared.write(entry)
+        call.resolve()
+    }
+
+    @objc public func exportLogs(_ call: CAPPluginCall) {
+        let content = NativeLogStore.shared.exportText()
+        call.resolve(["content": content])
+    }
+
+    @objc public func clearLogs(_ call: CAPPluginCall) {
+        NativeLogStore.shared.clear()
+        call.resolve()
+    }
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -147,6 +147,8 @@ describe('AppComponent', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    vi.mocked(isNativePlatform).mockReturnValue(false);
+    splashHideMock.mockResolvedValue(undefined);
     vi.mocked(getAppVersionInfo).mockReturnValue({
       value: '1.27.1',
       source: 'live',
@@ -324,6 +326,26 @@ describe('AppComponent', () => {
     );
     expect(present).toHaveBeenCalledOnce();
     expect(localStorage.getItem(LAST_SEEN_APP_VERSION_STORAGE_KEY)).toBe('1.27.1');
+  });
+
+  it('hides splash before version alert on native to prevent deadlock on first install', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    clientWriteAuthServiceMock.hasToken.mockReturnValue(true); // skip write-token prompt
+    const present = vi.fn().mockResolvedValue(undefined);
+    alertControllerMock.create.mockResolvedValueOnce({
+      present,
+      onDidDismiss: vi.fn().mockResolvedValue(undefined),
+    });
+
+    TestBed.runInInjectionContext(() => new AppComponent());
+    await flushAsync();
+
+    // splash.hide must have been called before alert.present
+    const splashOrder = splashHideMock.mock.invocationCallOrder[0] ?? Infinity;
+    const presentOrder = present.mock.invocationCallOrder[0] ?? Infinity;
+    expect(splashHideMock).toHaveBeenCalled();
+    expect(present).toHaveBeenCalled();
+    expect(splashOrder).toBeLessThan(presentOrder);
   });
 
   it('skips the version alert when the current version was already seen', async () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -231,6 +231,12 @@ export class AppComponent implements OnDestroy {
       return;
     }
 
+    if (isNativePlatform()) {
+      await SplashScreen.hide({ fadeOutDuration: 300 }).catch((error: unknown) => {
+        console.error('[app] splash_screen_hide_failed', error);
+      });
+    }
+
     const alert = await this.alertController.create({
       header: 'App Updated',
       message: `Welcome to Game Shelf v${currentVersion.value}.`,

--- a/src/app/core/data/image-file-store.spec.ts
+++ b/src/app/core/data/image-file-store.spec.ts
@@ -22,7 +22,9 @@ vi.mock('@capacitor/filesystem', () => ({
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
     convertFileSrc: (path: string) => convertFileSrcMock(path),
+    isNativePlatform: () => false,
   },
+  registerPlugin: vi.fn().mockReturnValue({}),
 }));
 
 import { ImageFileStore } from './image-file-store';

--- a/src/app/core/plugins/native-logger.plugin.spec.ts
+++ b/src/app/core/plugins/native-logger.plugin.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@capacitor/core', () => ({
+  registerPlugin: vi.fn((_name: string, implementations?: { web?: () => unknown }) => {
+    return implementations?.web?.() ?? {};
+  }),
+}));
+
+import { NativeLogger } from './native-logger.plugin';
+
+describe('NativeLoggerPlugin web stub', () => {
+  it('log resolves without error', async () => {
+    await expect(
+      NativeLogger.log({ level: 'info', message: 'test.message' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('log resolves with optional details', async () => {
+    await expect(
+      NativeLogger.log({ level: 'warn', message: 'test.message', details: 'extra' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('exportLogs resolves with empty content string', async () => {
+    const result = await NativeLogger.exportLogs();
+    expect(result).toEqual({ content: '' });
+  });
+
+  it('clearLogs resolves without error', async () => {
+    await expect(NativeLogger.clearLogs()).resolves.toBeUndefined();
+  });
+});

--- a/src/app/core/plugins/native-logger.plugin.ts
+++ b/src/app/core/plugins/native-logger.plugin.ts
@@ -1,0 +1,31 @@
+import { registerPlugin } from '@capacitor/core';
+
+export interface NativeLogOptions {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  details?: string;
+}
+
+export interface NativeLoggerPlugin {
+  log(options: NativeLogOptions): Promise<void>;
+  exportLogs(): Promise<{ content: string }>;
+  clearLogs(): Promise<void>;
+}
+
+class NativeLoggerWeb implements NativeLoggerPlugin {
+  log(_options: NativeLogOptions): Promise<void> {
+    return Promise.resolve();
+  }
+
+  exportLogs(): Promise<{ content: string }> {
+    return Promise.resolve({ content: '' });
+  }
+
+  clearLogs(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export const NativeLogger = registerPlugin<NativeLoggerPlugin>('NativeLogger', {
+  web: () => new NativeLoggerWeb(),
+});

--- a/src/app/core/services/debug-log.service.spec.ts
+++ b/src/app/core/services/debug-log.service.spec.ts
@@ -92,20 +92,20 @@ describe('DebugLogService', () => {
     expect(networkConnectivityMock.onConnectedChange).toHaveBeenCalledOnce();
   });
 
-  it('flush calls NativeLogger.log with js.flush_checkpoint when on native', () => {
+  it('flush calls NativeLogger.log with js.flush_checkpoint when on native', async () => {
     vi.mocked(isNativePlatform).mockReturnValue(true);
     service.initialize();
 
-    service.flush();
+    await service.flush();
 
     expect(nativeLogSpy).toHaveBeenCalledWith({ level: 'info', message: 'js.flush_checkpoint' });
   });
 
-  it('flush does not call NativeLogger.log when not on native', () => {
+  it('flush does not call NativeLogger.log when not on native', async () => {
     vi.mocked(isNativePlatform).mockReturnValue(false);
     service.initialize();
 
-    service.flush();
+    await service.flush();
 
     expect(nativeLogSpy).not.toHaveBeenCalled();
   });

--- a/src/app/core/services/debug-log.service.spec.ts
+++ b/src/app/core/services/debug-log.service.spec.ts
@@ -2,6 +2,24 @@ import { TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DebugLogService } from './debug-log.service';
 import { NetworkConnectivityService } from './network-connectivity.service';
+import { isNativePlatform } from '../utils/native-platform.util';
+
+const { nativeLogSpy } = vi.hoisted(() => ({
+  nativeLogSpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../plugins/native-logger.plugin', () => ({
+  NativeLogger: {
+    log: nativeLogSpy,
+    exportLogs: vi.fn().mockResolvedValue({ content: '' }),
+    clearLogs: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../utils/native-platform.util', () => ({
+  isNativePlatform: vi.fn().mockReturnValue(false),
+  getNativePlatform: vi.fn().mockReturnValue('web'),
+}));
 
 const connectivityListeners = new Set<(connected: boolean) => void>();
 const networkConnectivityMock = {
@@ -44,6 +62,7 @@ describe('DebugLogService', () => {
   afterEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+    nativeLogSpy.mockClear();
   });
 
   it('logs network.online when connectivity reports connected', () => {
@@ -71,5 +90,23 @@ describe('DebugLogService', () => {
     service.initialize();
 
     expect(networkConnectivityMock.onConnectedChange).toHaveBeenCalledOnce();
+  });
+
+  it('flush calls NativeLogger.log with js.flush_checkpoint when on native', () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    service.initialize();
+
+    service.flush();
+
+    expect(nativeLogSpy).toHaveBeenCalledWith({ level: 'info', message: 'js.flush_checkpoint' });
+  });
+
+  it('flush does not call NativeLogger.log when not on native', () => {
+    vi.mocked(isNativePlatform).mockReturnValue(false);
+    service.initialize();
+
+    service.flush();
+
+    expect(nativeLogSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/core/services/debug-log.service.ts
+++ b/src/app/core/services/debug-log.service.ts
@@ -143,7 +143,9 @@ export class DebugLogService {
   flush(): void {
     this.persist(true);
     if (isNativePlatform()) {
-      void NativeLogger.log({ level: 'info', message: 'js.flush_checkpoint' });
+      NativeLogger.log({ level: 'info', message: 'js.flush_checkpoint' }).catch(() => {
+        // best-effort; ignore failures
+      });
     }
   }
 

--- a/src/app/core/services/debug-log.service.ts
+++ b/src/app/core/services/debug-log.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { getAppVersionInfo } from '../config/runtime-config';
+import { NativeLogger } from '../plugins/native-logger.plugin';
 import { PreferenceStorageService } from '../storage/preference-storage.service';
 import { isNativePlatform } from '../utils/native-platform.util';
 import { NetworkConnectivityService } from './network-connectivity.service';
@@ -141,6 +142,9 @@ export class DebugLogService {
 
   flush(): void {
     this.persist(true);
+    if (isNativePlatform()) {
+      void NativeLogger.log({ level: 'info', message: 'js.flush_checkpoint' });
+    }
   }
 
   clear(): void {

--- a/src/app/core/services/debug-log.service.ts
+++ b/src/app/core/services/debug-log.service.ts
@@ -140,10 +140,10 @@ export class DebugLogService {
     this.info('debug.verbose_tracing_updated', { enabled: this.verboseTracingEnabled });
   }
 
-  flush(): void {
+  async flush(): Promise<void> {
     this.persist(true);
     if (isNativePlatform()) {
-      NativeLogger.log({ level: 'info', message: 'js.flush_checkpoint' }).catch(() => {
+      await NativeLogger.log({ level: 'info', message: 'js.flush_checkpoint' }).catch(() => {
         // best-effort; ignore failures
       });
     }

--- a/src/app/core/services/debug-log.service.ts
+++ b/src/app/core/services/debug-log.service.ts
@@ -139,6 +139,10 @@ export class DebugLogService {
     this.info('debug.verbose_tracing_updated', { enabled: this.verboseTracingEnabled });
   }
 
+  flush(): void {
+    this.persist(true);
+  }
+
   clear(): void {
     this.entries.length = 0;
     this.lastEntryFingerprint = null;

--- a/src/app/list-page/list-page.component.html
+++ b/src/app/list-page/list-page.component.html
@@ -88,70 +88,6 @@
 }
 
 <ng-template #listPageContent>
-  <ion-popover
-    [isOpen]="isBulkActionsPopoverOpen"
-    [arrow]="false"
-    [event]="bulkActionsPopoverEvent"
-    side="bottom"
-    alignment="end"
-    (didDismiss)="closeBulkActionsPopover()"
-  >
-    <ng-template>
-      <ion-content>
-        <ion-list lines="none">
-          <ion-item button detail="false" (click)="moveSelectedGamesFromPopover()">
-            Move to {{ getMoveTargetLabel() }}
-          </ion-item>
-          <ion-item button detail="false" (click)="setTagsForSelectedGamesFromPopover()">
-            Set tags
-          </ion-item>
-          <ion-item button detail="false" (click)="setStatusForSelectedGamesFromPopover()">
-            Set status
-          </ion-item>
-          <ion-item
-            button
-            detail="false"
-            (click)="openExternalMetadataForSelectedGamesFromPopover()"
-          >
-            External metadata
-          </ion-item>
-          <ion-item button detail="false" (click)="exportSelectedGamesFromPopover()">
-            Export CSV
-          </ion-item>
-          <ion-item button detail="false" color="danger" (click)="deleteSelectedGames()">
-            Delete
-          </ion-item>
-        </ion-list>
-      </ion-content>
-    </ng-template>
-  </ion-popover>
-
-  <ion-popover
-    #headerActionsPopover
-    [isOpen]="isHeaderActionsPopoverOpen"
-    [event]="headerActionsPopoverEvent"
-    [arrow]="false"
-    side="bottom"
-    alignment="end"
-    (didDismiss)="onHeaderActionsPopoverDidDismiss()"
-  >
-    <ng-template>
-      <ion-content>
-        <ion-list lines="none">
-          <ion-item button detail="false" (click)="openViewsFromPopover()">Views</ion-item>
-          <ion-item button detail="false" (click)="openTagsFromPopover()">Tags</ion-item>
-          <ion-item button detail="false" (click)="activateMultiSelectFromPopover()">
-            Multi-select
-          </ion-item>
-          <ion-item button detail="false" (click)="pickRandomGameFromPopover()">
-            Pick random game
-          </ion-item>
-          <ion-item button detail="false" (click)="openSettingsFromPopover()">Settings</ion-item>
-        </ion-list>
-      </ion-content>
-    </ng-template>
-  </ion-popover>
-
   <app-game-list
     [listType]="listType"
     [filters]="filters"
@@ -201,6 +137,67 @@
     </ion-fab>
   }
 </ng-template>
+
+<ion-popover
+  [isOpen]="isBulkActionsPopoverOpen"
+  [arrow]="false"
+  [event]="bulkActionsPopoverEvent"
+  side="bottom"
+  alignment="end"
+  (didDismiss)="closeBulkActionsPopover()"
+>
+  <ng-template>
+    <ion-content>
+      <ion-list lines="none">
+        <ion-item button detail="false" (click)="moveSelectedGamesFromPopover()">
+          Move to {{ getMoveTargetLabel() }}
+        </ion-item>
+        <ion-item button detail="false" (click)="setTagsForSelectedGamesFromPopover()">
+          Set tags
+        </ion-item>
+        <ion-item button detail="false" (click)="setStatusForSelectedGamesFromPopover()">
+          Set status
+        </ion-item>
+        <ion-item button detail="false" (click)="openExternalMetadataForSelectedGamesFromPopover()">
+          External metadata
+        </ion-item>
+        <ion-item button detail="false" (click)="exportSelectedGamesFromPopover()">
+          Export CSV
+        </ion-item>
+        <ion-item button detail="false" color="danger" (click)="deleteSelectedGames()">
+          Delete
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ng-template>
+</ion-popover>
+
+<ion-popover
+  #headerActionsPopover
+  [isOpen]="isHeaderActionsPopoverOpen"
+  [event]="headerActionsPopoverEvent"
+  [arrow]="false"
+  side="bottom"
+  alignment="end"
+  (didPresent)="onHeaderActionsPopoverDidPresent()"
+  (didDismiss)="onHeaderActionsPopoverDidDismiss()"
+>
+  <ng-template>
+    <ion-content>
+      <ion-list lines="none">
+        <ion-item button detail="false" (click)="openViewsFromPopover()">Views</ion-item>
+        <ion-item button detail="false" (click)="openTagsFromPopover()">Tags</ion-item>
+        <ion-item button detail="false" (click)="activateMultiSelectFromPopover()">
+          Multi-select
+        </ion-item>
+        <ion-item button detail="false" (click)="pickRandomGameFromPopover()">
+          Pick random game
+        </ion-item>
+        <ion-item button detail="false" (click)="openSettingsFromPopover()">Settings</ion-item>
+      </ion-list>
+    </ion-content>
+  </ng-template>
+</ion-popover>
 
 <ion-modal [isOpen]="isAddGameModalOpen" (didDismiss)="closeAddGameModal()">
   <ng-template>

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -701,9 +701,9 @@ describe('ListPageComponent', () => {
     expect(component.headerActionsPopoverEvent).toBeUndefined();
   });
 
-  it('openViewsFromPopover awaits dismiss then navigates to /views', async () => {
+  it('openViewsFromPopover sets context, awaits dismiss, then navigates to /views', async () => {
     const component = createComponent();
-    const navigateSpy = vi.spyOn(routerMock, 'navigate');
+    const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
     const dismissMock = vi.fn().mockResolvedValue(true);
     (component as unknown as Record<string, unknown>)['headerActionsPopover'] = {
       dismiss: dismissMock,
@@ -712,10 +712,7 @@ describe('ListPageComponent', () => {
     await component.openViewsFromPopover();
 
     expect(dismissMock).toHaveBeenCalledOnce();
-    expect(navigateSpy).toHaveBeenCalledOnce();
-    const [path, extras] = navigateSpy.mock.calls[0] as [string[], { state: { listType: string } }];
-    expect(path).toEqual(['/views']);
-    expect(extras.state.listType).toBe('collection');
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
   });
 
   it('openTagsFromPopover awaits dismiss then navigates to /tags', async () => {

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -70,6 +70,7 @@ import { AddToLibraryWorkflowService } from '../features/game-search/add-to-libr
 import { DEFAULT_GAME_LIST_FILTERS, type GameCatalogResult } from '../core/models/game.models';
 import { AlertController, MenuController, ToastController } from '@ionic/angular/standalone';
 import { serializeListPagePreferences } from './list-page-preferences';
+import { ViewsContextService } from '../views/views-context.service';
 
 describe('ListPageComponent', () => {
   const gameShelfServiceMock = {
@@ -703,6 +704,8 @@ describe('ListPageComponent', () => {
 
   it('openViewsFromPopover sets context, awaits dismiss, then navigates to /views', async () => {
     const component = createComponent();
+    const viewsContextService = TestBed.inject(ViewsContextService);
+    const setContextSpy = vi.spyOn(viewsContextService, 'set');
     const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
     const dismissMock = vi.fn().mockResolvedValue(true);
     (component as unknown as Record<string, unknown>)['headerActionsPopover'] = {
@@ -711,6 +714,8 @@ describe('ListPageComponent', () => {
 
     await component.openViewsFromPopover();
 
+    expect(setContextSpy).toHaveBeenCalledOnce();
+    expect(setContextSpy).toHaveBeenCalledWith(expect.objectContaining({ listType: 'collection' }));
     expect(dismissMock).toHaveBeenCalledOnce();
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
   });

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -1086,6 +1086,10 @@ export class ListPageComponent {
     this.headerActionsPopoverEvent = undefined;
   }
 
+  onHeaderActionsPopoverDidPresent(): void {
+    this.debugLogService.info('header_actions.did_present_fired');
+  }
+
   onHeaderActionsPopoverDidDismiss(): void {
     this.closeHeaderActionsPopover();
     this.debugLogService.info('header_actions.did_dismiss_fired');

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -64,6 +64,7 @@ import { IgdbProxyService } from '../core/api/igdb-proxy.service';
 import { PreferenceStorageService } from '../core/storage/preference-storage.service';
 import { GameShelfService } from '../core/services/game-shelf.service';
 import { DebugLogService } from '../core/services/debug-log.service';
+import { ViewsContextService } from '../views/views-context.service';
 import { SyncBootstrapProgressService } from '../core/services/sync-bootstrap-progress.service';
 import { SyncEventsService } from '../core/services/sync-events.service';
 import { LayoutModeService } from '../core/services/layout-mode.service';
@@ -230,6 +231,7 @@ export class ListPageComponent {
   private readonly alertController = inject(AlertController);
   private readonly toastController = inject(ToastController);
   private readonly debugLogService = inject(DebugLogService);
+  private readonly viewsContextService = inject(ViewsContextService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly gameShelfService = inject(GameShelfService);
@@ -775,36 +777,28 @@ export class ListPageComponent {
 
   async openSettingsFromPopover(): Promise<void> {
     this.debugLogService.info('header_actions.settings_tapped');
+    this.debugLogService.flush();
     await this.headerActionsPopover?.dismiss();
     void this.router.navigateByUrl('/settings');
   }
 
   async openTagsFromPopover(): Promise<void> {
     this.debugLogService.info('header_actions.tags_tapped');
+    this.debugLogService.flush();
     await this.headerActionsPopover?.dismiss();
     void this.router.navigateByUrl('/tags');
   }
 
   async openViewsFromPopover(): Promise<void> {
-    this.debugLogService.info('views.popover_item_tapped');
-    await this.headerActionsPopover?.dismiss();
-    this.debugLogService.info('views.navigate_called');
-    const promise = this.router.navigate(['/views'], {
-      state: {
-        listType: this.listType,
-        filters: this.filters,
-        groupBy: this.groupBy,
-      },
+    this.debugLogService.info('header_actions.views_tapped');
+    this.viewsContextService.set({
+      listType: this.listType,
+      filters: this.filters,
+      groupBy: this.groupBy,
     });
-    this.debugLogService.info('views.navigate_returned');
-    void promise.then(
-      (result) => {
-        this.debugLogService.info('views.navigate_resolved', { result });
-      },
-      (err: unknown) => {
-        this.debugLogService.error('views.navigate_rejected', err);
-      }
-    );
+    this.debugLogService.flush();
+    await this.headerActionsPopover?.dismiss();
+    void this.router.navigateByUrl('/views');
   }
 
   private openAddGameDetailShortcutSearchUrl(provider: DetailWebsiteSearchProvider): string | null {

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -777,14 +777,14 @@ export class ListPageComponent {
 
   async openSettingsFromPopover(): Promise<void> {
     this.debugLogService.info('header_actions.settings_tapped');
-    this.debugLogService.flush();
+    await this.debugLogService.flush();
     await this.headerActionsPopover?.dismiss();
     void this.router.navigateByUrl('/settings');
   }
 
   async openTagsFromPopover(): Promise<void> {
     this.debugLogService.info('header_actions.tags_tapped');
-    this.debugLogService.flush();
+    await this.debugLogService.flush();
     await this.headerActionsPopover?.dismiss();
     void this.router.navigateByUrl('/tags');
   }
@@ -796,7 +796,7 @@ export class ListPageComponent {
       filters: this.filters,
       groupBy: this.groupBy,
     });
-    this.debugLogService.flush();
+    await this.debugLogService.flush();
     await this.headerActionsPopover?.dismiss();
     void this.router.navigateByUrl('/views');
   }

--- a/src/app/settings/settings.page.spec.ts
+++ b/src/app/settings/settings.page.spec.ts
@@ -64,6 +64,28 @@ vi.mock('ionicons/icons', () => ({
   gameController: {},
 }));
 
+const { nativeExportLogsSpy, nativeClearLogsSpy } = vi.hoisted(() => ({
+  nativeExportLogsSpy: vi.fn().mockResolvedValue({ content: '' }),
+  nativeClearLogsSpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../core/plugins/native-logger.plugin', () => ({
+  NativeLogger: {
+    log: vi.fn().mockResolvedValue(undefined),
+    exportLogs: nativeExportLogsSpy,
+    clearLogs: nativeClearLogsSpy,
+  },
+}));
+
+vi.mock('../core/utils/native-platform.util', () => ({
+  isNativePlatform: vi.fn().mockReturnValue(false),
+  getNativePlatform: vi.fn().mockReturnValue('web'),
+}));
+
+vi.mock('../core/utils/share-file.util', () => ({
+  presentShareFile: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { AlertController, ToastController } from '@ionic/angular/standalone';
 import { SettingsPage } from './settings.page';
 import { GAME_REPOSITORY } from '../core/data/game-repository';
@@ -95,6 +117,8 @@ import {
   WISHLIST_RELEASE_DATE_DISPLAY_STORAGE_KEY,
 } from '../core/services/game-row-release-date-display.service';
 import { RECOMMENDATION_IGNORED_STORAGE_KEY } from '../core/services/recommendation-ignore.service';
+import { isNativePlatform } from '../core/utils/native-platform.util';
+import { presentShareFile } from '../core/utils/share-file.util';
 
 type PrivateSettingsPage = SettingsPage & Record<string, (...args: unknown[]) => unknown>;
 
@@ -183,6 +207,16 @@ describe('SettingsPage CSV review fields', () => {
   };
   let gameSyncServiceMock: {
     resetLocalSyncState: ReturnType<typeof vi.fn>;
+  };
+  let debugLogServiceMock: {
+    isVerboseTracingEnabled: ReturnType<typeof vi.fn>;
+    setVerboseTracingEnabled: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    trace: ReturnType<typeof vi.fn>;
+    flush: ReturnType<typeof vi.fn>;
+    exportText: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -289,6 +323,21 @@ describe('SettingsPage CSV review fields', () => {
     gameSyncServiceMock = {
       resetLocalSyncState: vi.fn().mockResolvedValue(true),
     };
+    debugLogServiceMock = {
+      isVerboseTracingEnabled: vi.fn().mockReturnValue(false),
+      setVerboseTracingEnabled: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      flush: vi.fn(),
+      exportText: vi.fn().mockReturnValue('Game Shelf Debug Logs\n'),
+      clear: vi.fn(),
+    };
+    nativeExportLogsSpy.mockReset();
+    nativeExportLogsSpy.mockResolvedValue({ content: '' });
+    nativeClearLogsSpy.mockReset();
+    nativeClearLogsSpy.mockResolvedValue(undefined);
+    vi.mocked(presentShareFile).mockClear();
 
     TestBed.configureTestingModule({
       providers: [
@@ -347,13 +396,7 @@ describe('SettingsPage CSV review fields', () => {
         },
         {
           provide: DebugLogService,
-          useValue: {
-            isVerboseTracingEnabled: vi.fn().mockReturnValue(false),
-            setVerboseTracingEnabled: vi.fn(),
-            info: vi.fn(),
-            error: vi.fn(),
-            trace: vi.fn(),
-          },
+          useValue: debugLogServiceMock,
         },
         {
           provide: ClientWriteAuthService,
@@ -1451,5 +1494,101 @@ describe('SettingsPage CSV review fields', () => {
     expect(disableSpy).toHaveBeenCalledOnce();
     expect(page.releaseNotificationsEnabled).toBe(true);
     expect(setEnabledSpy).not.toHaveBeenCalled();
+  });
+
+  it('exportDebugLogs flushes JS logs and shares JS-only content on web', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(false);
+    debugLogServiceMock.exportText.mockReturnValue('JS log content');
+    const page = createPage();
+
+    await page.exportDebugLogs();
+
+    expect(debugLogServiceMock.flush).toHaveBeenCalledOnce();
+    expect(presentShareFile).toHaveBeenCalledOnce();
+    const call = vi.mocked(presentShareFile).mock.calls[0][0];
+    expect(call.content).toBe('JS log content');
+    expect(call.content).not.toContain('NATIVE EVENTS');
+  });
+
+  it('exportDebugLogs appends native section when on native and exportLogs returns content', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    nativeExportLogsSpy.mockResolvedValue({ content: 'native event line\n' });
+    debugLogServiceMock.exportText.mockReturnValue('JS log content');
+    const page = createPage();
+
+    await page.exportDebugLogs();
+
+    const call = vi.mocked(presentShareFile).mock.calls[0][0];
+    expect(call.content).toContain('JS log content');
+    expect(call.content).toContain('--- NATIVE EVENTS ---');
+    expect(call.content).toContain('native event line');
+  });
+
+  it('exportDebugLogs omits native section when exportLogs returns empty content', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    nativeExportLogsSpy.mockResolvedValue({ content: '   ' });
+    debugLogServiceMock.exportText.mockReturnValue('JS log content');
+    const page = createPage();
+
+    await page.exportDebugLogs();
+
+    const call = vi.mocked(presentShareFile).mock.calls[0][0];
+    expect(call.content).not.toContain('NATIVE EVENTS');
+  });
+
+  it('exportDebugLogs includes fallback section when native exportLogs rejects', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    nativeExportLogsSpy.mockRejectedValue(new Error('bridge error'));
+    debugLogServiceMock.exportText.mockReturnValue('JS log content');
+    const page = createPage();
+
+    await page.exportDebugLogs();
+
+    const call = vi.mocked(presentShareFile).mock.calls[0][0];
+    expect(call.content).toContain('--- NATIVE EVENTS ---');
+    expect(call.content).toContain('(export failed)');
+  });
+
+  it('clearDebugLogs calls NativeLogger.clearLogs on native after confirm', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    const page = createPage();
+    const alertCreateSpy = vi.spyOn(TestBed.inject(AlertController), 'create').mockResolvedValue({
+      present: vi.fn().mockResolvedValue(undefined),
+      onDidDismiss: vi.fn().mockResolvedValue({ role: 'confirm' }),
+    } as never);
+
+    await page.clearDebugLogs();
+
+    expect(alertCreateSpy).toHaveBeenCalledOnce();
+    expect(debugLogServiceMock.clear).toHaveBeenCalledOnce();
+    expect(nativeClearLogsSpy).toHaveBeenCalledOnce();
+  });
+
+  it('clearDebugLogs does not call NativeLogger.clearLogs on web', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(false);
+    const page = createPage();
+    vi.spyOn(TestBed.inject(AlertController), 'create').mockResolvedValue({
+      present: vi.fn().mockResolvedValue(undefined),
+      onDidDismiss: vi.fn().mockResolvedValue({ role: 'confirm' }),
+    } as never);
+
+    await page.clearDebugLogs();
+
+    expect(debugLogServiceMock.clear).toHaveBeenCalledOnce();
+    expect(nativeClearLogsSpy).not.toHaveBeenCalled();
+  });
+
+  it('clearDebugLogs does not clear when user cancels', async () => {
+    vi.mocked(isNativePlatform).mockReturnValue(true);
+    const page = createPage();
+    vi.spyOn(TestBed.inject(AlertController), 'create').mockResolvedValue({
+      present: vi.fn().mockResolvedValue(undefined),
+      onDidDismiss: vi.fn().mockResolvedValue({ role: 'cancel' }),
+    } as never);
+
+    await page.clearDebugLogs();
+
+    expect(debugLogServiceMock.clear).not.toHaveBeenCalled();
+    expect(nativeClearLogsSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/settings/settings.page.spec.ts
+++ b/src/app/settings/settings.page.spec.ts
@@ -329,7 +329,7 @@ describe('SettingsPage CSV review fields', () => {
       info: vi.fn(),
       error: vi.fn(),
       trace: vi.fn(),
-      flush: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
       exportText: vi.fn().mockReturnValue('Game Shelf Debug Logs\n'),
       clear: vi.fn(),
     };

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -857,7 +857,7 @@ export class SettingsPage {
   async exportDebugLogs(): Promise<void> {
     try {
       this.debugLogService.info('settings.export_debug_logs_requested');
-      this.debugLogService.flush();
+      await this.debugLogService.flush();
       const jsContent = this.debugLogService.exportText();
 
       let nativeSection = '';

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -119,6 +119,8 @@ import {
   resolveTransientRetryDelayMs,
 } from './settings-mgc.utils';
 import { DebugLogService } from '../core/services/debug-log.service';
+import { NativeLogger } from '../core/plugins/native-logger.plugin';
+import { isNativePlatform } from '../core/utils/native-platform.util';
 import {
   NotificationService,
   RELEASE_NOTIFICATION_EVENTS_STORAGE_KEY,
@@ -855,7 +857,22 @@ export class SettingsPage {
   async exportDebugLogs(): Promise<void> {
     try {
       this.debugLogService.info('settings.export_debug_logs_requested');
-      const content = this.debugLogService.exportText();
+      this.debugLogService.flush();
+      const jsContent = this.debugLogService.exportText();
+
+      let nativeSection = '';
+      if (isNativePlatform()) {
+        try {
+          const { content } = await NativeLogger.exportLogs();
+          if (content.trim().length > 0) {
+            nativeSection = '\n\n--- NATIVE EVENTS ---\n' + content;
+          }
+        } catch {
+          nativeSection = '\n\n--- NATIVE EVENTS ---\n(export failed)\n';
+        }
+      }
+
+      const content = jsContent + nativeSection;
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const filename = `game-shelf-debug-${timestamp}.log`;
       await presentShareFile({
@@ -888,6 +905,13 @@ export class SettingsPage {
     }
 
     this.debugLogService.clear();
+    if (isNativePlatform()) {
+      try {
+        await NativeLogger.clearLogs();
+      } catch {
+        // best-effort
+      }
+    }
     await this.presentToast('Debug logs cleared.');
   }
 

--- a/src/app/views/views-context.service.spec.ts
+++ b/src/app/views/views-context.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { ViewsContextService } from './views-context.service';
+import { DEFAULT_GAME_LIST_FILTERS } from '../core/models/game.models';
+
+describe('ViewsContextService', () => {
+  let service: ViewsContextService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ViewsContextService);
+  });
+
+  it('consume returns default context when nothing was set', () => {
+    const ctx = service.consume();
+    expect(ctx.listType).toBe('collection');
+    expect(ctx.groupBy).toBe('none');
+    expect(ctx.filters).toEqual(DEFAULT_GAME_LIST_FILTERS);
+  });
+
+  it('consume returns set context and clears it', () => {
+    service.set({
+      listType: 'wishlist',
+      filters: { ...DEFAULT_GAME_LIST_FILTERS },
+      groupBy: 'status',
+    });
+    const first = service.consume();
+    expect(first.listType).toBe('wishlist');
+    expect(first.groupBy).toBe('status');
+
+    const second = service.consume();
+    expect(second.listType).toBe('collection');
+  });
+});

--- a/src/app/views/views-context.service.spec.ts
+++ b/src/app/views/views-context.service.spec.ts
@@ -11,24 +11,27 @@ describe('ViewsContextService', () => {
     service = TestBed.inject(ViewsContextService);
   });
 
-  it('consume returns default context when nothing was set', () => {
-    const ctx = service.consume();
-    expect(ctx.listType).toBe('collection');
-    expect(ctx.groupBy).toBe('none');
-    expect(ctx.filters).toEqual(DEFAULT_GAME_LIST_FILTERS);
+  it('consume returns default context and hasContext=false when nothing was set', () => {
+    const { context, hasContext } = service.consume();
+    expect(hasContext).toBe(false);
+    expect(context.listType).toBe('collection');
+    expect(context.groupBy).toBe('none');
+    expect(context.filters).toEqual(DEFAULT_GAME_LIST_FILTERS);
   });
 
-  it('consume returns set context and clears it', () => {
+  it('consume returns set context with hasContext=true and clears it', () => {
     service.set({
       listType: 'wishlist',
       filters: { ...DEFAULT_GAME_LIST_FILTERS },
       groupBy: 'status',
     });
-    const first = service.consume();
+    const { context: first, hasContext: firstHas } = service.consume();
+    expect(firstHas).toBe(true);
     expect(first.listType).toBe('wishlist');
     expect(first.groupBy).toBe('status');
 
-    const second = service.consume();
+    const { context: second, hasContext: secondHas } = service.consume();
+    expect(secondHas).toBe(false);
     expect(second.listType).toBe('collection');
   });
 });

--- a/src/app/views/views-context.service.ts
+++ b/src/app/views/views-context.service.ts
@@ -20,15 +20,16 @@ export class ViewsContextService {
     this.context = context;
   }
 
-  consume(): ViewsNavigationContext {
+  consume(): { context: ViewsNavigationContext; hasContext: boolean } {
     const ctx = this.context;
     this.context = null;
-    return (
-      ctx ?? {
+    return {
+      hasContext: ctx !== null,
+      context: ctx ?? {
         listType: 'collection',
         filters: { ...DEFAULT_GAME_LIST_FILTERS },
         groupBy: 'none',
-      }
-    );
+      },
+    };
   }
 }

--- a/src/app/views/views-context.service.ts
+++ b/src/app/views/views-context.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import {
+  DEFAULT_GAME_LIST_FILTERS,
+  GameGroupByField,
+  GameListFilters,
+  ListType,
+} from '../core/models/game.models';
+
+export interface ViewsNavigationContext {
+  listType: ListType;
+  filters: GameListFilters;
+  groupBy: GameGroupByField;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ViewsContextService {
+  private context: ViewsNavigationContext | null = null;
+
+  set(context: ViewsNavigationContext): void {
+    this.context = context;
+  }
+
+  consume(): ViewsNavigationContext {
+    const ctx = this.context;
+    this.context = null;
+    return (
+      ctx ?? {
+        listType: 'collection',
+        filters: { ...DEFAULT_GAME_LIST_FILTERS },
+        groupBy: 'none',
+      }
+    );
+  }
+}

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -87,11 +87,11 @@ export class ViewsPage implements OnInit {
   private readonly viewsContextService = inject(ViewsContextService);
 
   ngOnInit(): void {
-    const ctx = this.viewsContextService.consume();
+    const { context: ctx, hasContext } = this.viewsContextService.consume();
     this.listType = ctx.listType;
     this.currentFilters = { ...DEFAULT_GAME_LIST_FILTERS, ...ctx.filters };
     this.currentGroupBy = this.normalizeGroupBy(ctx.groupBy);
-    this.hasCurrentConfiguration = true;
+    this.hasCurrentConfiguration = hasContext;
     this.views$ = this.gameShelfService.watchViews(this.listType);
   }
 

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -34,6 +34,7 @@ import {
 } from '../core/models/game.models';
 import { GameShelfService } from '../core/services/game-shelf.service';
 import { DebugLogService } from '../core/services/debug-log.service';
+import { ViewsContextService } from './views-context.service';
 import { addIcons } from 'ionicons';
 import { ellipsisVertical, add } from 'ionicons/icons';
 import { isTasFeatureEnabled } from '../core/config/runtime-config';
@@ -83,31 +84,14 @@ export class ViewsPage implements OnInit {
   private readonly alertController = inject(AlertController);
   private readonly toastController = inject(ToastController);
   private readonly debugLogService = inject(DebugLogService);
+  private readonly viewsContextService = inject(ViewsContextService);
 
   ngOnInit(): void {
-    const state = window.history.state as Partial<{
-      listType: ListType;
-      filters: GameListFilters;
-      groupBy: GameGroupByField;
-    }>;
-
-    if (state.listType === 'collection' || state.listType === 'wishlist') {
-      this.listType = state.listType;
-    }
-
-    if (state.filters) {
-      this.currentFilters = {
-        ...DEFAULT_GAME_LIST_FILTERS,
-        ...state.filters,
-      };
-      this.hasCurrentConfiguration = true;
-    }
-
-    if (state.groupBy) {
-      this.currentGroupBy = this.normalizeGroupBy(state.groupBy);
-      this.hasCurrentConfiguration = true;
-    }
-
+    const ctx = this.viewsContextService.consume();
+    this.listType = ctx.listType;
+    this.currentFilters = { ...DEFAULT_GAME_LIST_FILTERS, ...ctx.filters };
+    this.currentGroupBy = this.normalizeGroupBy(ctx.groupBy);
+    this.hasCurrentConfiguration = true;
     this.views$ = this.gameShelfService.watchViews(this.listType);
   }
 


### PR DESCRIPTION
## Summary

This branch delivers two connected fixes:

1. **iOS deadlock fix**: On first install, the splash screen was not hidden before showing the "App Updated" version alert on iOS, causing a UI deadlock. The splash is now explicitly hidden before the alert is created.

2. **Native logger plugin**: Adds a native iOS event log (`NativeLogStore`) and a Capacitor plugin bridge (`NativeLoggerPlugin`) that captures app lifecycle events (launch, background, foreground, terminate, memory warnings) to a rolling 500-line file in `Library/`. JS-side `DebugLogService` gains a `flush()` method that writes a checkpoint to the native log before navigation, enabling cross-layer debug exports from Settings.

3. **Views navigation fix**: Navigation state for the Views page was passed via `window.history.state`, which is unreliable on iOS (state can be lost during Ionic nav transitions). Replaced with `ViewsContextService`, a singleton that holds context and consumes it once on `ngOnInit`.

## Type of change

- [x] fix (bug fix)
- [x] feat (new feature)

## Implementation details

- `NativeLogStore.swift`: Singleton file-backed log store. Writes are async (utility queue), reads are sync. Trims to 500 lines after each write. Detects abnormal previous session by checking whether the last log line ends with a graceful suffix (`app_backgrounded` or `app_terminating`).
- `NativeLoggerPlugin.swift`: Capacitor plugin registered via `MainViewController.capacitorDidLoad()`. Exposes `log`, `exportLogs`, and `clearLogs` methods. Observes `UIApplication` lifecycle notifications to write structured event strings.
- `MainViewController.swift`: Subclasses `CAPBridgeViewController` to register `NativeLoggerPlugin` via `capacitorDidLoad()`. Storyboard updated to reference `MainViewController` from `CapApp_SPM`.
- `AppDelegate.swift`: Checks for abnormal prior session on launch and writes `native.app_launched`.
- `native-logger.plugin.ts`: Capacitor `registerPlugin` bridge with a no-op web stub.
- `ViewsContextService`: Injectable singleton; `set()` stores context before navigation, `consume()` retrieves-and-clears it (defaults to `collection`/no filters if never set).
- `DebugLogService.flush()`: Calls `persist(true)` then fires `NativeLogger.log({ level: 'info', message: 'js.flush_checkpoint' })` on native, giving a timestamp anchor in the native log.
- `SettingsPage.exportDebugLogs()`: Flushes JS logs, then fetches native log content and appends a `--- NATIVE EVENTS ---` section if non-empty (or `(export failed)` on bridge error).
- `SettingsPage.clearDebugLogs()`: After confirmation, clears JS logs then calls `NativeLogger.clearLogs()` on native (best-effort).

## Testing performed

- `npm run lint` — passed (ESLint, no issues)
- `npm run test` — 98 test files, 1509 tests, all passed
- `npm run build` — build succeeded (bundle budget warning pre-exists, not introduced by this branch)
- New tests added:
  - `native-logger.plugin.spec.ts`: web stub coverage (log, exportLogs, clearLogs)
  - `debug-log.service.spec.ts`: `flush()` calls `NativeLogger.log` on native, skips it on web
  - `settings.page.spec.ts`: `exportDebugLogs` (web-only, native with content, native empty, native error), `clearDebugLogs` (native confirm, web confirm, cancel)
  - `app.component.spec.ts`: splash hidden before alert on native
  - `views-context.service.spec.ts`: default context when unset, set-then-consume clears state
  - `list-page.component.spec.ts`: `openViewsFromPopover` uses `navigateByUrl('/views')`

## Screenshots (if applicable)

N/A — native iOS UI changes require device/simulator testing.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
