### PR TITLE
fix(api): dispatch release-monitor HLTB/review refresh over real HTTP

### DIFF
--- a/docs/nas-deployment.md
+++ b/docs/nas-deployment.md
@@ -119,7 +119,7 @@ Common stack env vars:
 - `RECOMMENDATIONS_SCHEDULER_ENABLED` (optional; defaults `true`; consumed by `worker-general`)
 - `RECOMMENDATIONS_JOB_CONCURRENCY` (optional; defaults `1`; read by worker runtime; applies when `BACKGROUND_WORKER_MODE` includes recommendations work (`all` or `recommendations`))
 - `DISCOVERY_ENRICHMENT_JOB_CONCURRENCY` (optional; defaults `1`; consumed by `worker-general`)
-- `RECOMMENDATIONS_ENRICH_API_BASE_URL` (optional; defaults `http://api:3000`; worker-only)
+- `RECOMMENDATIONS_ENRICH_API_BASE_URL` (optional; defaults `http://api:3000`; consumed by `worker-general` and by the API process's own release monitor)
 - `RECOMMENDATIONS_RUNTIME_MODE_DEFAULT` (optional; `NEUTRAL|SHORT|LONG`, default `NEUTRAL`)
 - `RECOMMENDATIONS_EXPLORATION_WEIGHT` (optional; default `0.3`)
 - `RECOMMENDATIONS_DIVERSITY_PENALTY_WEIGHT` (optional; default `0.5`)

--- a/server/README.md
+++ b/server/README.md
@@ -159,7 +159,7 @@ Release notification preference defaults:
 - `RECOMMENDATIONS_SCHEDULER_ENABLED` (consumed by `worker-general`; API process no longer runs scheduler ticks)
 - `RECOMMENDATIONS_JOB_CONCURRENCY` (read by worker runtime; applies when `BACKGROUND_WORKER_MODE` includes recommendations work (`all` or `recommendations`); default `1`)
 - `DISCOVERY_ENRICHMENT_JOB_CONCURRENCY` (consumed by `worker-general`; default `1`)
-- `RECOMMENDATIONS_ENRICH_API_BASE_URL` (worker-only; defaults to `http://api:3000` for discovery enrichment lookups)
+- `RECOMMENDATIONS_ENRICH_API_BASE_URL` (defaults to `http://api:3000` for discovery enrichment lookups; consumed by `worker-general` and by the API process's own release monitor)
 - `RECOMMENDATIONS_DAILY_STALE_HOURS`
 - `RECOMMENDATIONS_TOP_LIMIT`
 - `RECOMMENDATIONS_SIMILARITY_K`

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -129,6 +129,7 @@ export interface AppConfig {
   metacriticSearchRateLimitMaxPerMinute: number;
   mobygamesApiBaseUrl: string;
   mobygamesApiKey: string;
+  recommendationsEnrichApiBaseUrl: string;
   steamStoreApiBaseUrl: string;
   steamStoreApiTimeoutMs: number;
   steamDefaultCountry: string;
@@ -617,6 +618,10 @@ export const config: AppConfig = {
   metacriticSearchRateLimitMaxPerMinute: rateLimitConfig.inbound.metacritic_search.max,
   mobygamesApiBaseUrl: readEnv('MOBYGAMES_API_BASE_URL', 'https://api.mobygames.com/v2'),
   mobygamesApiKey: readSecretFile('MOBYGAMES_API_KEY', 'mobygames_api_key'),
+  recommendationsEnrichApiBaseUrl: readEnv(
+    'RECOMMENDATIONS_ENRICH_API_BASE_URL',
+    'http://api:3000'
+  ),
   steamStoreApiBaseUrl: readEnv('STEAM_STORE_API_BASE_URL', 'https://store.steampowered.com'),
   steamStoreApiTimeoutMs: readIntegerEnv('STEAM_STORE_API_TIMEOUT_MS', 10_000),
   steamDefaultCountry: normalizeCountryCode(readEnv('STEAM_DEFAULT_COUNTRY', 'CH')) ?? 'CH',

--- a/server/src/local-api-client.ts
+++ b/server/src/local-api-client.ts
@@ -1,0 +1,54 @@
+export interface FetchJsonResult<T> {
+  ok: boolean;
+  value: T | null;
+}
+
+export function buildLocalApiUrl(
+  baseUrl: string,
+  pathname: string,
+  query: Record<string, string | number | boolean | null | undefined>
+): string {
+  const url = new URL(pathname, baseUrl);
+  Object.entries(query).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+    url.searchParams.set(key, String(value));
+  });
+  return url.toString();
+}
+
+export async function fetchLocalApiJson<T>(
+  url: string,
+  timeoutMs: number,
+  headers?: Record<string, string>
+): Promise<FetchJsonResult<T>> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return { ok: false, value: null };
+    }
+    if (response.status === 204) {
+      return { ok: true, value: null };
+    }
+
+    const bodyText = await response.text();
+    if (bodyText.trim().length === 0) {
+      return { ok: true, value: null };
+    }
+
+    return { ok: true, value: JSON.parse(bodyText) as T };
+  } catch {
+    return { ok: false, value: null };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/server/src/recommendations/discovery-enrichment-service.ts
+++ b/server/src/recommendations/discovery-enrichment-service.ts
@@ -16,6 +16,7 @@ import {
 import { normalizeDiscoveryGameKeys } from '../discovery-game-keys.js';
 import type { IgdbMetadataRecord } from '../metadata-enrichment/types.js';
 import { isProviderMatchLocked } from '../provider-match-lock.js';
+import { buildLocalApiUrl, fetchLocalApiJson, type FetchJsonResult } from '../local-api-client.js';
 
 const ENRICHMENT_LOCK_NAMESPACE = 77321;
 const ENRICHMENT_LOCK_KEY = 1;
@@ -61,11 +62,6 @@ interface MetacriticResponse {
     metacriticScore?: number | null;
     metacriticUrl?: string | null;
   } | null;
-}
-
-interface FetchJsonResult<T> {
-  ok: boolean;
-  value: T | null;
 }
 
 interface SteamMetadataClient {
@@ -390,8 +386,8 @@ export class DiscoveryEnrichmentService {
 
     const [hltbResponse, metacriticResponse] = await Promise.all([
       shouldTryHltb
-        ? this.fetchJson<HltbResponse>(
-            this.buildLocalUrl('/v1/hltb/search', {
+        ? fetchLocalApiJson<HltbResponse>(
+            buildLocalApiUrl(this.options.apiBaseUrl, '/v1/hltb/search', {
               q: hltbLookup.title,
               ...(hltbLookup.releaseYear ? { releaseYear: String(hltbLookup.releaseYear) } : {}),
               ...(hltbLookup.platform ? { platform: hltbLookup.platform } : {}),
@@ -399,7 +395,9 @@ export class DiscoveryEnrichmentService {
                 ? { preferredHltbGameId: String(hltbLookup.preferredGameId) }
                 : {}),
               ...(hltbLookup.preferredUrl ? { preferredHltbUrl: hltbLookup.preferredUrl } : {}),
-            })
+            }),
+            this.options.requestTimeoutMs,
+            { 'x-gameshelf-discovery-enrichment': '1' }
           )
         : Promise.resolve(null),
       shouldTryMetacritic ? this.fetchReviewPayload(reviewLookup) : Promise.resolve(null),
@@ -546,14 +544,6 @@ export class DiscoveryEnrichmentService {
     }
   }
 
-  private buildLocalUrl(path: string, query: Record<string, string>): string {
-    const url = new URL(path, this.options.apiBaseUrl);
-    for (const [key, value] of Object.entries(query)) {
-      url.searchParams.set(key, value);
-    }
-    return url.toString();
-  }
-
   private getRearmAfterDays(): number {
     const raw = this.options.rearmAfterDays;
     if (typeof raw === 'number' && Number.isFinite(raw)) {
@@ -570,51 +560,20 @@ export class DiscoveryEnrichmentService {
     return DISCOVERY_ENRICHMENT_REARM_RECENT_RELEASE_YEARS_DEFAULT;
   }
 
-  private async fetchJson<T>(url: string): Promise<FetchJsonResult<T>> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => {
-      controller.abort();
-    }, this.options.requestTimeoutMs);
-    try {
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          'x-gameshelf-discovery-enrichment': '1',
-        },
-        signal: controller.signal,
-      });
-      if (!response.ok) {
-        return { ok: false, value: null };
-      }
-      if (response.status === 204) {
-        return { ok: true, value: null };
-      }
-
-      const bodyText = await response.text();
-      if (bodyText.trim().length === 0) {
-        return { ok: true, value: null };
-      }
-
-      return { ok: true, value: JSON.parse(bodyText) as T };
-    } catch {
-      return { ok: false, value: null };
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
   private async fetchReviewPayload(
     params: ReviewLookupContext
   ): Promise<FetchJsonResult<ReviewLookupResult>> {
     if (params.reviewSource === 'mobygames' && params.mobygamesGameId !== null) {
-      const response = await this.fetchJson<MobyGamesResponse>(
-        this.buildLocalUrl('/v1/mobygames/search', {
+      const response = await fetchLocalApiJson<MobyGamesResponse>(
+        buildLocalApiUrl(this.options.apiBaseUrl, '/v1/mobygames/search', {
           q: params.title,
           id: String(params.mobygamesGameId),
           limit: '5',
           format: 'normal',
           include: 'game_id,moby_url,moby_score,critic_score',
-        })
+        }),
+        this.options.requestTimeoutMs,
+        { 'x-gameshelf-discovery-enrichment': '1' }
       );
 
       if (!response.ok) {
@@ -627,13 +586,15 @@ export class DiscoveryEnrichmentService {
       };
     }
 
-    const response = await this.fetchJson<MetacriticResponse>(
-      this.buildLocalUrl('/v1/metacritic/search', {
+    const response = await fetchLocalApiJson<MetacriticResponse>(
+      buildLocalApiUrl(this.options.apiBaseUrl, '/v1/metacritic/search', {
         q: params.title,
         ...(params.releaseYear ? { releaseYear: String(params.releaseYear) } : {}),
         ...(params.platform ? { platform: params.platform } : {}),
         platformIgdbId: String(params.platformIgdbId),
-      })
+      }),
+      this.options.requestTimeoutMs,
+      { 'x-gameshelf-discovery-enrichment': '1' }
     );
 
     if (!response.ok) {

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -4,6 +4,7 @@ import { config } from './config.js';
 import { BackgroundJobRepository } from './background-jobs.js';
 import { sendFcmMulticast } from './fcm.js';
 import { fetchMetadataPathFromWorker } from './metadata.js';
+import { buildLocalApiUrl, fetchLocalApiJson, type FetchJsonResult } from './local-api-client.js';
 import { clampTextWithEllipsis, MAX_NOTIFICATION_BODY } from './notification-copy-policy.js';
 import {
   MAX_ACTIVE_TOKENS_PER_RUN,
@@ -29,10 +30,7 @@ const RELEASE_NOTIFICATION_MONTH_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US
 });
 
 type ReleaseEventType =
-  | 'release_date_set'
-  | 'release_date_changed'
-  | 'release_date_removed'
-  | 'release_day';
+  'release_date_set' | 'release_date_changed' | 'release_date_removed' | 'release_day';
 type ReleaseState = 'unknown' | 'scheduled' | 'released';
 export type ReleasePrecision = 'unknown' | 'year' | 'quarter' | 'month' | 'day';
 
@@ -99,8 +97,10 @@ interface MonitorRunStats {
   igdbRefreshSuccesses: number;
   hltbRefreshAttempts: number;
   hltbRefreshSuccesses: number;
+  hltbRefreshTransportFailures: number;
   reviewRefreshAttempts: number;
   reviewRefreshSuccesses: number;
+  reviewRefreshTransportFailures: number;
   eventsConsidered: number;
   eventsDisabled: number;
   eventsReleaseDayAlreadyNotified: number;
@@ -476,18 +476,23 @@ async function processGameRow(
         platform: hltbRefreshQuery.platform,
       });
 
-      if (refreshedHltb) {
-        stats.hltbRefreshSuccesses += 1;
-        mergedPayload = {
-          ...mergedPayload,
-          hltbMainHours: finiteNumberOrNull(refreshedHltb.hltbMainHours),
-          hltbMainExtraHours: finiteNumberOrNull(refreshedHltb.hltbMainExtraHours),
-          hltbCompletionistHours: finiteNumberOrNull(refreshedHltb.hltbCompletionistHours),
-        };
+      if (refreshedHltb.ok) {
+        if (refreshedHltb.value) {
+          stats.hltbRefreshSuccesses += 1;
+          mergedPayload = {
+            ...mergedPayload,
+            hltbMainHours: finiteNumberOrNull(refreshedHltb.value.hltbMainHours),
+            hltbMainExtraHours: finiteNumberOrNull(refreshedHltb.value.hltbMainExtraHours),
+            hltbCompletionistHours: finiteNumberOrNull(refreshedHltb.value.hltbCompletionistHours),
+          };
+        }
+        // Advance cadence on a definitive response (match or clean no-match), not
+        // just an attempt, so a transport failure keeps retrying instead of going
+        // quiet for a full cadence period while a title with no match is skipped.
+        lastHltbRefreshAt = nowIso;
+      } else {
+        stats.hltbRefreshTransportFailures += 1;
       }
-      // Advance cadence on attempt (not just success) to avoid repeatedly
-      // hammering the scraper for titles that currently return no match.
-      lastHltbRefreshAt = nowIso;
     }
 
     if (reviewDue) {
@@ -500,13 +505,18 @@ async function processGameRow(
       );
       const refreshedReview = await fetchReviewPayload(reviewRefreshQuery);
 
-      if (refreshedReview) {
-        stats.reviewRefreshSuccesses += 1;
-        mergedPayload = mergeReviewRefreshPayload(mergedPayload, refreshedReview);
+      if (refreshedReview.ok) {
+        if (refreshedReview.value) {
+          stats.reviewRefreshSuccesses += 1;
+          mergedPayload = mergeReviewRefreshPayload(mergedPayload, refreshedReview.value);
+        }
+        // Advance cadence on a definitive response (match or clean no-match), not
+        // just an attempt, so a transport failure keeps retrying instead of going
+        // quiet for a full cadence period while a title with no match is skipped.
+        lastMetacriticRefreshAt = nowIso;
+      } else {
+        stats.reviewRefreshTransportFailures += 1;
       }
-      // Advance cadence on attempt (not just success) to avoid repeatedly
-      // hammering the scraper for titles that currently return no match.
-      lastMetacriticRefreshAt = nowIso;
     }
 
     const payloadPatch = buildPayloadPatch(originalPayload, mergedPayload);
@@ -786,22 +796,25 @@ async function fetchHltbPayload(params: {
   title: string;
   releaseYear: number | null;
   platform: string | null;
-}): Promise<HltbApiResponse['item'] | null> {
+}): Promise<FetchJsonResult<HltbApiResponse['item']>> {
   if (params.title.trim().length < 2) {
-    return null;
+    return { ok: true, value: null };
   }
 
-  const response = await fetchMetadataPathFromWorker('/v1/hltb/search', {
+  const url = buildLocalApiUrl(config.recommendationsEnrichApiBaseUrl, '/v1/hltb/search', {
     q: params.title,
     releaseYear: params.releaseYear ?? undefined,
     platform: params.platform ?? undefined,
   });
-  if (!response.ok) {
-    return null;
+  const result = await fetchLocalApiJson<HltbApiResponse>(
+    url,
+    config.recommendationsDiscoveryEnrichRequestTimeoutMs
+  );
+  if (!result.ok) {
+    return { ok: false, value: null };
   }
 
-  const payload = (await response.json()) as HltbApiResponse;
-  return payload.item ?? null;
+  return { ok: true, value: result.value?.item ?? null };
 }
 
 async function fetchMetacriticPayload(params: {
@@ -809,23 +822,26 @@ async function fetchMetacriticPayload(params: {
   releaseYear: number | null;
   platform: string | null;
   platformIgdbId: number;
-}): Promise<MetacriticApiResponse['item'] | null> {
+}): Promise<FetchJsonResult<MetacriticApiResponse['item']>> {
   if (params.title.trim().length < 2) {
-    return null;
+    return { ok: true, value: null };
   }
 
-  const response = await fetchMetadataPathFromWorker('/v1/metacritic/search', {
+  const url = buildLocalApiUrl(config.recommendationsEnrichApiBaseUrl, '/v1/metacritic/search', {
     q: params.title,
     releaseYear: params.releaseYear ?? undefined,
     platform: params.platform ?? undefined,
     platformIgdbId: params.platformIgdbId,
   });
-  if (!response.ok) {
-    return null;
+  const result = await fetchLocalApiJson<MetacriticApiResponse>(
+    url,
+    config.recommendationsDiscoveryEnrichRequestTimeoutMs
+  );
+  if (!result.ok) {
+    return { ok: false, value: null };
   }
 
-  const payload = (await response.json()) as MetacriticApiResponse;
-  return payload.item ?? null;
+  return { ok: true, value: result.value?.item ?? null };
 }
 
 async function fetchReviewPayload(params: {
@@ -834,22 +850,28 @@ async function fetchReviewPayload(params: {
   platform: string | null;
   platformIgdbId: number;
   reviewMatchMobygamesGameId: number | null;
-}): Promise<RefreshedReviewPayload | null> {
+}): Promise<FetchJsonResult<RefreshedReviewPayload>> {
   if (params.reviewMatchMobygamesGameId !== null) {
     const mobygames = await fetchMobygamesPayload({
       title: params.title,
       reviewMatchMobygamesGameId: params.reviewMatchMobygamesGameId,
     });
-    if (!mobygames) {
-      return null;
+    if (!mobygames.ok) {
+      return { ok: false, value: null };
+    }
+    if (!mobygames.value) {
+      return { ok: true, value: null };
     }
 
     return {
-      source: 'mobygames',
-      mobygamesGameId: mobygames.mobygamesGameId,
-      mobyScore: mobygames.mobyScore,
-      reviewScore: mobygames.reviewScore,
-      reviewUrl: mobygames.reviewUrl,
+      ok: true,
+      value: {
+        source: 'mobygames',
+        mobygamesGameId: mobygames.value.mobygamesGameId,
+        mobyScore: mobygames.value.mobyScore,
+        reviewScore: mobygames.value.reviewScore,
+        reviewUrl: mobygames.value.reviewUrl,
+      },
     };
   }
 
@@ -859,45 +881,56 @@ async function fetchReviewPayload(params: {
     platform: params.platform,
     platformIgdbId: params.platformIgdbId,
   });
-  if (!metacritic) {
-    return null;
+  if (!metacritic.ok) {
+    return { ok: false, value: null };
+  }
+  if (!metacritic.value) {
+    return { ok: true, value: null };
   }
 
   return {
-    source: 'metacritic',
-    metacriticScore: finiteNumberOrNull(metacritic.metacriticScore),
-    metacriticUrl: stringOrNull(metacritic.metacriticUrl),
+    ok: true,
+    value: {
+      source: 'metacritic',
+      metacriticScore: finiteNumberOrNull(metacritic.value.metacriticScore),
+      metacriticUrl: stringOrNull(metacritic.value.metacriticUrl),
+    },
   };
 }
 
 async function fetchMobygamesPayload(params: {
   title: string;
   reviewMatchMobygamesGameId: number;
-}): Promise<{
-  mobygamesGameId: number | null;
-  mobyScore: number | null;
-  reviewScore: number | null;
-  reviewUrl: string | null;
-} | null> {
+}): Promise<
+  FetchJsonResult<{
+    mobygamesGameId: number | null;
+    mobyScore: number | null;
+    reviewScore: number | null;
+    reviewUrl: string | null;
+  }>
+> {
   if (params.title.trim().length < 2) {
-    return null;
+    return { ok: true, value: null };
   }
 
-  const response = await fetchMetadataPathFromWorker('/v1/mobygames/search', {
+  const url = buildLocalApiUrl(config.recommendationsEnrichApiBaseUrl, '/v1/mobygames/search', {
     q: params.title,
     id: params.reviewMatchMobygamesGameId,
     limit: 5,
     format: 'normal',
     include: 'game_id,moby_url,moby_score,critic_score',
   });
-  if (!response.ok) {
-    return null;
+  const result = await fetchLocalApiJson<MobyGamesApiResponse>(
+    url,
+    config.recommendationsDiscoveryEnrichRequestTimeoutMs
+  );
+  if (!result.ok) {
+    return { ok: false, value: null };
   }
 
-  const payload = (await response.json()) as MobyGamesApiResponse;
-  const games = Array.isArray(payload.games) ? payload.games : [];
+  const games = Array.isArray(result.value?.games) ? result.value.games : [];
   if (games.length === 0) {
-    return null;
+    return { ok: true, value: null };
   }
   const matched = games.find(
     (entry) => integerOrNull(entry.game_id) === params.reviewMatchMobygamesGameId
@@ -905,7 +938,7 @@ async function fetchMobygamesPayload(params: {
   if (!matched) {
     // Explicit override id was not returned by provider; treat this as no match
     // to avoid persisting data from an unrelated fallback result.
-    return null;
+    return { ok: true, value: null };
   }
 
   const criticScore = normalizeReviewScore(finiteNumberFromNumberOrString(matched.critic_score));
@@ -917,10 +950,13 @@ async function fetchMobygamesPayload(params: {
     );
 
   return {
-    mobygamesGameId: integerOrNull(matched.game_id),
-    mobyScore,
-    reviewScore,
-    reviewUrl: stringOrNull(matched.moby_url),
+    ok: true,
+    value: {
+      mobygamesGameId: integerOrNull(matched.game_id),
+      mobyScore,
+      reviewScore,
+      reviewUrl: stringOrNull(matched.moby_url),
+    },
   };
 }
 
@@ -2143,8 +2179,10 @@ function createMonitorRunStats(): MonitorRunStats {
     igdbRefreshSuccesses: 0,
     hltbRefreshAttempts: 0,
     hltbRefreshSuccesses: 0,
+    hltbRefreshTransportFailures: 0,
     reviewRefreshAttempts: 0,
     reviewRefreshSuccesses: 0,
+    reviewRefreshTransportFailures: 0,
     eventsConsidered: 0,
     eventsDisabled: 0,
     eventsReleaseDayAlreadyNotified: 0,

--- a/server/src/tests/release-monitor.delivery.test.ts
+++ b/server/src/tests/release-monitor.delivery.test.ts
@@ -290,8 +290,10 @@ function createRunStats() {
     igdbRefreshSuccesses: 0,
     hltbRefreshAttempts: 0,
     hltbRefreshSuccesses: 0,
+    hltbRefreshTransportFailures: 0,
     reviewRefreshAttempts: 0,
     reviewRefreshSuccesses: 0,
+    reviewRefreshTransportFailures: 0,
     eventsConsidered: 0,
     eventsDisabled: 0,
     eventsReleaseDayAlreadyNotified: 0,
@@ -658,15 +660,17 @@ class ProcessGameRowClientMock {
 class ProcessGameRowPoolMock {
   readonly client = new ProcessGameRowClientMock();
   watchStateWrites = 0;
+  lastWatchStateParams: unknown[] | null = null;
 
   connect(): Promise<ProcessGameRowClientMock> {
     return Promise.resolve(this.client);
   }
 
-  query(sql: string): Promise<{ rows: unknown[]; rowCount: number }> {
+  query(sql: string, params: unknown[] = []): Promise<{ rows: unknown[]; rowCount: number }> {
     const normalizedSql = sql.replace(/\s+/g, ' ').trim().toLowerCase();
     if (normalizedSql.startsWith('insert into release_watch_state')) {
       this.watchStateWrites += 1;
+      this.lastWatchStateParams = params;
       return Promise.resolve({ rows: [], rowCount: 1 });
     }
     return Promise.resolve({ rows: [], rowCount: 0 });
@@ -850,13 +854,27 @@ void test('processGameRow refreshes unlocked HLTB/review metadata and persists a
     assert.equal(stats.igdbRefreshAttempts, 1);
     assert.equal(stats.igdbRefreshSuccesses, 1);
     assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.hltbRefreshSuccesses, 1);
+    assert.equal(stats.hltbRefreshTransportFailures, 0);
     assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshSuccesses, 1);
+    assert.equal(stats.reviewRefreshTransportFailures, 0);
 
     assert.equal(pool.watchStateWrites, 1);
     assert.equal(pool.client.payloadPatch['title'], 'A Better Title');
     assert.equal(pool.client.payloadPatch['releasePrecision'], 'day');
     assert.equal(pool.client.payloadPatch['releaseMarker'], '2026-01-01');
+    assert.equal(pool.client.payloadPatch['hltbMainHours'], 10);
+    assert.equal(pool.client.payloadPatch['hltbMainExtraHours'], 15);
+    assert.equal(pool.client.payloadPatch['hltbCompletionistHours'], 24);
+    assert.equal(pool.client.payloadPatch['metacriticScore'], 88);
+    assert.equal(pool.client.payloadPatch['metacriticUrl'], 'https://metacritic.example/game');
     assert.equal(pool.client.syncEventPayload['title'], 'A Better Title');
+
+    const watchStateParams = pool.lastWatchStateParams;
+    assert.ok(watchStateParams);
+    assert.notEqual(watchStateParams[8], null);
+    assert.notEqual(watchStateParams[9], null);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -983,7 +1001,20 @@ void test('processGameRow refreshes locked HLTB/review metadata using saved matc
     );
 
     assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.hltbRefreshSuccesses, 1);
+    assert.equal(stats.hltbRefreshTransportFailures, 0);
     assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshSuccesses, 1);
+    assert.equal(stats.reviewRefreshTransportFailures, 0);
+
+    assert.equal(pool.client.payloadPatch['hltbMainHours'], 11);
+    assert.equal(pool.client.payloadPatch['hltbMainExtraHours'], 17);
+    assert.equal(pool.client.payloadPatch['hltbCompletionistHours'], 26);
+    assert.equal(pool.client.payloadPatch['metacriticScore'], 89);
+    assert.equal(
+      pool.client.payloadPatch['metacriticUrl'],
+      'https://metacritic.example/locked-game'
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1092,10 +1123,248 @@ void test('processGameRow treats explicit mobygames override id mismatch as revi
 
     assert.equal(stats.reviewRefreshAttempts, 1);
     assert.equal(stats.reviewRefreshSuccesses, 0);
+    assert.equal(stats.reviewRefreshTransportFailures, 0);
     assert.equal(pool.client.payloadPatch?.['mobygamesGameId'], undefined);
     assert.equal(pool.client.payloadPatch?.['reviewSource'], undefined);
     assert.equal(pool.client.syncEventPayload?.['mobygamesGameId'], undefined);
     assert.equal(pool.client.syncEventPayload?.['reviewSource'], undefined);
+
+    const watchStateParams = pool.lastWatchStateParams;
+    assert.ok(watchStateParams);
+    assert.notEqual(watchStateParams[9], null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test('processGameRow does not advance HLTB cadence on transport failure', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input: URL | RequestInfo) => {
+    const url =
+      input instanceof URL ? input.toString() : input instanceof Request ? input.url : input;
+
+    if (url.includes('id.twitch.tv/oauth2/token')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: 'test-token',
+            expires_in: 3600,
+            token_type: 'bearer',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      );
+    }
+
+    if (url.includes('api.igdb.com/v4/games')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([
+            {
+              id: 52189,
+              name: 'A Better Title',
+              first_release_date: 1_767_225_600,
+              release_dates: [{ category: 0, platform: 167, y: 2026, m: 1, d: 1 }],
+              platforms: [{ id: 167, name: 'PlayStation 5' }],
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      );
+    }
+
+    if (url.includes('/v1/hltb/search')) {
+      return Promise.resolve(new Response(null, { status: 500 }));
+    }
+
+    if (url.includes('/v1/metacritic/search')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            item: {
+              metacriticScore: 88,
+              metacriticUrl: 'https://metacritic.example/game',
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      );
+    }
+
+    return Promise.resolve(new Response(null, { status: 404 }));
+  };
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Original Title',
+          platform: 'PlayStation 5',
+          releaseYear: 2026,
+          releaseMarker: '2026',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+        },
+        watch_exists: true,
+        last_known_release_marker: '2026',
+        last_known_release_precision: 'year',
+        last_known_release_date: null,
+        last_known_release_year: 2026,
+        last_seen_state: 'released',
+        last_hltb_refresh_at: null,
+        last_metacritic_refresh_at: null,
+        last_notified_release_day: null,
+      },
+      { enabled: false, events: { set: true, changed: true, removed: true, day: true } },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.hltbRefreshSuccesses, 0);
+    assert.equal(stats.hltbRefreshTransportFailures, 1);
+    assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshSuccesses, 1);
+    assert.equal(stats.reviewRefreshTransportFailures, 0);
+
+    assert.equal(pool.client.payloadPatch?.['hltbMainHours'], undefined);
+    assert.equal(pool.client.payloadPatch?.['metacriticScore'], 88);
+
+    const watchStateParams = pool.lastWatchStateParams;
+    assert.ok(watchStateParams);
+    assert.equal(watchStateParams[8], null);
+    assert.notEqual(watchStateParams[9], null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test('processGameRow does not advance review cadence on transport failure', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input: URL | RequestInfo) => {
+    const url =
+      input instanceof URL ? input.toString() : input instanceof Request ? input.url : input;
+
+    if (url.includes('id.twitch.tv/oauth2/token')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: 'test-token',
+            expires_in: 3600,
+            token_type: 'bearer',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      );
+    }
+
+    if (url.includes('api.igdb.com/v4/games')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([
+            {
+              id: 52189,
+              name: 'A Better Title',
+              first_release_date: 1_767_225_600,
+              release_dates: [{ category: 0, platform: 167, y: 2026, m: 1, d: 1 }],
+              platforms: [{ id: 167, name: 'PlayStation 5' }],
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      );
+    }
+
+    if (url.includes('/v1/hltb/search')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            item: {
+              hltbMainHours: 10,
+              hltbMainExtraHours: 15,
+              hltbCompletionistHours: 24,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      );
+    }
+
+    if (url.includes('/v1/metacritic/search')) {
+      return Promise.reject(new Error('network error'));
+    }
+
+    return Promise.resolve(new Response(null, { status: 404 }));
+  };
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Original Title',
+          platform: 'PlayStation 5',
+          releaseYear: 2026,
+          releaseMarker: '2026',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+        },
+        watch_exists: true,
+        last_known_release_marker: '2026',
+        last_known_release_precision: 'year',
+        last_known_release_date: null,
+        last_known_release_year: 2026,
+        last_seen_state: 'released',
+        last_hltb_refresh_at: null,
+        last_metacritic_refresh_at: null,
+        last_notified_release_day: null,
+      },
+      { enabled: false, events: { set: true, changed: true, removed: true, day: true } },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshSuccesses, 0);
+    assert.equal(stats.reviewRefreshTransportFailures, 1);
+    assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.hltbRefreshSuccesses, 1);
+    assert.equal(stats.hltbRefreshTransportFailures, 0);
+
+    assert.equal(pool.client.payloadPatch?.['metacriticScore'], undefined);
+    assert.equal(pool.client.payloadPatch?.['hltbMainHours'], 10);
+
+    const watchStateParams = pool.lastWatchStateParams;
+    assert.ok(watchStateParams);
+    assert.notEqual(watchStateParams[8], null);
+    assert.equal(watchStateParams[9], null);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary

The release monitor's periodic HLTB/Metacritic/MobyGames refresh silently no-op'd: it dispatched
lookups through an in-process call into the IGDB Cloudflare worker, whose route table only
recognizes IGDB game/platform/box-art paths. Every HLTB/review request fell through to a 404,
which the caller treated as "no match," while the cadence timer still advanced as if the refresh
had succeeded — so the job looked healthy but never wrote updated HLTB or review data.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new feature)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Extracted `buildLocalApiUrl`/`fetchLocalApiJson` into a new shared module,
  `server/src/local-api-client.ts`, used by both `discovery-enrichment-service.ts` (refactor,
  no behavior change) and `release-monitor.ts` (bug fix).
- `release-monitor.ts`'s `fetchHltbPayload`, `fetchMetacriticPayload`, and `fetchMobygamesPayload`
  now issue real HTTP requests against `config.recommendationsEnrichApiBaseUrl` (new config field
  backed by the existing `RECOMMENDATIONS_ENRICH_API_BASE_URL` env var / `http://api:3000`
  default) instead of dispatching in-process into the IGDB worker.
- Refresh functions now return a `FetchJsonResult<T>` (`{ ok, value }`) instead of `T | null`,
  distinguishing a transport failure from a clean no-match.
- `processGameRow` only advances `lastHltbRefreshAt`/`lastMetacriticRefreshAt` on a definitive
  response (`ok: true`), not on transport failure, so an outage keeps retrying instead of going
  quiet for a full cadence period.
- Added `hltbRefreshTransportFailures`/`reviewRefreshTransportFailures` run stats.
- Updated `server/README.md` and `docs/nas-deployment.md`: `RECOMMENDATIONS_ENRICH_API_BASE_URL`
  was documented as worker-only; it's now also consumed by the API process's own release monitor.

## Testing performed

- `npm run lint` — passes.
- `npm run test` (root Vitest suite, coverage) — 99 files / 1539 tests pass.
- `server` suite (`npm run test:coverage`) — 646 tests, 644 pass, 2 skipped, 0 fail; coverage
  95.45%/80.44%/94.19% (statements/branches/functions), above the 80% gate.
- `npm run build` — Angular build succeeds.
- New tests: `processGameRow does not advance HLTB cadence on transport failure` and
  `processGameRow does not advance review cadence on transport failure`, plus expanded assertions
  on existing success-path tests verifying HLTB/Metacritic values are actually persisted into
  `payloadPatch` and `watch_state`.

## Screenshots (if applicable)

N/A — backend-only change.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
