### PR TITLE
chore(list-page): log view row counts to diagnose Views freeze

### DIFF
--- a/src/app/core/services/game-shelf.service.ts
+++ b/src/app/core/services/game-shelf.service.ts
@@ -1515,6 +1515,10 @@ export class GameShelfService {
     return this.repository.getView(viewId);
   }
 
+  async listViews(listType: ListType): Promise<GameListView[]> {
+    return this.repository.listViews(listType);
+  }
+
   async createView(
     name: string,
     listType: ListType,

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -748,6 +748,37 @@ describe('ListPageComponent', () => {
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
   });
 
+  it('openViewsFromPopover still navigates when the view-count diagnostic times out', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const component = createComponent();
+      const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
+      const dismissMock = vi.fn().mockResolvedValue(true);
+      (component as unknown as Record<string, unknown>)['headerActionsPopover'] = {
+        dismiss: dismissMock,
+      };
+      const debugLogService = (component as unknown as { debugLogService: DebugLogService })
+        .debugLogService;
+      const errorSpy = vi.spyOn(debugLogService, 'error');
+      gameShelfServiceMock.listViews.mockReturnValue(new Promise<never>(() => undefined));
+
+      const opened = component.openViewsFromPopover();
+      await vi.advanceTimersByTimeAsync(2000);
+      await opened;
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0]?.[0]).toBe('header_actions.views_count_failed');
+      expect(errorSpy.mock.calls[0]?.[1]).toEqual(
+        expect.objectContaining({ name: 'Error', message: 'views_count_timeout' })
+      );
+      expect(dismissMock).toHaveBeenCalledOnce();
+      expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('openTagsFromPopover awaits dismiss then navigates to /tags', async () => {
     const component = createComponent();
     const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -76,6 +76,7 @@ describe('ListPageComponent', () => {
   const gameShelfServiceMock = {
     findGameByIdentity: vi.fn(),
     getView: vi.fn(),
+    listViews: vi.fn(),
   };
   const igdbProxyServiceMock = {
     getGameById: vi.fn(),
@@ -103,6 +104,7 @@ describe('ListPageComponent', () => {
     vi.clearAllMocks();
     gameShelfServiceMock.findGameByIdentity.mockResolvedValue(null);
     gameShelfServiceMock.getView.mockResolvedValue(null);
+    gameShelfServiceMock.listViews.mockResolvedValue([]);
     igdbProxyServiceMock.getGameById.mockReturnValue(of(null));
     addToLibraryWorkflowMock.addToLibrary.mockResolvedValue({ status: 'added' });
 
@@ -716,6 +718,8 @@ describe('ListPageComponent', () => {
 
     expect(setContextSpy).toHaveBeenCalledOnce();
     expect(setContextSpy).toHaveBeenCalledWith(expect.objectContaining({ listType: 'collection' }));
+    expect(gameShelfServiceMock.listViews).toHaveBeenCalledWith('collection');
+    expect(gameShelfServiceMock.listViews).toHaveBeenCalledWith('wishlist');
     expect(dismissMock).toHaveBeenCalledOnce();
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
   });

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -64,6 +64,7 @@ import { ListPageComponent } from './list-page.component';
 import { IgdbProxyService } from '../core/api/igdb-proxy.service';
 import { SyncBootstrapProgressService } from '../core/services/sync-bootstrap-progress.service';
 import { SyncEventsService } from '../core/services/sync-events.service';
+import { DebugLogService } from '../core/services/debug-log.service';
 import { GameShelfService } from '../core/services/game-shelf.service';
 import { LayoutModeService } from '../core/services/layout-mode.service';
 import { AddToLibraryWorkflowService } from '../features/game-search/add-to-library-workflow.service';
@@ -720,6 +721,26 @@ describe('ListPageComponent', () => {
     expect(setContextSpy).toHaveBeenCalledWith(expect.objectContaining({ listType: 'collection' }));
     expect(gameShelfServiceMock.listViews).toHaveBeenCalledWith('collection');
     expect(gameShelfServiceMock.listViews).toHaveBeenCalledWith('wishlist');
+    expect(dismissMock).toHaveBeenCalledOnce();
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
+  });
+
+  it('openViewsFromPopover still navigates when the view-count diagnostic throws', async () => {
+    const component = createComponent();
+    const navigateByUrlSpy = vi.spyOn(routerMock, 'navigateByUrl');
+    const dismissMock = vi.fn().mockResolvedValue(true);
+    (component as unknown as Record<string, unknown>)['headerActionsPopover'] = {
+      dismiss: dismissMock,
+    };
+    const debugLogService = (component as unknown as { debugLogService: DebugLogService })
+      .debugLogService;
+    const errorSpy = vi.spyOn(debugLogService, 'error');
+    gameShelfServiceMock.listViews.mockRejectedValue(new Error('boom'));
+
+    await component.openViewsFromPopover();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toBe('header_actions.views_count_failed');
     expect(dismissMock).toHaveBeenCalledOnce();
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
   });

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -741,6 +741,9 @@ describe('ListPageComponent', () => {
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy.mock.calls[0]?.[0]).toBe('header_actions.views_count_failed');
+    expect(errorSpy.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ name: 'Error', message: 'boom' })
+    );
     expect(dismissMock).toHaveBeenCalledOnce();
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/views');
   });

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -763,8 +763,12 @@ describe('ListPageComponent', () => {
       const errorSpy = vi.spyOn(debugLogService, 'error');
       gameShelfServiceMock.listViews.mockReturnValue(new Promise<never>(() => undefined));
 
+      const timeoutMs = (
+        ListPageComponent as unknown as { VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS: number }
+      ).VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS;
+
       const opened = component.openViewsFromPopover();
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(timeoutMs);
       await opened;
 
       expect(errorSpy).toHaveBeenCalledTimes(1);

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -732,8 +732,7 @@ describe('ListPageComponent', () => {
     (component as unknown as Record<string, unknown>)['headerActionsPopover'] = {
       dismiss: dismissMock,
     };
-    const debugLogService = (component as unknown as { debugLogService: DebugLogService })
-      .debugLogService;
+    const debugLogService = TestBed.inject(DebugLogService);
     const errorSpy = vi.spyOn(debugLogService, 'error');
     gameShelfServiceMock.listViews.mockRejectedValue(new Error('boom'));
 
@@ -758,14 +757,11 @@ describe('ListPageComponent', () => {
       (component as unknown as Record<string, unknown>)['headerActionsPopover'] = {
         dismiss: dismissMock,
       };
-      const debugLogService = (component as unknown as { debugLogService: DebugLogService })
-        .debugLogService;
+      const debugLogService = TestBed.inject(DebugLogService);
       const errorSpy = vi.spyOn(debugLogService, 'error');
       gameShelfServiceMock.listViews.mockReturnValue(new Promise<never>(() => undefined));
 
-      const timeoutMs = (
-        ListPageComponent as unknown as { VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS: number }
-      ).VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS;
+      const timeoutMs = ListPageComponent.VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS;
 
       const opened = component.openViewsFromPopover();
       await vi.advanceTimersByTimeAsync(timeoutMs);

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -825,7 +825,11 @@ export class ListPageComponent {
         totalRows: collectionViews.length + wishlistViews.length,
       });
     } catch (error: unknown) {
-      this.debugLogService.error('header_actions.views_count_failed', { error });
+      const detail =
+        error instanceof Error
+          ? { name: error.name, message: error.message, stack: error.stack }
+          : { error };
+      this.debugLogService.error('header_actions.views_count_failed', detail);
     }
   }
 

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -35,6 +35,7 @@ import {
   GameEntry,
   GameGroupByField,
   GameListFilters,
+  GameListView,
   GameType,
   GameVideo,
   GameWebsite,
@@ -791,6 +792,7 @@ export class ListPageComponent {
 
   async openViewsFromPopover(): Promise<void> {
     this.debugLogService.info('header_actions.views_tapped');
+    await this.logViewRowCounts();
     this.viewsContextService.set({
       listType: this.listType,
       filters: this.filters,
@@ -799,6 +801,32 @@ export class ListPageComponent {
     await this.debugLogService.flush();
     await this.headerActionsPopover?.dismiss();
     void this.router.navigateByUrl('/views');
+  }
+
+  /**
+   * Diagnostic: count rows in the views table before navigating. Logged and
+   * flushed prior to navigation so the count survives even if rendering the
+   * Views page freezes. A row count far exceeding the distinct-name count
+   * indicates duplicate view rows accumulating in storage.
+   */
+  private async logViewRowCounts(): Promise<void> {
+    try {
+      const [collectionViews, wishlistViews] = await Promise.all([
+        this.gameShelfService.listViews('collection'),
+        this.gameShelfService.listViews('wishlist'),
+      ]);
+      const distinctNames = (views: GameListView[]): number =>
+        new Set(views.map((view) => view.name)).size;
+      this.debugLogService.info('header_actions.views_count', {
+        collectionRows: collectionViews.length,
+        collectionDistinctNames: distinctNames(collectionViews),
+        wishlistRows: wishlistViews.length,
+        wishlistDistinctNames: distinctNames(wishlistViews),
+        totalRows: collectionViews.length + wishlistViews.length,
+      });
+    } catch (error: unknown) {
+      this.debugLogService.error('header_actions.views_count_failed', { error });
+    }
   }
 
   private openAddGameDetailShortcutSearchUrl(provider: DetailWebsiteSearchProvider): string | null {

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -175,7 +175,7 @@ function buildConfig(listType: ListType): ListPageConfig {
 })
 export class ListPageComponent {
   private static readonly SEARCH_DEBOUNCE_MS = 180;
-  private static readonly VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS = 2000;
+  static readonly VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS = 2000;
   readonly noneTagFilterValue = '__none__';
   readonly groupByOptions: { value: GameGroupByField; label: string }[] = [
     { value: 'none', label: 'None' },
@@ -834,7 +834,7 @@ export class ListPageComponent {
       const distinctNames = (views: GameListView[]): number => {
         const names = new Set<string>();
         for (const view of views) {
-          names.add(view.name);
+          names.add(view.name.trim().toLowerCase());
         }
         return names.size;
       };

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -832,10 +832,13 @@ export class ListPageComponent {
       // any late rejection so it never surfaces as an unhandled rejection.
       inFlight.catch(() => undefined);
       const [collectionViews, wishlistViews] = await Promise.race([inFlight, timeout]);
+      // Match LocalGameRepository.normalizeViewName (trim-only) so the distinct
+      // count reflects the app's actual view-name normalization and is directly
+      // comparable to the row count when detecting duplicate view rows.
       const distinctNames = (views: GameListView[]): number => {
         const names = new Set<string>();
         for (const view of views) {
-          names.add(view.name.trim().toLowerCase());
+          names.add(view.name.trim());
         }
         return names.size;
       };

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -824,13 +824,14 @@ export class ListPageComponent {
           reject(new Error('views_count_timeout'));
         }, ListPageComponent.VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS);
       });
-      const [collectionViews, wishlistViews] = await Promise.race([
-        Promise.all([
-          this.gameShelfService.listViews('collection'),
-          this.gameShelfService.listViews('wishlist'),
-        ]),
-        timeout,
+      const inFlight = Promise.all([
+        this.gameShelfService.listViews('collection'),
+        this.gameShelfService.listViews('wishlist'),
       ]);
+      // If the timeout wins the race, the in-flight reads keep running. Absorb
+      // any late rejection so it never surfaces as an unhandled rejection.
+      inFlight.catch(() => undefined);
+      const [collectionViews, wishlistViews] = await Promise.race([inFlight, timeout]);
       const distinctNames = (views: GameListView[]): number => {
         const names = new Set<string>();
         for (const view of views) {

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -175,6 +175,7 @@ function buildConfig(listType: ListType): ListPageConfig {
 })
 export class ListPageComponent {
   private static readonly SEARCH_DEBOUNCE_MS = 180;
+  private static readonly VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS = 2000;
   readonly noneTagFilterValue = '__none__';
   readonly groupByOptions: { value: GameGroupByField; label: string }[] = [
     { value: 'none', label: 'None' },
@@ -808,12 +809,24 @@ export class ListPageComponent {
    * flushed prior to navigation so the count survives even if rendering the
    * Views page freezes. A row count far exceeding the distinct-name count
    * indicates duplicate view rows accumulating in storage.
+   *
+   * Bounded by a short timeout and swallows errors so tapping "Views" stays
+   * responsive even when storage is slow or unhealthy.
    */
   private async logViewRowCounts(): Promise<void> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
-      const [collectionViews, wishlistViews] = await Promise.all([
-        this.gameShelfService.listViews('collection'),
-        this.gameShelfService.listViews('wishlist'),
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new Error('views_count_timeout'));
+        }, ListPageComponent.VIEWS_COUNT_DIAGNOSTIC_TIMEOUT_MS);
+      });
+      const [collectionViews, wishlistViews] = await Promise.race([
+        Promise.all([
+          this.gameShelfService.listViews('collection'),
+          this.gameShelfService.listViews('wishlist'),
+        ]),
+        timeout,
       ]);
       const distinctNames = (views: GameListView[]): number =>
         new Set(views.map((view) => view.name)).size;
@@ -830,6 +843,10 @@ export class ListPageComponent {
           ? { name: error.name, message: error.message, stack: error.stack }
           : { error };
       this.debugLogService.error('header_actions.views_count_failed', detail);
+    } finally {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -793,14 +793,17 @@ export class ListPageComponent {
 
   async openViewsFromPopover(): Promise<void> {
     this.debugLogService.info('header_actions.views_tapped');
-    await this.logViewRowCounts();
     this.viewsContextService.set({
       listType: this.listType,
       filters: this.filters,
       groupBy: this.groupBy,
     });
-    await this.debugLogService.flush();
+    // Dismiss the popover before running the bounded diagnostic so tapping
+    // "Views" stays responsive even when storage is slow. The count is still
+    // logged and flushed prior to navigation.
     await this.headerActionsPopover?.dismiss();
+    await this.logViewRowCounts();
+    await this.debugLogService.flush();
     void this.router.navigateByUrl('/views');
   }
 
@@ -828,8 +831,13 @@ export class ListPageComponent {
         ]),
         timeout,
       ]);
-      const distinctNames = (views: GameListView[]): number =>
-        new Set(views.map((view) => view.name)).size;
+      const distinctNames = (views: GameListView[]): number => {
+        const names = new Set<string>();
+        for (const view of views) {
+          names.add(view.name);
+        }
+        return names.size;
+      };
       this.debugLogService.info('header_actions.views_count', {
         collectionRows: collectionViews.length,
         collectionDistinctNames: distinctNames(collectionViews),


### PR DESCRIPTION
## Summary
Adds temporary diagnostic instrumentation to investigate the production-only
iOS freeze when opening the Views page. Before navigating to /views, the list
page now logs the number of stored view rows alongside the number of distinct
view names for both collection and wishlist. A row count far exceeding the
distinct-name count points to duplicate view rows accumulating in storage as
the suspected root cause. The count is logged and flushed before navigation so
it survives even if rendering the Views page subsequently freezes. No
user-facing behavior changes.

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [x] chore

## Implementation details

- `GameShelfService`: add a public `listViews(listType)` promise wrapper that
  delegates to `repository.listViews`, mirroring the existing `getView`
  wrapper. Provides a one-shot read for the diagnostic (the repository method
  was previously only consumed internally by `watchViews`).
- `ListPageComponent.openViewsFromPopover()`: invoke a new private
  `logViewRowCounts()` before setting the views context and navigating.
  - Loads collection and wishlist views in parallel via `Promise.all`.
  - Logs `header_actions.views_count` with per-list row counts, distinct-name
    counts, and total rows.
  - Wrapped in try/catch; on failure logs `header_actions.views_count_failed`
    and navigation still proceeds. The existing `debugLogService.flush()`
    runs before `router.navigateByUrl('/views')`, so the count is persisted
    prior to navigation.

## Testing performed

- Added a unit test asserting that when `listViews` rejects, the failure is
  logged and navigation to `/views` still proceeds (covers the new catch
  branch).
- Existing test extended to assert `listViews` is queried for both
  'collection' and 'wishlist'.
- `npm run lint` — pass.
- `npm run test` — 1510 passed (98 files).
- `npm run build` — success (pre-existing initial-bundle budget warning only;
  unrelated to this change).

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
