### PR TITLE
fix(views): harden view summary against malformed rows and add diagnostics

### DIFF
--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -131,31 +131,26 @@ describe('ViewsPage', () => {
       expect(debugLogServiceMock.warn).not.toHaveBeenCalled();
     });
 
-    it('falls back to defaults and warns when filters are missing', () => {
+    it('falls back to defaults without side effects when filters are missing', () => {
       const malformed = makeView({ id: 7, name: 'Broken' });
       delete (malformed as Partial<GameListView>).filters;
 
       const summary = component.getViewSummary(malformed);
 
       expect(summary).toBe('Game title ↑ • Group: None');
-      expect(debugLogServiceMock.warn).toHaveBeenCalledWith(
-        'views.page.view_malformed',
-        expect.objectContaining({ id: 7, name: 'Broken', hasFilters: false, hasGroupBy: true })
-      );
-      expect(debugLogServiceMock.flush).toHaveBeenCalled();
+      // getViewSummary runs during change detection, so it must stay
+      // side-effect free — warnings are emitted from the views$ pipeline.
+      expect(debugLogServiceMock.warn).not.toHaveBeenCalled();
     });
 
-    it('normalizes an unknown groupBy to none and warns when groupBy is missing', () => {
+    it('normalizes a missing groupBy to none without side effects', () => {
       const malformed = makeView();
       delete (malformed as Partial<GameListView>).groupBy;
 
       const summary = component.getViewSummary(malformed);
 
       expect(summary).toContain('Group: None');
-      expect(debugLogServiceMock.warn).toHaveBeenCalledWith(
-        'views.page.view_malformed',
-        expect.objectContaining({ hasFilters: true, hasGroupBy: false })
-      );
+      expect(debugLogServiceMock.warn).not.toHaveBeenCalled();
     });
   });
 
@@ -170,6 +165,39 @@ describe('ViewsPage', () => {
       expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.views_emit', {
         count: 1,
       });
+    });
+
+    it('warns once per emission for each malformed view', () => {
+      const malformedFilters = makeView({ id: 7, name: 'Broken' });
+      delete (malformedFilters as Partial<GameListView>).filters;
+      const malformedGroupBy = makeView({ id: 8, name: 'AlsoBroken' });
+      delete (malformedGroupBy as Partial<GameListView>).groupBy;
+      gameShelfServiceMock.watchViews.mockReturnValue(
+        of([makeView(), malformedFilters, malformedGroupBy])
+      );
+
+      component.ngOnInit();
+      component.views$.subscribe();
+
+      expect(debugLogServiceMock.warn).toHaveBeenCalledTimes(2);
+      expect(debugLogServiceMock.warn).toHaveBeenCalledWith(
+        'views.page.view_malformed',
+        expect.objectContaining({ id: 7, name: 'Broken', hasFilters: false, hasGroupBy: true })
+      );
+      expect(debugLogServiceMock.warn).toHaveBeenCalledWith(
+        'views.page.view_malformed',
+        expect.objectContaining({ id: 8, name: 'AlsoBroken', hasFilters: true, hasGroupBy: false })
+      );
+      expect(debugLogServiceMock.flush).toHaveBeenCalled();
+    });
+
+    it('does not warn when all emitted views are well-formed', () => {
+      gameShelfServiceMock.watchViews.mockReturnValue(of([makeView(), makeView({ id: 2 })]));
+
+      component.ngOnInit();
+      component.views$.subscribe();
+
+      expect(debugLogServiceMock.warn).not.toHaveBeenCalled();
     });
 
     it('records start and end diagnostic checkpoints', () => {

--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -1,0 +1,184 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@ionic/angular/standalone', () => {
+  const AlertControllerToken = function AlertController() {
+    return undefined;
+  };
+  const PopoverControllerToken = function PopoverController() {
+    return undefined;
+  };
+  const ToastControllerToken = function ToastController() {
+    return undefined;
+  };
+
+  return {
+    AlertController: AlertControllerToken,
+    PopoverController: PopoverControllerToken,
+    ToastController: ToastControllerToken,
+    IonHeader: {},
+    IonToolbar: {},
+    IonButtons: {},
+    IonBackButton: {},
+    IonTitle: {},
+    IonContent: {},
+    IonList: {},
+    IonItem: {},
+    IonLabel: {},
+    IonButton: {},
+    IonIcon: {},
+    IonFab: {},
+    IonFabButton: {},
+    IonPopover: {},
+    IonModal: {},
+    IonInput: {},
+    IonNote: {},
+  };
+});
+
+vi.mock('ionicons', () => ({
+  addIcons: vi.fn(),
+}));
+
+vi.mock('ionicons/icons', () => ({
+  ellipsisVertical: {},
+  add: {},
+}));
+
+import { AlertController, PopoverController, ToastController } from '@ionic/angular/standalone';
+import { ViewsPage } from './views.page';
+import { GameShelfService } from '../core/services/game-shelf.service';
+import { DebugLogService } from '../core/services/debug-log.service';
+import { ViewsContextService } from './views-context.service';
+import { DEFAULT_GAME_LIST_FILTERS, GameListView } from '../core/models/game.models';
+
+function makeView(overrides: Partial<GameListView> = {}): GameListView {
+  return {
+    id: 1,
+    name: 'Recent',
+    listType: 'collection',
+    filters: { ...DEFAULT_GAME_LIST_FILTERS },
+    groupBy: 'none',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ViewsPage', () => {
+  let component: ViewsPage;
+  let gameShelfServiceMock: { watchViews: ReturnType<typeof vi.fn> };
+  let viewsContextServiceMock: { consume: ReturnType<typeof vi.fn> };
+  let debugLogServiceMock: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    trace: ReturnType<typeof vi.fn>;
+    flush: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    gameShelfServiceMock = {
+      watchViews: vi.fn().mockReturnValue(of([] as GameListView[])),
+    };
+    viewsContextServiceMock = {
+      consume: vi.fn().mockReturnValue({
+        context: {
+          listType: 'collection',
+          filters: { ...DEFAULT_GAME_LIST_FILTERS },
+          groupBy: 'none',
+        },
+        hasContext: false,
+      }),
+    };
+    debugLogServiceMock = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      trace: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: GameShelfService, useValue: gameShelfServiceMock },
+        { provide: ViewsContextService, useValue: viewsContextServiceMock },
+        { provide: DebugLogService, useValue: debugLogServiceMock },
+        { provide: Router, useValue: { navigateByUrl: vi.fn() } },
+        { provide: AlertController, useValue: { create: vi.fn() } },
+        { provide: PopoverController, useValue: { dismiss: vi.fn() } },
+        { provide: ToastController, useValue: { create: vi.fn() } },
+      ],
+    });
+
+    component = TestBed.runInInjectionContext(() => new ViewsPage());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getViewSummary', () => {
+    it('formats sort and group labels for a well-formed view', () => {
+      const view = makeView({
+        filters: { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'createdAt', sortDirection: 'desc' },
+        groupBy: 'platform',
+      });
+
+      const summary = component.getViewSummary(view);
+
+      expect(summary).toBe('Date added ↓ • Group: Platform');
+      expect(debugLogServiceMock.warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to defaults and warns when filters are missing', () => {
+      const malformed = makeView({ id: 7, name: 'Broken' });
+      delete (malformed as Partial<GameListView>).filters;
+
+      const summary = component.getViewSummary(malformed);
+
+      expect(summary).toBe('Game title ↑ • Group: None');
+      expect(debugLogServiceMock.warn).toHaveBeenCalledWith(
+        'views.page.view_malformed',
+        expect.objectContaining({ id: 7, name: 'Broken', hasFilters: false, hasGroupBy: true })
+      );
+      expect(debugLogServiceMock.flush).toHaveBeenCalled();
+    });
+
+    it('normalizes an unknown groupBy to none and warns when groupBy is missing', () => {
+      const malformed = makeView();
+      delete (malformed as Partial<GameListView>).groupBy;
+
+      const summary = component.getViewSummary(malformed);
+
+      expect(summary).toContain('Group: None');
+      expect(debugLogServiceMock.warn).toHaveBeenCalledWith(
+        'views.page.view_malformed',
+        expect.objectContaining({ hasFilters: true, hasGroupBy: false })
+      );
+    });
+  });
+
+  describe('ngOnInit', () => {
+    it('logs a diagnostic checkpoint on each views emission', () => {
+      const views = [makeView()];
+      gameShelfServiceMock.watchViews.mockReturnValue(of(views));
+
+      component.ngOnInit();
+      component.views$.subscribe();
+
+      expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.views_emit', {
+        count: 1,
+      });
+    });
+
+    it('records start and end diagnostic checkpoints', () => {
+      component.ngOnInit();
+
+      expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.ngoninit.start');
+      expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.ngoninit.end', {
+        listType: 'collection',
+      });
+    });
+  });
+});

