### PR TITLE
fix(views): add iOS freeze heartbeat and change-detection diagnostics

### DIFF
--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -120,7 +120,11 @@ describe('ViewsPage', () => {
   });
 
   afterEach(() => {
+    // ngOnInit starts a heartbeat interval; tear it down so timers never leak
+    // into later tests.
+    component.ngOnDestroy();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   describe('getViewSummary', () => {
@@ -224,6 +228,41 @@ describe('ViewsPage', () => {
       expect(debugLogServiceMock.info).toHaveBeenCalledWith('views.page.ngoninit.end', {
         listType: 'collection',
       });
+    });
+  });
+
+  describe('heartbeat diagnostics', () => {
+    it('emits a heartbeat with the change-detection count every interval', () => {
+      vi.useFakeTimers();
+      component.ngOnInit();
+      component.ngDoCheck();
+      component.ngDoCheck();
+
+      vi.advanceTimersByTime(2000);
+
+      const heartbeat = debugLogServiceMock.info.mock.calls.find(
+        ([event]) => event === 'views.page.heartbeat'
+      );
+      expect(heartbeat?.[1]).toEqual({ elapsedMs: 2000, docheckCount: 2 });
+    });
+
+    it('stops the heartbeat on destroy', () => {
+      vi.useFakeTimers();
+      component.ngOnInit();
+      component.ngOnDestroy();
+
+      vi.advanceTimersByTime(6000);
+
+      const heartbeats = debugLogServiceMock.info.mock.calls.filter(
+        ([event]) => event === 'views.page.heartbeat'
+      );
+      expect(heartbeats).toHaveLength(0);
+    });
+
+    it('is safe to destroy when ngOnInit never ran', () => {
+      expect(() => {
+        component.ngOnDestroy();
+      }).not.toThrow();
     });
   });
 

--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -296,6 +296,20 @@ describe('ViewsPage', () => {
         component.ngOnDestroy();
       }).not.toThrow();
     });
