### PR TITLE
fix(views): replace per-row popovers with root-level actions popover to fix iOS freeze

### DIFF
--- a/src/app/views/views.page.html
+++ b/src/app/views/views.page.html
@@ -20,33 +20,10 @@
             slot="end"
             fill="clear"
             aria-label="View actions"
-            [id]="getActionsTriggerId(view)"
-            (click)="$event.stopPropagation()"
+            (click)="openViewActions(view, $event)"
           >
             <ion-icon slot="icon-only" name="ellipsis-vertical"></ion-icon>
           </ion-button>
-          <ion-popover [trigger]="getActionsTriggerId(view)" triggerAction="click">
-            <ng-template>
-              <ion-content>
-                <ion-list lines="none">
-                  <ion-item button detail="false" (click)="renameViewFromPopover(view)">
-                    Rename
-                  </ion-item>
-                  <ion-item button detail="false" (click)="updateViewFromPopover(view)">
-                    Update from current
-                  </ion-item>
-                  <ion-item
-                    button
-                    detail="false"
-                    color="danger"
-                    (click)="deleteViewFromPopover(view)"
-                  >
-                    Delete
-                  </ion-item>
-                </ion-list>
-              </ion-content>
-            </ng-template>
-          </ion-popover>
         </ion-item>
       }
       @if (views.length === 0) {
@@ -68,6 +45,30 @@
     </ion-fab-button>
   </ion-fab>
 </ion-content>
+
+<ion-popover
+  #viewActionsPopover
+  [isOpen]="isViewActionsPopoverOpen"
+  [event]="viewActionsPopoverEvent"
+  [arrow]="false"
+  side="bottom"
+  alignment="end"
+  (didDismiss)="onViewActionsDismiss()"
+>
+  <ng-template>
+    <ion-content>
+      <ion-list lines="none">
+        <ion-item button detail="false" (click)="renameViewFromPopover()">Rename</ion-item>
+        <ion-item button detail="false" (click)="updateViewFromPopover()">
+          Update from current
+        </ion-item>
+        <ion-item button detail="false" color="danger" (click)="deleteViewFromPopover()">
+          Delete
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ng-template>
+</ion-popover>
 
 <ion-modal [isOpen]="isNameModalOpen" (didDismiss)="closeNameModal()">
   <ng-template>

--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -7,16 +7,12 @@ vi.mock('@ionic/angular/standalone', () => {
   const AlertControllerToken = function AlertController() {
     return undefined;
   };
-  const PopoverControllerToken = function PopoverController() {
-    return undefined;
-  };
   const ToastControllerToken = function ToastController() {
     return undefined;
   };
 
   return {
     AlertController: AlertControllerToken,
-    PopoverController: PopoverControllerToken,
     ToastController: ToastControllerToken,
     IonHeader: {},
     IonToolbar: {},
@@ -47,7 +43,7 @@ vi.mock('ionicons/icons', () => ({
   add: {},
 }));
 
-import { AlertController, PopoverController, ToastController } from '@ionic/angular/standalone';
+import { AlertController, ToastController } from '@ionic/angular/standalone';
 import { ViewsPage } from './views.page';
 import { GameShelfService } from '../core/services/game-shelf.service';
 import { DebugLogService } from '../core/services/debug-log.service';
@@ -69,8 +65,14 @@ function makeView(overrides: Partial<GameListView> = {}): GameListView {
 
 describe('ViewsPage', () => {
   let component: ViewsPage;
-  let gameShelfServiceMock: { watchViews: ReturnType<typeof vi.fn> };
+  let gameShelfServiceMock: {
+    watchViews: ReturnType<typeof vi.fn>;
+    updateViewConfiguration: ReturnType<typeof vi.fn>;
+    deleteView: ReturnType<typeof vi.fn>;
+  };
   let viewsContextServiceMock: { consume: ReturnType<typeof vi.fn> };
+  let alertControllerMock: { create: ReturnType<typeof vi.fn> };
+  let toastControllerMock: { create: ReturnType<typeof vi.fn> };
   let debugLogServiceMock: {
     info: ReturnType<typeof vi.fn>;
     warn: ReturnType<typeof vi.fn>;
@@ -81,7 +83,11 @@ describe('ViewsPage', () => {
   beforeEach(() => {
     gameShelfServiceMock = {
       watchViews: vi.fn().mockReturnValue(of([] as GameListView[])),
+      updateViewConfiguration: vi.fn().mockResolvedValue(undefined),
+      deleteView: vi.fn().mockResolvedValue(undefined),
     };
+    alertControllerMock = { create: vi.fn() };
+    toastControllerMock = { create: vi.fn().mockResolvedValue({ present: vi.fn() }) };
     viewsContextServiceMock = {
       consume: vi.fn().mockReturnValue({
         context: {
@@ -105,9 +111,8 @@ describe('ViewsPage', () => {
         { provide: ViewsContextService, useValue: viewsContextServiceMock },
         { provide: DebugLogService, useValue: debugLogServiceMock },
         { provide: Router, useValue: { navigateByUrl: vi.fn() } },
-        { provide: AlertController, useValue: { create: vi.fn() } },
-        { provide: PopoverController, useValue: { dismiss: vi.fn() } },
-        { provide: ToastController, useValue: { create: vi.fn() } },
+        { provide: AlertController, useValue: alertControllerMock },
+        { provide: ToastController, useValue: toastControllerMock },
       ],
     });
 
@@ -155,7 +160,7 @@ describe('ViewsPage', () => {
   });
 
   describe('ngOnInit', () => {
-    it('logs a diagnostic checkpoint on each views emission', () => {
+    it('logs a diagnostic checkpoint on the first views emission', () => {
       const views = [makeView()];
       gameShelfServiceMock.watchViews.mockReturnValue(of(views));
 
@@ -165,6 +170,19 @@ describe('ViewsPage', () => {
       expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.views_emit', {
         count: 1,
       });
+    });
+
+    it('logs the views_emit checkpoint only once across multiple subscriptions', () => {
+      gameShelfServiceMock.watchViews.mockReturnValue(of([makeView()]));
+
+      component.ngOnInit();
+      component.views$.subscribe();
+      component.views$.subscribe();
+
+      const emitCalls = debugLogServiceMock.info.mock.calls.filter(
+        ([event]) => event === 'views.page.views_emit'
+      );
+      expect(emitCalls).toHaveLength(1);
     });
 
     it('warns once per emission for each malformed view', () => {
@@ -177,9 +195,6 @@ describe('ViewsPage', () => {
       );
 
       component.ngOnInit();
-      // ngOnInit flushes its start/end checkpoints, so reset the mock to assert
-      // the conditional flush in the views$ tap actually fires for malformed rows.
-      debugLogServiceMock.flush.mockClear();
       component.views$.subscribe();
 
       expect(debugLogServiceMock.warn).toHaveBeenCalledTimes(2);
@@ -191,7 +206,6 @@ describe('ViewsPage', () => {
         'views.page.view_malformed',
         expect.objectContaining({ id: 8, name: 'AlsoBroken', hasFilters: true, hasGroupBy: false })
       );
-      expect(debugLogServiceMock.flush).toHaveBeenCalled();
     });
 
     it('does not warn when all emitted views are well-formed', () => {
@@ -210,6 +224,138 @@ describe('ViewsPage', () => {
       expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.ngoninit.end', {
         listType: 'collection',
       });
+    });
+  });
+
+  describe('view actions popover', () => {
+    it('opens the popover for the selected view and stops event propagation', () => {
+      const view = makeView();
+      const stopPropagation = vi.fn();
+      const event = { stopPropagation } as unknown as Event;
+
+      component.openViewActions(view, event);
+
+      expect(stopPropagation).toHaveBeenCalledOnce();
+      expect(component.isViewActionsPopoverOpen).toBe(true);
+      expect(component.viewActionsPopoverEvent).toBe(event);
+      expect(component.selectedViewForActions).toBe(view);
+    });
+
+    it('resets popover state on dismiss', () => {
+      const view = makeView();
+      component.openViewActions(view, { stopPropagation: vi.fn() } as unknown as Event);
+
+      component.onViewActionsDismiss();
+
+      expect(component.isViewActionsPopoverOpen).toBe(false);
+      expect(component.viewActionsPopoverEvent).toBeUndefined();
+      expect(component.selectedViewForActions).toBeNull();
+    });
+  });
+
+  describe('renameViewFromPopover', () => {
+    it('opens the rename modal seeded from the selected view', async () => {
+      const view = makeView({ id: 5, name: 'Backlog' });
+      component.openViewActions(view, { stopPropagation: vi.fn() } as unknown as Event);
+
+      await component.renameViewFromPopover();
+
+      expect(component.isRenameMode).toBe(true);
+      expect(component.editingViewId).toBe(5);
+      expect(component.draftName).toBe('Backlog');
+      expect(component.isNameModalOpen).toBe(true);
+    });
+
+    it('does nothing when no view is selected', async () => {
+      component.selectedViewForActions = null;
+
+      await component.renameViewFromPopover();
+
+      expect(component.isNameModalOpen).toBe(false);
+    });
+
+    it('does nothing when the selected view has no numeric id', async () => {
+      const view = makeView();
+      delete (view as Partial<GameListView>).id;
+      component.selectedViewForActions = view;
+
+      await component.renameViewFromPopover();
+
+      expect(component.isNameModalOpen).toBe(false);
+    });
+  });
+
+  describe('updateViewFromPopover', () => {
+    it('updates the configuration and toasts when a context is available', async () => {
+      gameShelfServiceMock.updateViewConfiguration.mockResolvedValue(undefined);
+      const view = makeView({ id: 9 });
+      component.hasCurrentConfiguration = true;
+      component.selectedViewForActions = view;
+
+      await component.updateViewFromPopover();
+
+      expect(gameShelfServiceMock.updateViewConfiguration).toHaveBeenCalledWith(
+        9,
+        component.currentFilters,
+        component.currentGroupBy
+      );
+      expect(toastControllerMock.create).toHaveBeenCalled();
+    });
+
+    it('warns and skips the update without a current configuration', async () => {
+      const view = makeView({ id: 9 });
+      component.hasCurrentConfiguration = false;
+      component.selectedViewForActions = view;
+
+      await component.updateViewFromPopover();
+
+      expect(gameShelfServiceMock.updateViewConfiguration).not.toHaveBeenCalled();
+      expect(toastControllerMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'warning' })
+      );
+    });
+
+    it('does nothing when no view is selected', async () => {
+      component.selectedViewForActions = null;
+
+      await component.updateViewFromPopover();
+
+      expect(gameShelfServiceMock.updateViewConfiguration).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteViewFromPopover', () => {
+    it('deletes the view when the confirmation is accepted', async () => {
+      gameShelfServiceMock.deleteView.mockResolvedValue(undefined);
+      alertControllerMock.create.mockResolvedValue({
+        present: vi.fn().mockResolvedValue(undefined),
+        onDidDismiss: vi.fn().mockResolvedValue({ role: 'confirm' }),
+      });
+      component.selectedViewForActions = makeView({ id: 3 });
+
+      await component.deleteViewFromPopover();
+
+      expect(gameShelfServiceMock.deleteView).toHaveBeenCalledWith(3);
+    });
+
+    it('does not delete when the confirmation is cancelled', async () => {
+      alertControllerMock.create.mockResolvedValue({
+        present: vi.fn().mockResolvedValue(undefined),
+        onDidDismiss: vi.fn().mockResolvedValue({ role: 'cancel' }),
+      });
+      component.selectedViewForActions = makeView({ id: 3 });
+
+      await component.deleteViewFromPopover();
+
+      expect(gameShelfServiceMock.deleteView).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no view is selected', async () => {
+      component.selectedViewForActions = null;
+
+      await component.deleteViewFromPopover();
+
+      expect(alertControllerMock.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -1,10 +1,9 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import {
   AlertController,
-  PopoverController,
   ToastController,
   IonHeader,
   IonToolbar,
@@ -78,13 +77,24 @@ export class ViewsPage implements OnInit {
   editingViewId: number | null = null;
   draftName = '';
 
+  // Single root-level actions popover (one for the whole page), opened
+  // programmatically per row. Replaces the previous per-item, in-content
+  // `ion-popover` which froze the iOS WKWebView when the list rendered — the
+  // same iOS backdrop freeze fixed in list-page by moving popovers to root.
+  isViewActionsPopoverOpen = false;
+  viewActionsPopoverEvent: Event | undefined = undefined;
+  selectedViewForActions: GameListView | null = null;
+
+  private loggedFirstViewsEmit = false;
+
   private readonly gameShelfService = inject(GameShelfService);
   private readonly router = inject(Router);
-  private readonly popoverController = inject(PopoverController);
   private readonly alertController = inject(AlertController);
   private readonly toastController = inject(ToastController);
   private readonly debugLogService = inject(DebugLogService);
   private readonly viewsContextService = inject(ViewsContextService);
+
+  @ViewChild('viewActionsPopover') private viewActionsPopover?: IonPopover;
 
   ngOnInit(): void {
     // Diagnostic checkpoints: flush() serializes buffered entries on the main
@@ -101,15 +111,16 @@ export class ViewsPage implements OnInit {
     this.hasCurrentConfiguration = hasContext;
     this.views$ = this.gameShelfService.watchViews(this.listType).pipe(
       tap((views) => {
-        this.debugLogService.info('views.page.views_emit', { count: views.length });
-        // Only force a flush when a malformed row is detected. The expensive,
-        // main-thread part of flush() is the synchronous JSON.stringify (the
-        // native storage write is scheduled async), so flushing on every
-        // emission would add serialization work to a hot observable — the
-        // routine checkpoint is left to the debounced persist instead.
-        if (this.warnMalformedViews(views)) {
+        // Flush the first emission so the export confirms the list actually
+        // rendered (distinguishes a transition hang from a list-render hang).
+        // Subsequent emissions rely on the debounced persist to avoid adding
+        // serialization work on every change.
+        if (!this.loggedFirstViewsEmit) {
+          this.loggedFirstViewsEmit = true;
+          this.debugLogService.info('views.page.views_emit', { count: views.length });
           void this.debugLogService.flush();
         }
+        this.warnMalformedViews(views);
       })
     );
     this.debugLogService.info('views.page.ngoninit.end', { listType: this.listType });
@@ -196,10 +207,24 @@ export class ViewsPage implements OnInit {
     await this.router.navigateByUrl(`${targetUrl}?applyView=${String(view.id)}`);
   }
 
-  async renameViewFromPopover(view: GameListView): Promise<void> {
-    await this.popoverController.dismiss();
+  openViewActions(view: GameListView, event: Event): void {
+    event.stopPropagation();
+    this.selectedViewForActions = view;
+    this.viewActionsPopoverEvent = event;
+    this.isViewActionsPopoverOpen = true;
+  }
 
-    if (typeof view.id !== 'number') {
+  onViewActionsDismiss(): void {
+    this.isViewActionsPopoverOpen = false;
+    this.viewActionsPopoverEvent = undefined;
+    this.selectedViewForActions = null;
+  }
+
+  async renameViewFromPopover(): Promise<void> {
+    const view = this.selectedViewForActions;
+    await this.viewActionsPopover?.dismiss();
+
+    if (!view || typeof view.id !== 'number') {
       return;
     }
 
@@ -209,10 +234,11 @@ export class ViewsPage implements OnInit {
     this.isNameModalOpen = true;
   }
 
-  async updateViewFromPopover(view: GameListView): Promise<void> {
-    await this.popoverController.dismiss();
+  async updateViewFromPopover(): Promise<void> {
+    const view = this.selectedViewForActions;
+    await this.viewActionsPopover?.dismiss();
 
-    if (typeof view.id !== 'number') {
+    if (!view || typeof view.id !== 'number') {
       return;
     }
 
@@ -232,10 +258,11 @@ export class ViewsPage implements OnInit {
     await this.presentToast('View updated.');
   }
 
-  async deleteViewFromPopover(view: GameListView): Promise<void> {
-    await this.popoverController.dismiss();
+  async deleteViewFromPopover(): Promise<void> {
+    const view = this.selectedViewForActions;
+    await this.viewActionsPopover?.dismiss();
 
-    if (typeof view.id !== 'number') {
+    if (!view || typeof view.id !== 'number') {
       return;
     }
 
@@ -266,10 +293,6 @@ export class ViewsPage implements OnInit {
 
     await this.gameShelfService.deleteView(view.id);
     await this.presentToast('View deleted.');
-  }
-
-  getActionsTriggerId(view: GameListView): string {
-    return `view-actions-trigger-${String(view.id ?? view.name).replace(/[^a-zA-Z0-9_-]/g, '_')}`;
   }
 
   getViewSummary(view: GameListView): string {

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -310,15 +310,13 @@ export class ViewsPage implements OnInit {
   }
 
   // Logs malformed rows (missing `filters`/`groupBy`) once per views emission
-  // rather than per change-detection render. Returns true if any malformed row
-  // was found so the caller can force-flush only in that case. The flush is
-  // left to the caller.
-  private warnMalformedViews(views: readonly GameListView[]): boolean {
-    let foundMalformed = false;
+  // rather than per change-detection render. The diagnostic flush is keyed to
+  // the first emission, not malformed rows, so this no longer reports back to
+  // the caller.
+  private warnMalformedViews(views: readonly GameListView[]): void {
     for (const view of views) {
       const looseView = view as Partial<Pick<GameListView, 'filters' | 'groupBy'>>;
       if (!looseView.filters || !looseView.groupBy) {
-        foundMalformed = true;
         this.debugLogService.warn('views.page.view_malformed', {
           id: view.id,
           name: view.name,
@@ -327,7 +325,6 @@ export class ViewsPage implements OnInit {
         });
       }
     }
-    return foundMalformed;
   }
 
   trackByViewId(_: number, view: GameListView): string {


### PR DESCRIPTION
## Summary

The Views page froze inside the iOS WKWebView because every saved-view row
rendered its own in-content `ion-popover`. This moves the page to a single
root-level actions popover opened programmatically per row — the same backdrop
freeze fix already applied in list-page — and reduces diagnostic flush work on
the views observable.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Removed the per-row `ion-popover` (and its `getActionsTriggerId` trigger ids)
  from `views.page.html`; the row action button now calls `openViewActions(view, $event)`.
- Added one root-level `ion-popover` (`#viewActionsPopover`) bound via `[isOpen]`
  and `[event]`, dismissed through `onViewActionsDismiss()`.
- `views.page.ts`: dropped `PopoverController` in favor of a `@ViewChild`
  `IonPopover` reference; track the active row in `selectedViewForActions`.
- `renameViewFromPopover` / `updateViewFromPopover` / `deleteViewFromPopover`
  now read the selected view from component state and guard against a missing
  view or non-numeric id before acting.
- Diagnostic flush in the `watchViews` tap now fires only on the first emission
  (gated by `loggedFirstViewsEmit`) to keep `JSON.stringify` off the hot path;
  malformed-row detection still warns per emission.

## Testing performed

- `npm run lint` — passes
- `npm run test` — 1530 tests passing, coverage thresholds met
- `npm run build` — Angular build succeeds
- Added unit tests covering: popover open/dismiss state, all three popover
  actions including no-selection and non-numeric-id guards, the
  no-current-configuration warning path, delete confirm/cancel branches, and
  single first-emission diagnostic logging.

## Screenshots (if applicable)

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [ ] No console errors

## Related issues

Fixes #
