### PR TITLE
feat(notifications): log FCM send failures and unconfigured state

### DIFF
--- a/server/src/fcm.ts
+++ b/server/src/fcm.ts
@@ -1,6 +1,6 @@
 import { config } from './config.js';
 import { cert, getApps, initializeApp, type ServiceAccount } from 'firebase-admin/app';
-import { getMessaging, type Messaging } from 'firebase-admin/messaging';
+import { getMessaging, type BatchResponse, type Messaging } from 'firebase-admin/messaging';
 
 export interface FcmSendPayload {
   title: string;
@@ -17,11 +17,13 @@ export interface FcmSendResult {
 let cachedServiceAccount: ServiceAccount | null = null;
 let cachedServiceAccountError: Error | null = null;
 let cachedMessaging: Messaging | null = null;
+let loggedNotConfiguredWarning = false;
 
 export function resetFcmStateForTests(): void {
   cachedServiceAccount = null;
   cachedServiceAccountError = null;
   cachedMessaging = null;
+  loggedNotConfiguredWarning = false;
 }
 
 export function hasConfiguredFcm(): boolean {
@@ -45,6 +47,10 @@ export async function sendFcmMulticast(
   }
 
   if (!hasConfiguredFcm()) {
+    if (!loggedNotConfiguredWarning) {
+      loggedNotConfiguredWarning = true;
+      console.warn('[fcm] not_configured', { skippedTokenCount: activeTokens.length });
+    }
     return {
       successCount: 0,
       failureCount: activeTokens.length,
@@ -67,15 +73,46 @@ export async function sendFcmMulticast(
     })
   );
 
-  const invalidTokens: string[] = [];
   let successCount = 0;
   let failureCount = 0;
-
-  for (let i = 0; i < responses.length; i += 1) {
-    const response = responses[i];
-    const tokenChunk = tokenChunks[i] ?? [];
+  for (const response of responses) {
     successCount += response.successCount;
     failureCount += response.failureCount;
+  }
+
+  const { invalidTokens, failuresByCode } = summarizeFcmSendFailures(responses, tokenChunks);
+
+  if (Object.keys(failuresByCode).length > 0) {
+    // Codes and counts only — never log token values (they are delivery credentials).
+    console.warn('[fcm] send_failures', { failuresByCode, successCount, failureCount });
+  }
+
+  return {
+    successCount,
+    failureCount,
+    invalidTokens,
+  };
+}
+
+const INVALID_TOKEN_ERROR_CODES = [
+  'registration-token-not-registered',
+  'invalid-registration-token',
+];
+
+/**
+ * Splits per-token send failures into invalid-token deactivation candidates and a
+ * `code -> count` summary of every other failure (e.g. messaging/third-party-auth-error).
+ * Pure so it can be unit-tested without initializing Firebase.
+ */
+export function summarizeFcmSendFailures(
+  responses: BatchResponse[],
+  tokenChunks: string[][]
+): { invalidTokens: string[]; failuresByCode: Record<string, number> } {
+  const invalidTokens = new Set<string>();
+  const failuresByCode: Record<string, number> = {};
+
+  responses.forEach((response, chunkIndex) => {
+    const tokenChunk = tokenChunks[chunkIndex] ?? [];
 
     response.responses.forEach((entry, entryIndex) => {
       if (entry.success) {
@@ -83,22 +120,26 @@ export async function sendFcmMulticast(
       }
 
       const code = entry.error?.code ?? '';
-      if (
-        code.includes('registration-token-not-registered') ||
-        code.includes('invalid-registration-token')
-      ) {
+      const isInvalidToken = INVALID_TOKEN_ERROR_CODES.some((invalidCode) =>
+        code.includes(invalidCode)
+      );
+
+      if (isInvalidToken) {
         const token = tokenChunk[entryIndex];
         if (token) {
-          invalidTokens.push(token);
+          invalidTokens.add(token);
         }
+        return;
       }
+
+      const bucket = code.length > 0 ? code : 'unknown';
+      failuresByCode[bucket] = (failuresByCode[bucket] ?? 0) + 1;
     });
-  }
+  });
 
   return {
-    successCount,
-    failureCount,
-    invalidTokens: [...new Set(invalidTokens)],
+    invalidTokens: [...invalidTokens],
+    failuresByCode,
   };
 }
 

--- a/server/src/tests/fcm.test.ts
+++ b/server/src/tests/fcm.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { config } from '../config.js';
-import { hasConfiguredFcm, resetFcmStateForTests, sendFcmMulticast } from '../fcm.js';
+import {
+  hasConfiguredFcm,
+  resetFcmStateForTests,
+  sendFcmMulticast,
+  summarizeFcmSendFailures,
+} from '../fcm.js';
+import type { BatchResponse } from 'firebase-admin/messaging';
 
 void test('hasConfiguredFcm reflects service account config presence', () => {
   const original = config.firebaseServiceAccountJson;
@@ -48,6 +54,99 @@ void test('sendFcmMulticast handles empty and unconfigured token flows', async (
     resetFcmStateForTests();
     config.firebaseServiceAccountJson = original;
   }
+});
+
+void test('sendFcmMulticast warns once when FCM is unconfigured', async () => {
+  const original = config.firebaseServiceAccountJson;
+  const originalWarn = console.warn;
+  const warnings: Array<{ message: unknown; detail: unknown }> = [];
+  console.warn = (message?: unknown, detail?: unknown): void => {
+    warnings.push({ message, detail });
+  };
+
+  try {
+    resetFcmStateForTests();
+    config.firebaseServiceAccountJson = '';
+
+    const first = await sendFcmMulticast(['token-1', 'token-2'], {
+      title: 't',
+      body: 'b',
+      data: { eventType: 'test' },
+    });
+    const second = await sendFcmMulticast(['token-3'], {
+      title: 't',
+      body: 'b',
+      data: { eventType: 'test' },
+    });
+
+    // Return contract is unchanged by the added logging.
+    assert.deepEqual(first, { successCount: 0, failureCount: 2, invalidTokens: [] });
+    assert.deepEqual(second, { successCount: 0, failureCount: 1, invalidTokens: [] });
+
+    const notConfiguredWarnings = warnings.filter(
+      (entry) => entry.message === '[fcm] not_configured'
+    );
+    assert.equal(notConfiguredWarnings.length, 1);
+    assert.deepEqual(notConfiguredWarnings[0]?.detail, { skippedTokenCount: 2 });
+  } finally {
+    console.warn = originalWarn;
+    resetFcmStateForTests();
+    config.firebaseServiceAccountJson = original;
+  }
+});
+
+void test('summarizeFcmSendFailures separates invalid tokens from other failure codes', () => {
+  const responses = [
+    {
+      successCount: 1,
+      failureCount: 3,
+      responses: [
+        { success: true, messageId: 'm1' },
+        { success: false, error: { code: 'messaging/registration-token-not-registered' } },
+        { success: false, error: { code: 'messaging/third-party-auth-error' } },
+        { success: false, error: {} },
+      ],
+    },
+  ] as unknown as BatchResponse[];
+  const tokenChunks = [['tok-good', 'tok-invalid', 'tok-auth', 'tok-unknown']];
+
+  const summary = summarizeFcmSendFailures(responses, tokenChunks);
+
+  assert.deepEqual(summary.invalidTokens, ['tok-invalid']);
+  assert.deepEqual(summary.failuresByCode, {
+    'messaging/third-party-auth-error': 1,
+    unknown: 1,
+  });
+});
+
+void test('summarizeFcmSendFailures dedupes invalid tokens and counts repeated codes', () => {
+  const responses = [
+    {
+      successCount: 0,
+      failureCount: 2,
+      responses: [
+        { success: false, error: { code: 'messaging/third-party-auth-error' } },
+        { success: false, error: { code: 'messaging/invalid-registration-token' } },
+      ],
+    },
+    {
+      successCount: 0,
+      failureCount: 2,
+      responses: [
+        { success: false, error: { code: 'messaging/third-party-auth-error' } },
+        { success: false, error: { code: 'messaging/invalid-registration-token' } },
+      ],
+    },
+  ] as unknown as BatchResponse[];
+  const tokenChunks = [
+    ['tok-auth', 'tok-dup'],
+    ['tok-auth2', 'tok-dup'],
+  ];
+
+  const summary = summarizeFcmSendFailures(responses, tokenChunks);
+
+  assert.deepEqual(summary.invalidTokens, ['tok-dup']);
+  assert.deepEqual(summary.failuresByCode, { 'messaging/third-party-auth-error': 2 });
 });
 
 void test('sendFcmMulticast surfaces invalid Firebase service account JSON once configured', async () => {


### PR DESCRIPTION
## Summary

Adds observability to the FCM push delivery path so silent push failures are
diagnosable in production. Previously, sends that failed (e.g. third-party auth
errors) or were attempted while FCM was unconfigured produced no log signal.
This change emits structured warnings — using only error codes and counts, never
token values — and refactors per-token failure handling into a pure, unit-testable
function.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `sendFcmMulticast` now emits a one-time `[fcm] not_configured` warning
  (with `skippedTokenCount`) the first time a send is attempted without a
  configured service account. A new `loggedNotConfiguredWarning` module flag
  gates it and is cleared by `resetFcmStateForTests`.
- Extracted per-token failure handling into a new exported pure function
  `summarizeFcmSendFailures(responses, tokenChunks)` returning
  `{ invalidTokens, failuresByCode }`. It separates invalid-token
  deactivation candidates (deduped via a `Set`) from a `code -> count`
  summary of all other failures; missing codes bucket as `unknown`.
- When any non-invalid-token failures occur, `sendFcmMulticast` logs
  `[fcm] send_failures` with `failuresByCode`, `successCount`, and
  `failureCount`. Token values are never logged (they are delivery credentials).
- Invalid-token error codes are centralized in an `INVALID_TOKEN_ERROR_CODES`
  constant. The public `FcmSendResult` contract is unchanged.

## Testing performed

- `npm run lint` — pass
- `npm run test:server` — 631 pass / 0 fail
- `npm run test` (root) and `npm run build` — pass
- New tests added: warn-once `not_configured` path (asserting unchanged return
  contract), invalid-token vs other-code separation, dedup of repeated invalid
  tokens, repeated-code counting, and the `unknown` bucket.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [x] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