+
+    it('self-terminates after the bounded diagnostic window', () => {
+      vi.useFakeTimers();
+      component.ionViewDidEnter();
+
+      // Run well past the 60-tick (~2min) bound; the heartbeat should stop on
+      // its own so an extended session can't crowd out other diagnostics.
+      vi.advanceTimersByTime(2000 * 200);
+
+      const heartbeats = debugLogServiceMock.info.mock.calls.filter(
+        ([event]) => event === 'views.page.heartbeat'
+      );
+      expect(heartbeats).toHaveLength(60);
+    });
   });
 
   describe('view actions popover', () => {

--- a/src/app/views/views.page.spec.ts
+++ b/src/app/views/views.page.spec.ts
@@ -120,8 +120,8 @@ describe('ViewsPage', () => {
   });
 
   afterEach(() => {
-    // ngOnInit starts a heartbeat interval; tear it down so timers never leak
-    // into later tests.
+    // ionViewDidEnter starts a heartbeat interval; tear it down so timers never
+    // leak into later tests.
     component.ngOnDestroy();
     vi.clearAllMocks();
     vi.useRealTimers();
@@ -234,7 +234,7 @@ describe('ViewsPage', () => {
   describe('heartbeat diagnostics', () => {
     it('emits a heartbeat with the change-detection count every interval', () => {
       vi.useFakeTimers();
-      component.ngOnInit();
+      component.ionViewDidEnter();
       component.ngDoCheck();
       component.ngDoCheck();
 
@@ -246,9 +246,41 @@ describe('ViewsPage', () => {
       expect(heartbeat?.[1]).toEqual({ elapsedMs: 2000, docheckCount: 2 });
     });
 
+    it('stops the heartbeat when the view leaves', () => {
+      vi.useFakeTimers();
+      component.ionViewDidEnter();
+      component.ionViewDidLeave();
+
+      vi.advanceTimersByTime(6000);
+
+      const heartbeats = debugLogServiceMock.info.mock.calls.filter(
+        ([event]) => event === 'views.page.heartbeat'
+      );
+      expect(heartbeats).toHaveLength(0);
+    });
+
+    it('resets elapsed time and the change-detection count on re-entry', () => {
+      vi.useFakeTimers();
+      component.ionViewDidEnter();
+      component.ngDoCheck();
+      vi.advanceTimersByTime(2000);
+      component.ionViewDidLeave();
+
+      // Re-enter a cached instance: counters should start from zero, not carry
+      // over from the previous visit.
+      component.ionViewDidEnter();
+      component.ngDoCheck();
+      vi.advanceTimersByTime(2000);
+
+      const heartbeats = debugLogServiceMock.info.mock.calls.filter(
+        ([event]) => event === 'views.page.heartbeat'
+      );
+      expect(heartbeats.at(-1)?.[1]).toEqual({ elapsedMs: 2000, docheckCount: 1 });
+    });
+
     it('stops the heartbeat on destroy', () => {
       vi.useFakeTimers();
-      component.ngOnInit();
+      component.ionViewDidEnter();
       component.ngOnDestroy();
 
       vi.advanceTimersByTime(6000);
@@ -259,7 +291,7 @@ describe('ViewsPage', () => {
       expect(heartbeats).toHaveLength(0);
     });
 
-    it('is safe to destroy when ngOnInit never ran', () => {
+    it('is safe to destroy when the view never entered', () => {
       expect(() => {
         component.ngOnDestroy();
       }).not.toThrow();

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -95,7 +95,13 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
   // (enter/leave) rather than ngOnInit/ngOnDestroy because IonicRouteStrategy
   // reuses cached page instances, so ngOnDestroy may not run on navigation —
   // an ngOnInit-scoped interval would keep firing while /views is offscreen.
+  // Stop the heartbeat after this many ticks (2s each → ~2min). The freeze
+  // shows up shortly after entry, so a bounded window captures it without
+  // letting a long /views session evict other diagnostics from the 8000-entry
+  // buffer or sustain storage-write pressure on iOS.
+  private static readonly HEARTBEAT_MAX_TICKS = 60;
   private heartbeatHandle: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTicks = 0;
   private docheckCount = 0;
   private enteredAtMs = 0;
 
@@ -174,6 +180,7 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
     this.stopHeartbeat();
     this.enteredAtMs = Date.now();
     this.docheckCount = 0;
+    this.heartbeatTicks = 0;
     // Run outside Angular so the tick itself doesn't trigger change detection:
     // an in-zone interval would both add main-thread work every 2s (worsening
     // the freeze under investigation) and inflate docheckCount, hiding the
@@ -187,6 +194,12 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
           elapsedMs: Date.now() - this.enteredAtMs,
           docheckCount: this.docheckCount,
         });
+        this.heartbeatTicks += 1;
+        if (this.heartbeatTicks >= ViewsPage.HEARTBEAT_MAX_TICKS) {
+          // Self-terminate once the diagnostic window has elapsed so an
+          // extended session can't crowd out other logs.
+          this.stopHeartbeat();
+        }
       }, 2000);
     });
   }

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -1,4 +1,4 @@
-import { Component, DoCheck, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, DoCheck, NgZone, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -105,6 +105,7 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
   private readonly toastController = inject(ToastController);
   private readonly debugLogService = inject(DebugLogService);
   private readonly viewsContextService = inject(ViewsContextService);
+  private readonly ngZone = inject(NgZone);
 
   @ViewChild('viewActionsPopover') private viewActionsPopover?: IonPopover;
 
@@ -173,13 +174,21 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
     this.stopHeartbeat();
     this.enteredAtMs = Date.now();
     this.docheckCount = 0;
-    this.heartbeatHandle = setInterval(() => {
-      this.debugLogService.info('views.page.heartbeat', {
-        elapsedMs: Date.now() - this.enteredAtMs,
-        docheckCount: this.docheckCount,
-      });
-      void this.debugLogService.flush();
-    }, 2000);
+    // Run outside Angular so the tick itself doesn't trigger change detection:
+    // an in-zone interval would both add main-thread work every 2s (worsening
+    // the freeze under investigation) and inflate docheckCount, hiding the
+    // change-detection signal we're trying to measure.
+    this.ngZone.runOutsideAngular(() => {
+      this.heartbeatHandle = setInterval(() => {
+        // Rely on info()'s debounced persist rather than flush(); a synchronous
+        // JSON.stringify of the full buffer every 2s is avoidable main-thread
+        // jank on iOS.
+        this.debugLogService.info('views.page.heartbeat', {
+          elapsedMs: Date.now() - this.enteredAtMs,
+          docheckCount: this.docheckCount,
+        });
+      }, 2000);
+    });
   }
 
   private stopHeartbeat(): void {

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -91,7 +91,10 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
   // plus a change-detection counter. If heartbeats keep firing while the page
   // is shown, the main thread is alive and the crash is native (memory/GPU);
   // if they stop, the main thread is blocked. A runaway docheckCount points to
-  // a change-detection loop.
+  // a change-detection loop. The heartbeat is tied to the Ionic view lifecycle
+  // (enter/leave) rather than ngOnInit/ngOnDestroy because IonicRouteStrategy
+  // reuses cached page instances, so ngOnDestroy may not run on navigation —
+  // an ngOnInit-scoped interval would keep firing while /views is offscreen.
   private heartbeatHandle: ReturnType<typeof setInterval> | null = null;
   private docheckCount = 0;
   private enteredAtMs = 0;
@@ -134,15 +137,6 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
     );
     this.debugLogService.info('views.page.ngoninit.end', { listType: this.listType });
     void this.debugLogService.flush();
-
-    this.enteredAtMs = Date.now();
-    this.heartbeatHandle = setInterval(() => {
-      this.debugLogService.info('views.page.heartbeat', {
-        elapsedMs: Date.now() - this.enteredAtMs,
-        docheckCount: this.docheckCount,
-      });
-      void this.debugLogService.flush();
-    }, 2000);
   }
 
   ngDoCheck(): void {
@@ -150,10 +144,9 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (this.heartbeatHandle !== null) {
-      clearInterval(this.heartbeatHandle);
-      this.heartbeatHandle = null;
-    }
+    // Safety net for the non-reused case; the heartbeat is normally stopped in
+    // ionViewDidLeave.
+    this.stopHeartbeat();
   }
 
   ionViewWillEnter(): void {
@@ -164,6 +157,36 @@ export class ViewsPage implements OnInit, DoCheck, OnDestroy {
   ionViewDidEnter(): void {
     this.debugLogService.info('views.page.did_enter');
     void this.debugLogService.flush();
+    this.startHeartbeat();
+  }
+
+  ionViewDidLeave(): void {
+    // Pause diagnostics while the page is offscreen. With route reuse the
+    // instance is cached, so without this the interval would keep logging and
+    // flush-writing on the main thread for a page the user can't see.
+    this.stopHeartbeat();
+  }
+
+  private startHeartbeat(): void {
+    // Reset per-visit so elapsedMs/docheckCount reflect this visit, not the
+    // cumulative lifetime of a reused instance.
+    this.stopHeartbeat();
+    this.enteredAtMs = Date.now();
+    this.docheckCount = 0;
+    this.heartbeatHandle = setInterval(() => {
+      this.debugLogService.info('views.page.heartbeat', {
+        elapsedMs: Date.now() - this.enteredAtMs,
+        docheckCount: this.docheckCount,
+      });
+      void this.debugLogService.flush();
+    }, 2000);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatHandle !== null) {
+      clearInterval(this.heartbeatHandle);
+      this.heartbeatHandle = null;
+    }
   }
 
   get backHref(): string {

--- a/src/app/views/views.page.ts
+++ b/src/app/views/views.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, DoCheck, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -65,7 +65,7 @@ import { isTasFeatureEnabled } from '../core/config/runtime-config';
     IonNote,
   ],
 })
-export class ViewsPage implements OnInit {
+export class ViewsPage implements OnInit, DoCheck, OnDestroy {
   views$!: Observable<GameListView[]>;
   listType: ListType = 'collection';
   hasCurrentConfiguration = false;
@@ -86,6 +86,15 @@ export class ViewsPage implements OnInit {
   selectedViewForActions: GameListView | null = null;
 
   private loggedFirstViewsEmit = false;
+
+  // Diagnostics for the iOS renderer crash on /views: a wall-clock heartbeat
+  // plus a change-detection counter. If heartbeats keep firing while the page
+  // is shown, the main thread is alive and the crash is native (memory/GPU);
+  // if they stop, the main thread is blocked. A runaway docheckCount points to
+  // a change-detection loop.
+  private heartbeatHandle: ReturnType<typeof setInterval> | null = null;
+  private docheckCount = 0;
+  private enteredAtMs = 0;
 
   private readonly gameShelfService = inject(GameShelfService);
   private readonly router = inject(Router);
@@ -125,6 +134,26 @@ export class ViewsPage implements OnInit {
     );
     this.debugLogService.info('views.page.ngoninit.end', { listType: this.listType });
     void this.debugLogService.flush();
+
+    this.enteredAtMs = Date.now();
+    this.heartbeatHandle = setInterval(() => {
+      this.debugLogService.info('views.page.heartbeat', {
+        elapsedMs: Date.now() - this.enteredAtMs,
+        docheckCount: this.docheckCount,
+      });
+      void this.debugLogService.flush();
+    }, 2000);
+  }
+
+  ngDoCheck(): void {
+    this.docheckCount += 1;
+  }
+
+  ngOnDestroy(): void {
+    if (this.heartbeatHandle !== null) {
+      clearInterval(this.heartbeatHandle);
+      this.heartbeatHandle = null;
+    }
   }
 
   ionViewWillEnter(): void {


### PR DESCRIPTION
## Summary

The `/views` page intermittently triggers a renderer freeze on iOS in
production only. This adds non-invasive runtime diagnostics so the failure
can be localized from exported debug logs without a reproduction in dev.
The instrumentation distinguishes a blocked main thread from a native
(memory/GPU) crash, and surfaces any runaway change-detection loop.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `ViewsPage` now implements `DoCheck` and `OnDestroy` alongside `OnInit`.
- The heartbeat is tied to the Ionic view lifecycle: `ionViewDidEnter`
  starts it and `ionViewDidLeave` stops it. `IonicRouteStrategy` reuses
  cached page instances, so an `ngOnInit`-scoped interval would keep firing
  while `/views` is offscreen; lifecycle hooks pause diagnostics when the
  page is not shown.
- The interval runs via `NgZone.runOutsideAngular` so the tick itself does
  not trigger change detection (which would add main-thread work every 2s
  and inflate `docheckCount`).
- Every 2s it logs `views.page.heartbeat` with `elapsedMs` (wall clock) and
  the current `docheckCount`. It relies on `DebugLogService`'s debounced
  persist rather than flushing per tick, avoiding a synchronous
  `JSON.stringify` of the full buffer every 2s on the main thread. Continued
  heartbeats imply a live main thread (native crash); stalled heartbeats
  imply a blocked main thread.
- The heartbeat is bounded to 60 ticks (~2min) and self-terminates, so an
  extended `/views` session cannot evict other diagnostics from the
  8000-entry buffer or sustain storage-write pressure on iOS.
- On (re-)entry `enteredAtMs`, `docheckCount`, and the tick counter are
  reset so each visit reflects that visit, not a reused instance's lifetime.
- `ngDoCheck` increments `docheckCount`; a runaway value indicates a
  change-detection loop.
- `ngOnDestroy` clears the interval and nulls the handle as a safety net for
  the non-reused case, guarded so it is safe when the view never entered.

## Testing performed

- `npm run lint` — passes.
- `npm run test` — full Vitest suite passes; `views.page.spec.ts` covers the
  heartbeat payload, teardown on `ionViewDidLeave` and `ngOnDestroy`,
  counter reset on re-entry, idempotent destroy without prior init, and the
  bounded self-termination after the diagnostic window.
- `npm run build` — Angular production build succeeds.
- Added `ngOnDestroy()` + `vi.useRealTimers()` to the spec `afterEach` to
  prevent the heartbeat interval from leaking real timers across tests.

## Screenshots (if applicable)

N/A — diagnostics only, no UI change.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