--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -177,6 +177,9 @@ describe('ViewsPage', () => {
       );
 
       component.ngOnInit();
+      // ngOnInit flushes its start/end checkpoints, so reset the mock to assert
+      // the conditional flush in the views$ tap actually fires for malformed rows.
+      debugLogServiceMock.flush.mockClear();
       component.views$.subscribe();
 
       expect(debugLogServiceMock.warn).toHaveBeenCalledTimes(2);

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -100,8 +100,14 @@ export class ViewsPage implements OnInit {
     this.views$ = this.gameShelfService.watchViews(this.listType).pipe(
       tap((views) => {
         this.debugLogService.info('views.page.views_emit', { count: views.length });
-        this.warnMalformedViews(views);
-        void this.debugLogService.flush();
+        // Only force a synchronous flush when a malformed row is detected.
+        // flush() persists buffered entries synchronously (JSON.stringify +
+        // storage write), so doing it on every emission would add main-thread
+        // blocking work to a hot observable — the routine checkpoint above is
+        // left to the debounced persist instead.
+        if (this.warnMalformedViews(views)) {
+          void this.debugLogService.flush();
+        }
       })
     );
     this.debugLogService.info('views.page.ngoninit.end', { listType: this.listType });
@@ -279,11 +285,15 @@ export class ViewsPage implements OnInit {
   }
 
   // Logs malformed rows (missing `filters`/`groupBy`) once per views emission
-  // rather than per change-detection render. The flush is left to the caller.
-  private warnMalformedViews(views: readonly GameListView[]): void {
+  // rather than per change-detection render. Returns true if any malformed row
+  // was found so the caller can force-flush only in that case. The flush is
+  // left to the caller.
+  private warnMalformedViews(views: readonly GameListView[]): boolean {
+    let foundMalformed = false;
     for (const view of views) {
       const looseView = view as Partial<Pick<GameListView, 'filters' | 'groupBy'>>;
       if (!looseView.filters || !looseView.groupBy) {
+        foundMalformed = true;
         this.debugLogService.warn('views.page.view_malformed', {
           id: view.id,
           name: view.name,
@@ -292,6 +302,7 @@ export class ViewsPage implements OnInit {
         });
       }
     }
+    return foundMalformed;
   }
 
   trackByViewId(_: number, view: GameListView): string {

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -100,6 +100,7 @@ export class ViewsPage implements OnInit {
     this.views$ = this.gameShelfService.watchViews(this.listType).pipe(
       tap((views) => {
         this.debugLogService.info('views.page.views_emit', { count: views.length });
+        this.warnMalformedViews(views);
         void this.debugLogService.flush();
       })
     );
@@ -267,21 +268,30 @@ export class ViewsPage implements OnInit {
     // Harden against malformed rows: a missing `filters` or `groupBy` would
     // otherwise throw here during render. The declared type says both are
     // always present, but synced/migrated data may not honor that, so read
-    // through an optional view. Log it so the export reveals malformed rows.
+    // through an optional view and fall back to defaults. This runs during
+    // change detection, so it must stay side-effect free — malformed rows are
+    // logged once per emission in `warnMalformedViews`, not here.
     const looseView = view as Partial<Pick<GameListView, 'filters' | 'groupBy'>>;
-    if (!looseView.filters || !looseView.groupBy) {
-      this.debugLogService.warn('views.page.view_malformed', {
-        id: view.id,
-        name: view.name,
-        hasFilters: Boolean(looseView.filters),
-        hasGroupBy: Boolean(looseView.groupBy),
-      });
-      void this.debugLogService.flush();
-    }
     const filters = looseView.filters ?? DEFAULT_GAME_LIST_FILTERS;
     const sortLabel = this.getSortLabel(filters.sortField, filters.sortDirection);
     const groupLabel = this.getGroupLabel(this.normalizeGroupBy(looseView.groupBy));
     return `${sortLabel} • Group: ${groupLabel}`;
+  }
+
+  // Logs malformed rows (missing `filters`/`groupBy`) once per views emission
+  // rather than per change-detection render. The flush is left to the caller.
+  private warnMalformedViews(views: readonly GameListView[]): void {
+    for (const view of views) {
+      const looseView = view as Partial<Pick<GameListView, 'filters' | 'groupBy'>>;
+      if (!looseView.filters || !looseView.groupBy) {
+        this.debugLogService.warn('views.page.view_malformed', {
+          id: view.id,
+          name: view.name,
+          hasFilters: Boolean(looseView.filters),
+          hasGroupBy: Boolean(looseView.groupBy),
+        });
+      }
+    }
   }
 
   trackByViewId(_: number, view: GameListView): string {

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -24,7 +24,7 @@ import {
   IonInput,
   IonNote,
 } from '@ionic/angular/standalone';
-import { Observable } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import {
   DEFAULT_GAME_LIST_FILTERS,
   GameGroupByField,
@@ -87,12 +87,34 @@ export class ViewsPage implements OnInit {
   private readonly viewsContextService = inject(ViewsContextService);
 
   ngOnInit(): void {
+    // Diagnostic checkpoints: each flush() persists buffered entries
+    // synchronously, so the last checkpoint survives even a subsequent
+    // synchronous freeze. Used to localize the iOS Views-page freeze.
+    this.debugLogService.info('views.page.ngoninit.start');
+    void this.debugLogService.flush();
     const { context: ctx, hasContext } = this.viewsContextService.consume();
     this.listType = ctx.listType;
     this.currentFilters = { ...DEFAULT_GAME_LIST_FILTERS, ...ctx.filters };
     this.currentGroupBy = this.normalizeGroupBy(ctx.groupBy);
     this.hasCurrentConfiguration = hasContext;
-    this.views$ = this.gameShelfService.watchViews(this.listType);
+    this.views$ = this.gameShelfService.watchViews(this.listType).pipe(
+      tap((views) => {
+        this.debugLogService.info('views.page.views_emit', { count: views.length });
+        void this.debugLogService.flush();
+      })
+    );
+    this.debugLogService.info('views.page.ngoninit.end', { listType: this.listType });
+    void this.debugLogService.flush();
+  }
+
+  ionViewWillEnter(): void {
+    this.debugLogService.info('views.page.will_enter');
+    void this.debugLogService.flush();
+  }
+
+  ionViewDidEnter(): void {
+    this.debugLogService.info('views.page.did_enter');
+    void this.debugLogService.flush();
   }
 
   get backHref(): string {
@@ -242,8 +264,23 @@ export class ViewsPage implements OnInit {
   }
 
   getViewSummary(view: GameListView): string {
-    const sortLabel = this.getSortLabel(view.filters.sortField, view.filters.sortDirection);
-    const groupLabel = this.getGroupLabel(view.groupBy);
+    // Harden against malformed rows: a missing `filters` or `groupBy` would
+    // otherwise throw here during render. The declared type says both are
+    // always present, but synced/migrated data may not honor that, so read
+    // through an optional view. Log it so the export reveals malformed rows.
+    const looseView = view as Partial<Pick<GameListView, 'filters' | 'groupBy'>>;
+    if (!looseView.filters || !looseView.groupBy) {
+      this.debugLogService.warn('views.page.view_malformed', {
+        id: view.id,
+        name: view.name,
+        hasFilters: Boolean(looseView.filters),
+        hasGroupBy: Boolean(looseView.groupBy),
+      });
+      void this.debugLogService.flush();
+    }
+    const filters = looseView.filters ?? DEFAULT_GAME_LIST_FILTERS;
+    const sortLabel = this.getSortLabel(filters.sortField, filters.sortDirection);
+    const groupLabel = this.getGroupLabel(this.normalizeGroupBy(looseView.groupBy));
     return `${sortLabel} • Group: ${groupLabel}`;
   }
 
@@ -343,5 +380,7 @@ export class ViewsPage implements OnInit {
 
   constructor() {
     addIcons({ ellipsisVertical, add });
+    this.debugLogService.info('views.page.ctor');
+    void this.debugLogService.flush();
   }
 }

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -87,9 +87,11 @@ export class ViewsPage implements OnInit {
   private readonly viewsContextService = inject(ViewsContextService);
 
   ngOnInit(): void {
-    // Diagnostic checkpoints: each flush() persists buffered entries
-    // synchronously, so the last checkpoint survives even a subsequent
-    // synchronous freeze. Used to localize the iOS Views-page freeze.
+    // Diagnostic checkpoints: flush() serializes buffered entries on the main
+    // thread (JSON.stringify) and then issues the storage write — async on
+    // native, where Preferences.set() is scheduled rather than awaited here. It
+    // is best-effort rather than guaranteed-synchronous persistence, but the
+    // serialized snapshot helps localize the iOS Views-page freeze.
     this.debugLogService.info('views.page.ngoninit.start');
     void this.debugLogService.flush();
     const { context: ctx, hasContext } = this.viewsContextService.consume();
@@ -100,11 +102,11 @@ export class ViewsPage implements OnInit {
     this.views$ = this.gameShelfService.watchViews(this.listType).pipe(
       tap((views) => {
         this.debugLogService.info('views.page.views_emit', { count: views.length });
-        // Only force a synchronous flush when a malformed row is detected.
-        // flush() persists buffered entries synchronously (JSON.stringify +
-        // storage write), so doing it on every emission would add main-thread
-        // blocking work to a hot observable — the routine checkpoint above is
-        // left to the debounced persist instead.
+        // Only force a flush when a malformed row is detected. The expensive,
+        // main-thread part of flush() is the synchronous JSON.stringify (the
+        // native storage write is scheduled async), so flushing on every
+        // emission would add serialization work to a hot observable — the
+        // routine checkpoint is left to the debounced persist instead.
         if (this.warnMalformedViews(views)) {
           void this.debugLogService.flush();
         }


### PR DESCRIPTION
## Summary

Defends the Views page against malformed view rows that would otherwise throw
during render, and adds lifecycle diagnostics to localize a production-only iOS
Views-page freeze. The page previously had no test coverage; this PR also adds a
focused spec for the new logic.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `getViewSummary` now reads `filters`/`groupBy` through an optional view. A
  missing `filters` falls back to `DEFAULT_GAME_LIST_FILTERS`, and `groupBy` is
  passed through `normalizeGroupBy`, so synced/migrated rows that violate the
  declared type no longer throw during render. Malformed rows emit a
  `views.page.view_malformed` warning (with id, name, and shape flags).
- Added synchronous diagnostic checkpoints around the page lifecycle
  (`ctor`, `ngoninit.start`/`ngoninit.end`, `will_enter`, `did_enter`) and a
  `tap` on `views$` logging `views.page.views_emit` per emission. Each is
  followed by a `flush()` so the last checkpoint survives a subsequent
  synchronous freeze, to localize the iOS Views-page freeze.
- Added `src/app/views/views.page.spec.ts` covering the well-formed summary
  path, the missing-`filters` and missing-`groupBy` fallback/warning branches,
  and the `ngOnInit` diagnostic checkpoints.

## Testing performed

- `npm run lint` — passes
- `npm run test` — 99 files, 1516 tests pass (5 new tests in the Views spec)
- `npm run build` — Angular production build succeeds
- New spec verifies the malformed-row fallbacks return safe summaries and emit
  `views.page.view_malformed`, and that the diagnostic checkpoints fire.

## Screenshots (if applicable)

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
