### PR TITLE
feat(server): support recency/staleness gates in admin refresh-data

### DIFF
--- a/postman/game-shelf.postman_collection.json
+++ b/postman/game-shelf.postman_collection.json
@@ -590,7 +590,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"dataTypes\": [\"hltb\", \"reviews\", \"igdb\", \"pricing\"]\n}",
+              "raw": "{\n  \"dataTypes\": [\"hltb\", \"reviews\", \"igdb\", \"pricing\"],\n  \"respectRecency\": false\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -602,7 +602,7 @@
               "host": ["{{apiBaseUrl}}"],
               "path": ["v1", "admin", "refresh-data"]
             },
-            "description": "Force-triggers HLTB, review (Metacritic/MobyGames), IGDB metadata, and pricing refresh, bypassing normal cadence eligibility. Scope per data type matches its existing periodic mechanism: hltb/reviews/igdb cover collection+wishlist games, pricing covers wishlist+discovery games. Enqueues background jobs and returns enqueued/deduped counts immediately; does not wait for jobs to complete. Edit the dataTypes array to trigger a subset (any of hltb, reviews, igdb, pricing)."
+            "description": "Force-triggers HLTB, review (Metacritic/MobyGames), IGDB metadata, and pricing refresh. Scope per data type matches its existing periodic mechanism: hltb/reviews/igdb cover collection+wishlist games, pricing covers wishlist+discovery games. Enqueues background jobs and returns enqueued/deduped counts immediately; does not wait for jobs to complete. Edit the dataTypes array to trigger a subset (any of hltb, reviews, igdb, pricing). By default this still gates hltb/reviews/igdb on release recency (respectRecency: true) but bypasses the last-refreshed staleness check (respectStaleness: false); this request sets respectRecency: false to fully bypass cadence eligibility as before. Pass respectStaleness: true to skip games refreshed too recently instead."
           }
         },
         {

--- a/server/README.md
+++ b/server/README.md
@@ -133,7 +133,7 @@ This service replaces the Cloudflare Worker runtime for NAS deployment.
 - `RELEASE_MONITOR_BATCH_SIZE` (default `100`)
 - `RELEASE_MONITOR_JOB_CONCURRENCY` (consumed by `worker-general`; default `2`)
 - `RELEASE_MONITOR_DEBUG_LOGS` (`true|false`, default `false`)
-- `ADMIN_FORCED_REFRESH_MAX_GAMES` (default `10000`) caps rows scanned for the `hltb`, `reviews`, and `pricing` data types on `POST /v1/admin/refresh-data`; the `igdb` data type enqueues one `metadata_enrichment_run` job, whose scan size is instead controlled by `IGDB_METADATA_ENRICH_MAX_GAMES_PER_RUN`
+- `ADMIN_FORCED_REFRESH_MAX_GAMES` (default `10000`) caps rows scanned for the `hltb`, `reviews`, and `pricing` data types on `POST /v1/admin/refresh-data`; the `igdb` data type enqueues one `metadata_enrichment_run` job, whose scan size is instead controlled by `IGDB_METADATA_ENRICH_MAX_GAMES_PER_RUN`. The request body also accepts optional `respectRecency` (default `true`) and `respectStaleness` (default `false`) booleans: `respectRecency` still gates `hltb`/`reviews`/`igdb` on release recency, and `respectStaleness` still skips rows refreshed too recently; pass `respectRecency: false` to fully bypass cadence eligibility as the endpoint did before these flags existed.
 - `NOTIFICATIONS_TEST_ENDPOINT_ENABLED` (`true|false`, default `false`) enables `POST /v1/notifications/test` for controlled testing
 - `NOTIFICATIONS_OBSERVABILITY_ENDPOINT_ENABLED` (`true|false`, default `false`) enables `GET /v1/notifications/observability`
 - `HLTB_PERIODIC_REFRESH_YEARS` (default `3`)

--- a/server/src/admin-refresh-data-routes.test.ts
+++ b/server/src/admin-refresh-data-routes.test.ts
@@ -555,3 +555,50 @@ void test('admin refresh-data route pricing skips fresh prices only when respect
     }
   });
 });
+
+void test('admin refresh-data route pricing skips fresh discovery prices only when respectStaleness is true', async () => {
+  await withAdminAuth(async () => {
+    const app = fastifyFactory({ logger: false });
+    const pool = new PoolMock();
+    pool.seed({
+      igdbGameId: '1',
+      platformIgdbId: 6,
+      payload: {
+        listType: 'discovery',
+        title: 'Freshly Priced Discovery Steam Game',
+        steamAppId: 123,
+        priceIsFree: false,
+        priceAmount: 19.99,
+        priceFetchedAt: new Date().toISOString(),
+      },
+    });
+
+    try {
+      registerAdminRefreshDataRoutes(app, pool as unknown as Pool);
+
+      const defaultResponse = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/refresh-data',
+        headers: { 'x-game-shelf-client-token': 'device-token-1' },
+        payload: { dataTypes: ['pricing'] },
+      });
+      const defaultBody = JSON.parse(defaultResponse.body) as {
+        results: { pricing: { enqueued: number } };
+      };
+      assert.equal(defaultBody.results.pricing.enqueued, 1);
+
+      const respectStalenessResponse = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/refresh-data',
+        headers: { 'x-game-shelf-client-token': 'device-token-1' },
+        payload: { dataTypes: ['pricing'], respectStaleness: true },
+      });
+      const respectStalenessBody = JSON.parse(respectStalenessResponse.body) as {
+        results: { pricing: { enqueued: number } };
+      };
+      assert.equal(respectStalenessBody.results.pricing.enqueued, 0);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/server/src/admin-refresh-data-routes.test.ts
+++ b/server/src/admin-refresh-data-routes.test.ts
@@ -236,16 +236,99 @@ void test('admin refresh-data route scopes hltb/reviews to collection+wishlist a
       };
       assert.equal(body.results.hltb.scanned, 2);
       assert.deepEqual(body.results.hltb, body.results.reviews);
+      assert.equal(body.respectRecency, true);
+      assert.equal(body.respectStaleness, false);
 
       const releaseMonitorJobs = pool.enqueuedJobs.filter(
         (job) => job.jobType === 'release_monitor_game'
       );
       assert.equal(releaseMonitorJobs.length, 2);
       for (const job of releaseMonitorJobs) {
-        const payload = job.payload as { force_hltb: boolean; force_review: boolean };
+        const payload = job.payload as {
+          force_hltb: boolean;
+          force_review: boolean;
+          respect_recency: boolean;
+          respect_staleness: boolean;
+        };
         assert.equal(payload.force_hltb, true);
         assert.equal(payload.force_review, true);
+        assert.equal(payload.respect_recency, true);
+        assert.equal(payload.respect_staleness, false);
       }
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+void test('admin refresh-data route rejects non-boolean respectRecency/respectStaleness', async () => {
+  await withAdminAuth(async () => {
+    const app = fastifyFactory({ logger: false });
+    const pool = new PoolMock();
+
+    try {
+      registerAdminRefreshDataRoutes(app, pool as unknown as Pool);
+
+      for (const payload of [
+        { dataTypes: ['hltb'], respectRecency: 'yes' },
+        { dataTypes: ['hltb'], respectStaleness: 1 },
+      ]) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/v1/admin/refresh-data',
+          headers: { 'x-game-shelf-client-token': 'device-token-1' },
+          payload,
+        });
+        assert.equal(
+          response.statusCode,
+          400,
+          `expected 400 for payload ${JSON.stringify(payload)}`
+        );
+      }
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+void test('admin refresh-data route threads respectRecency/respectStaleness overrides onto release-monitor job payloads', async () => {
+  await withAdminAuth(async () => {
+    const app = fastifyFactory({ logger: false });
+    const pool = new PoolMock();
+    pool.seed({
+      igdbGameId: '1',
+      platformIgdbId: 6,
+      payload: { listType: 'wishlist', title: 'Wishlist Game' },
+    });
+
+    try {
+      registerAdminRefreshDataRoutes(app, pool as unknown as Pool);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/refresh-data',
+        headers: { 'x-game-shelf-client-token': 'device-token-1' },
+        payload: { dataTypes: ['hltb'], respectRecency: false, respectStaleness: true },
+      });
+
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body) as {
+        respectRecency: boolean;
+        respectStaleness: boolean;
+      };
+      assert.equal(body.respectRecency, false);
+      assert.equal(body.respectStaleness, true);
+
+      const releaseMonitorJobs = pool.enqueuedJobs.filter(
+        (job) => job.jobType === 'release_monitor_game'
+      );
+      assert.equal(releaseMonitorJobs.length, 1);
+      const payload = releaseMonitorJobs[0]?.payload as {
+        respect_recency: boolean;
+        respect_staleness: boolean;
+      };
+      assert.equal(payload.respect_recency, false);
+      assert.equal(payload.respect_staleness, true);
     } finally {
       await app.close();
     }
@@ -287,7 +370,27 @@ void test('admin refresh-data route enqueues a single forced igdb metadata job a
         (job) => job.jobType === 'metadata_enrichment_run'
       );
       assert.equal(metadataJobs.length, 1);
-      assert.equal((metadataJobs[0]?.payload as { force: boolean }).force, true);
+      const metadataPayload = metadataJobs[0]?.payload as {
+        force: boolean;
+        respectRecency: boolean;
+        respectStaleness: boolean;
+      };
+      assert.equal(metadataPayload.force, true);
+      assert.equal(metadataPayload.respectRecency, true);
+      assert.equal(metadataPayload.respectStaleness, false);
+
+      // A repeat call with different respect flags is a distinct forced-refresh request
+      // and must not dedupe against the first.
+      const third = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/refresh-data',
+        headers: { 'x-game-shelf-client-token': 'device-token-1' },
+        payload: { dataTypes: ['igdb'], respectRecency: false, respectStaleness: true },
+      });
+      const thirdBody = JSON.parse(third.body) as {
+        results: { igdb: { enqueued: number; deduped: number } };
+      };
+      assert.deepEqual(thirdBody.results.igdb, { enqueued: 1, deduped: 0 });
     } finally {
       await app.close();
     }
@@ -400,6 +503,53 @@ void test('admin refresh-data route also enqueues pricing jobs for discovery row
       );
       assert.equal(discoverySteamJobs.length, 1);
       assert.equal(discoveryPspricesJobs.length, 1);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+void test('admin refresh-data route pricing skips fresh prices only when respectStaleness is true', async () => {
+  await withAdminAuth(async () => {
+    const app = fastifyFactory({ logger: false });
+    const pool = new PoolMock();
+    pool.seed({
+      igdbGameId: '1',
+      platformIgdbId: 6,
+      payload: {
+        listType: 'wishlist',
+        title: 'Freshly Priced Steam Game',
+        steamAppId: 123,
+        priceIsFree: false,
+        priceAmount: 19.99,
+        priceFetchedAt: new Date().toISOString(),
+      },
+    });
+
+    try {
+      registerAdminRefreshDataRoutes(app, pool as unknown as Pool);
+
+      const defaultResponse = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/refresh-data',
+        headers: { 'x-game-shelf-client-token': 'device-token-1' },
+        payload: { dataTypes: ['pricing'] },
+      });
+      const defaultBody = JSON.parse(defaultResponse.body) as {
+        results: { pricing: { enqueued: number } };
+      };
+      assert.equal(defaultBody.results.pricing.enqueued, 1);
+
+      const respectStalenessResponse = await app.inject({
+        method: 'POST',
+        url: '/v1/admin/refresh-data',
+        headers: { 'x-game-shelf-client-token': 'device-token-1' },
+        payload: { dataTypes: ['pricing'], respectStaleness: true },
+      });
+      const respectStalenessBody = JSON.parse(respectStalenessResponse.body) as {
+        results: { pricing: { enqueued: number } };
+      };
+      assert.equal(respectStalenessBody.results.pricing.enqueued, 0);
     } finally {
       await app.close();
     }

--- a/server/src/admin-refresh-data-routes.ts
+++ b/server/src/admin-refresh-data-routes.ts
@@ -16,6 +16,7 @@ import { DISCOVERY_RECOMMENDATION_ALLOWED_STATUSES } from './recommendations/typ
 import { applyRouteRateLimit } from './rate-limit.js';
 import { CLIENT_WRITE_TOKEN_HEADER_NAME, isAuthorizedMutatingRequest } from './request-security.js';
 import { runWithConcurrencyLimit } from './utils/concurrency.js';
+import { resolvePriceFetchedAtMs } from './pricing-freshness.js';
 
 const PRICING_ENQUEUE_CONCURRENCY = 5;
 
@@ -24,6 +25,8 @@ const KNOWN_DATA_TYPES: ReadonlySet<DataType> = new Set(['hltb', 'reviews', 'igd
 
 interface RefreshDataBody {
   dataTypes?: unknown;
+  respectRecency?: unknown;
+  respectStaleness?: unknown;
 }
 
 interface DataTypeResult {
@@ -61,14 +64,30 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
         return;
       }
 
+      // Recency (how new the game's release is) defaults to enforced; staleness (how
+      // recently the data was last refreshed) defaults to bypassed, since the point of
+      // this endpoint is to force a refresh regardless of when it last ran.
+      const respectRecency = parseBooleanFlag(body.respectRecency, true);
+      const respectStaleness = parseBooleanFlag(body.respectStaleness, false);
+      if (respectRecency === null || respectStaleness === null) {
+        reply.code(400).send({
+          error: 'respectRecency and respectStaleness must be booleans when provided.',
+        });
+        return;
+      }
+
       const results: Partial<Record<DataType, DataTypeResult>> = {};
       const totals = { enqueued: 0, deduped: 0 };
 
       if (dataTypes.has('hltb') || dataTypes.has('reviews')) {
-        const forced = await enqueueForcedReleaseMonitorRefreshJobs(pool, {
-          hltb: dataTypes.has('hltb'),
-          review: dataTypes.has('reviews'),
-        });
+        const forced = await enqueueForcedReleaseMonitorRefreshJobs(
+          pool,
+          {
+            hltb: dataTypes.has('hltb'),
+            review: dataTypes.has('reviews'),
+          },
+          { respectRecency, respectStaleness }
+        );
         const shared: DataTypeResult = {
           scanned: forced.scanned,
           enqueued: forced.enqueued,
@@ -87,9 +106,11 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
       if (dataTypes.has('igdb')) {
         const queued = await backgroundJobs.enqueue({
           jobType: 'metadata_enrichment_run',
-          dedupeKey: 'metadata-enrichment:admin-refresh-force',
+          dedupeKey: `metadata-enrichment:admin-refresh-force:${respectRecency ? '1' : '0'}${respectStaleness ? '1' : '0'}`,
           payload: {
             force: true,
+            respectRecency,
+            respectStaleness,
             requestedAt: new Date().toISOString(),
             requestedBy: 'admin-refresh-data',
           },
@@ -102,15 +123,24 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
       }
 
       if (dataTypes.has('pricing')) {
+        // Pricing has no recency (release-year) gate to respect; only staleness applies.
         const wishlist = await enqueueForcedWishlistPricingRefreshJobs(
           pool,
           backgroundJobs,
-          config.adminForcedRefreshMaxGames
+          config.adminForcedRefreshMaxGames,
+          { respectStaleness }
         );
         const discoveryMaxRows = Math.max(0, config.adminForcedRefreshMaxGames - wishlist.scanned);
         const discovery =
           discoveryMaxRows > 0
-            ? await enqueueForcedDiscoveryPricingRefreshJobs(pool, backgroundJobs, discoveryMaxRows)
+            ? await enqueueForcedDiscoveryPricingRefreshJobs(
+                pool,
+                backgroundJobs,
+                discoveryMaxRows,
+                {
+                  respectStaleness,
+                }
+              )
             : { scanned: 0, enqueued: 0, deduped: 0 };
         results.pricing = {
           scanned: wishlist.scanned + discovery.scanned,
@@ -124,6 +154,8 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
       reply.send({
         ok: true,
         requestedDataTypes: [...dataTypes],
+        respectRecency,
+        respectStaleness,
         results,
         totals,
       });
@@ -145,6 +177,13 @@ function parseDataTypes(value: unknown): Set<DataType> | null {
   }
 
   return dataTypes.size > 0 ? dataTypes : null;
+}
+
+function parseBooleanFlag(value: unknown, defaultValue: boolean): boolean | null {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  return typeof value === 'boolean' ? value : null;
 }
 
 function isAdminAuthorized(
@@ -176,7 +215,8 @@ interface PricingEnqueueStats {
 async function enqueueForcedWishlistPricingRefreshJobs(
   pool: Pool,
   backgroundJobs: BackgroundJobRepository,
-  maxRows: number
+  maxRows: number,
+  options: { respectStaleness: boolean }
 ): Promise<PricingEnqueueStats> {
   const rows = await pool.query<PricingCandidateRow>(
     `
@@ -193,12 +233,20 @@ async function enqueueForcedWishlistPricingRefreshJobs(
   const steamCountry = config.steamDefaultCountry;
   const pspricesRegion = config.pspricesRegionPath.toLowerCase();
   const pspricesShow = config.pspricesShow.toLowerCase();
+  const staleThresholdMs = Date.now() - Math.max(1, config.pricingRefreshStaleHours) * 3600 * 1000;
   const jobs: Array<() => Promise<{ deduped: boolean }>> = [];
 
   for (const row of rows.rows) {
     const payload = normalizePayloadObject(row.payload);
     if (payload === null) {
       continue;
+    }
+
+    if (options.respectStaleness) {
+      const fetchedAtMs = resolvePriceFetchedAtMs(payload);
+      if (fetchedAtMs !== null && fetchedAtMs > staleThresholdMs) {
+        continue;
+      }
     }
 
     if (row.platform_igdb_id === STEAM_WINDOWS_PLATFORM_IGDB_ID) {
@@ -262,7 +310,8 @@ async function enqueueForcedWishlistPricingRefreshJobs(
 async function enqueueForcedDiscoveryPricingRefreshJobs(
   pool: Pool,
   backgroundJobs: BackgroundJobRepository,
-  maxRows: number
+  maxRows: number,
+  options: { respectStaleness: boolean }
 ): Promise<PricingEnqueueStats> {
   const perModeTopLimit = Math.max(1, config.recommendationsTopLimit);
   const rows = await pool.query<PricingCandidateRow>(
@@ -317,12 +366,21 @@ async function enqueueForcedDiscoveryPricingRefreshJobs(
   const pspricesRegion = config.pspricesRegionPath.toLowerCase();
   const pspricesShow = config.pspricesShow.toLowerCase();
   const nowMs = Date.now();
+  const staleThresholdMs =
+    nowMs - Math.max(1, config.discoveryPricingRefreshStaleHours) * 3600 * 1000;
   const jobs: Array<() => Promise<{ deduped: boolean }>> = [];
 
   for (const row of rows.rows) {
     const payload = normalizePayloadObject(row.payload);
     if (payload === null) {
       continue;
+    }
+
+    if (options.respectStaleness) {
+      const fetchedAtMs = resolvePriceFetchedAtMs(payload);
+      if (fetchedAtMs !== null && fetchedAtMs > staleThresholdMs) {
+        continue;
+      }
     }
 
     if (row.platform_igdb_id === STEAM_WINDOWS_PLATFORM_IGDB_ID) {

--- a/server/src/background-worker.ts
+++ b/server/src/background-worker.ts
@@ -19,6 +19,7 @@ import { processQueuedPspricesPriceRevalidation } from './psprices-prices.js';
 import { isProviderMatchLocked } from './provider-match-lock.js';
 import { STEAM_WINDOWS_PLATFORM_IGDB_ID, PSPRICES_PLATFORM_IGDB_IDS } from './platform-ids.js';
 import { resolvePreferredPsPricesUrl } from './psprices-url.js';
+import { hasUnifiedPriceValue, resolvePriceFetchedAtMs } from './pricing-freshness.js';
 import { OpenAiEmbeddingClient } from './recommendations/embedding-client.js';
 import { DiscoveryEnrichmentService } from './recommendations/discovery-enrichment-service.js';
 import { DiscoveryIgdbClient } from './recommendations/discovery-igdb-client.js';
@@ -176,45 +177,6 @@ function normalizeNonEmptyString(value: unknown): string | null {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function hasUnifiedPriceValue(payload: Record<string, unknown>): boolean {
-  if (payload['priceIsFree'] === true) {
-    return true;
-  }
-
-  const amountCandidate = payload['priceAmount'];
-  if (typeof amountCandidate === 'number') {
-    return Number.isFinite(amountCandidate) && amountCandidate >= 0;
-  }
-  if (typeof amountCandidate === 'string') {
-    const parsed = Number.parseFloat(amountCandidate.trim());
-    return Number.isFinite(parsed) && parsed >= 0;
-  }
-
-  return false;
-}
-
-function resolvePriceFetchedAtMs(payload: Record<string, unknown>): number | null {
-  // Freshness should track successful unified pricing snapshots, not fetch attempts.
-  if (!hasUnifiedPriceValue(payload)) {
-    return null;
-  }
-
-  const candidates = [payload['priceFetchedAt']];
-
-  for (const candidate of candidates) {
-    const normalized = normalizeNonEmptyString(candidate);
-    if (!normalized) {
-      continue;
-    }
-    const parsedMs = Date.parse(normalized);
-    if (Number.isFinite(parsedMs)) {
-      return parsedMs;
-    }
-  }
-
-  return null;
 }
 
 function resolvePspricesRevalidationTitle(payload: Record<string, unknown>): string | null {
@@ -1181,7 +1143,15 @@ async function main(): Promise<void> {
       }
       case 'metadata_enrichment_run': {
         const force = job.payload['force'] === true;
-        const summary = await metadataEnrichmentService.runOnce(force ? { force } : undefined);
+        const summary = await metadataEnrichmentService.runOnce(
+          force
+            ? {
+                force,
+                respectRecency: job.payload['respectRecency'] !== false,
+                respectStaleness: job.payload['respectStaleness'] === true,
+              }
+            : undefined
+        );
         return { summary };
       }
       case 'igdb_popularity_ingest': {

--- a/server/src/metadata-enrichment/repository.test.ts
+++ b/server/src/metadata-enrichment/repository.test.ts
@@ -260,7 +260,7 @@ void test('repository update writes sync event for changed game payload', async 
   ]);
 });
 
-void test('repository force mode bypasses date-gating and marks rows as periodic refresh', async () => {
+void test('repository force mode with default respect flags gates on recency but not staleness', async () => {
   const pool = new PoolMock({
     onQuery: () => ({
       rows: [
@@ -282,7 +282,12 @@ void test('repository force mode bypasses date-gating and marks rows as periodic
   });
   const repository = new MetadataEnrichmentRepository(pool as never);
 
-  const rows = await repository.listRowsMissingMetadata({ limit: 10, force: true });
+  const rows = await repository.listRowsMissingMetadata({
+    limit: 10,
+    refreshMonths: 6,
+    refreshDays: 30,
+    force: true,
+  });
 
   assert.equal(rows.length, 1);
   assert.equal(rows[0]?.isPeriodicRefresh, true);
@@ -292,8 +297,25 @@ void test('repository force mode bypasses date-gating and marks rows as periodic
     true
   );
   assert.equal(sql.includes('is_periodic_refresh'), true);
-  assert.equal(sql.includes('taxonomyEnrichedAt'), false);
-  assert.deepEqual(pool.queries[0]?.params, [10]);
+  assert.equal(sql.includes('taxonomyEnrichedAt'), true);
+  // Defaults: respectRecency true, respectStaleness false.
+  assert.deepEqual(pool.queries[0]?.params, [10, 6, 30, true, false]);
+});
+
+void test('repository force mode with respectRecency false and respectStaleness true passes flags through', async () => {
+  const pool = new PoolMock({ onQuery: () => ({ rows: [] }) });
+  const repository = new MetadataEnrichmentRepository(pool as never);
+
+  await repository.listRowsMissingMetadata({
+    limit: 10,
+    refreshMonths: 6,
+    refreshDays: 30,
+    force: true,
+    respectRecency: false,
+    respectStaleness: true,
+  });
+
+  assert.deepEqual(pool.queries[0]?.params, [10, 6, 30, false, true]);
 });
 
 void test('repository force: false selects the normal gated query', async () => {

--- a/server/src/metadata-enrichment/repository.ts
+++ b/server/src/metadata-enrichment/repository.ts
@@ -66,20 +66,62 @@ export class MetadataEnrichmentRepository {
     refreshDays?: number;
     queryable?: Queryable;
     force?: boolean;
+    respectRecency?: boolean;
+    respectStaleness?: boolean;
   }): Promise<MetadataEnrichmentGameRow[]> {
-    const { limit, refreshMonths, refreshDays, queryable = this.pool, force = false } = params;
+    const {
+      limit,
+      refreshMonths,
+      refreshDays,
+      queryable = this.pool,
+      force = false,
+      respectRecency = true,
+      respectStaleness = false,
+    } = params;
     const normalizedLimit = Number.isInteger(limit) && limit > 0 ? limit : 1;
 
     if (force) {
+      // Recency gate (Arm A): honored only when respectRecency is true — game must have
+      // been released within refreshMonths. Staleness gate (Arm B): honored only when
+      // respectStaleness is true — game must be missing enrichment fields or overdue by
+      // refreshDays. Either gate can be independently bypassed for a forced admin refresh.
       const forcedResult = await queryable.query<MissingRow>(
         `
         SELECT igdb_game_id, platform_igdb_id, payload, TRUE AS is_periodic_refresh
         FROM games
         WHERE COALESCE(payload ->> 'listType', '') IN ('collection', 'wishlist')
+          AND (
+            NOT $4::boolean
+            OR (
+              $2 > 0
+              AND COALESCE(NULLIF(payload ->> 'releaseDate', ''), '') <> ''
+              AND payload ->> 'releaseDate' ~ '^\\d{4}-\\d{2}-\\d{2}'
+              AND CASE WHEN pg_input_is_valid(LEFT(payload ->> 'releaseDate', 10), 'date')
+                    THEN LEFT(payload ->> 'releaseDate', 10)::date <= CURRENT_DATE
+                    ELSE FALSE END
+              AND CASE WHEN pg_input_is_valid(LEFT(payload ->> 'releaseDate', 10), 'date')
+                    THEN LEFT(payload ->> 'releaseDate', 10)::date >= CURRENT_DATE - ($2 * INTERVAL '1 month')
+                    ELSE FALSE END
+            )
+          )
+          AND (
+            NOT $5::boolean
+            OR COALESCE(NULLIF(payload ->> 'taxonomyEnrichedAt', ''), '') = ''
+            OR COALESCE(NULLIF(payload ->> 'mediaEnrichedAt', ''), '') = ''
+            OR COALESCE(NULLIF(payload ->> 'steamEnrichedAt', ''), '') = ''
+            OR COALESCE(NULLIF(payload ->> 'websitesEnrichedAt', ''), '') = ''
+            OR (
+              $3 > 0
+              AND payload ->> 'taxonomyEnrichedAt' ~ '^\\d{4}-\\d{2}-\\d{2}T'
+              AND CASE WHEN pg_input_is_valid(payload ->> 'taxonomyEnrichedAt', 'timestamptz')
+                    THEN (payload ->> 'taxonomyEnrichedAt')::timestamptz <= NOW() - ($3 * INTERVAL '1 day')
+                    ELSE FALSE END
+            )
+          )
         ORDER BY igdb_game_id ASC, platform_igdb_id ASC
         LIMIT $1
         `,
-        [normalizedLimit]
+        [normalizedLimit, refreshMonths ?? 0, refreshDays ?? 0, respectRecency, respectStaleness]
       );
       return forcedResult.rows.map(mapMissingRow);
     }

--- a/server/src/metadata-enrichment/service.test.ts
+++ b/server/src/metadata-enrichment/service.test.ts
@@ -17,6 +17,8 @@ class RepositoryMock {
     refreshDays?: number;
     queryable?: object;
     force?: boolean;
+    respectRecency?: boolean;
+    respectStaleness?: boolean;
   } | null = null;
 
   async withAdvisoryLock<T>(
@@ -36,6 +38,8 @@ class RepositoryMock {
     refreshDays?: number;
     queryable?: object;
     force?: boolean;
+    respectRecency?: boolean;
+    respectStaleness?: boolean;
   }): Promise<MetadataEnrichmentGameRow[]> {
     this.lastListParams = params;
     return Promise.resolve(this.rows.slice(0, params.limit));
@@ -1020,6 +1024,50 @@ void test('runOnce with no overrides passes force: false to the repository', asy
 
   await service.runOnce();
   assert.equal(repository.lastListParams?.force, false);
+});
+
+void test('runOnce({ force: true }) defaults respectRecency true and respectStaleness false', async () => {
+  const repository = new RepositoryMock();
+  const service = new MetadataEnrichmentService(
+    repository as never,
+    new IgdbClientMock(new Map()) as never,
+    {
+      enabled: true,
+      batchSize: 200,
+      maxGamesPerRun: 5000,
+      startupDelayMs: 0,
+      refreshMonths: 6,
+      refreshDays: 30,
+    }
+  );
+
+  await service.runOnce({ force: true });
+  const params = repository.lastListParams;
+  assert.ok(params);
+  assert.equal(params.respectRecency, true);
+  assert.equal(params.respectStaleness, false);
+});
+
+void test('runOnce({ force: true, respectRecency: false, respectStaleness: true }) passes overrides through', async () => {
+  const repository = new RepositoryMock();
+  const service = new MetadataEnrichmentService(
+    repository as never,
+    new IgdbClientMock(new Map()) as never,
+    {
+      enabled: true,
+      batchSize: 200,
+      maxGamesPerRun: 5000,
+      startupDelayMs: 0,
+      refreshMonths: 6,
+      refreshDays: 30,
+    }
+  );
+
+  await service.runOnce({ force: true, respectRecency: false, respectStaleness: true });
+  const params = repository.lastListParams;
+  assert.ok(params);
+  assert.equal(params.respectRecency, false);
+  assert.equal(params.respectStaleness, true);
 });
 
 void test('runOnce({ force: true }) passes force through and refetches an already fully-enriched row', async () => {

--- a/server/src/metadata-enrichment/service.ts
+++ b/server/src/metadata-enrichment/service.ts
@@ -43,8 +43,14 @@ export class MetadataEnrichmentService {
     );
   }
 
-  async runOnce(overrides?: { force?: boolean }): Promise<MetadataEnrichmentSummary | null> {
+  async runOnce(overrides?: {
+    force?: boolean;
+    respectRecency?: boolean;
+    respectStaleness?: boolean;
+  }): Promise<MetadataEnrichmentSummary | null> {
     const force = overrides?.force === true;
+    const respectRecency = overrides?.respectRecency ?? true;
+    const respectStaleness = overrides?.respectStaleness ?? false;
     const lockResult = await this.repository.withAdvisoryLock(async (client) => {
       const rows = await this.repository.listRowsMissingMetadata({
         limit: this.options.maxGamesPerRun,
@@ -52,6 +58,8 @@ export class MetadataEnrichmentService {
         refreshDays: this.options.refreshDays,
         queryable: client,
         force,
+        respectRecency,
+        respectStaleness,
       });
       const summary: MetadataEnrichmentSummary = {
         scannedRows: rows.length,

--- a/server/src/pricing-freshness.ts
+++ b/server/src/pricing-freshness.ts
@@ -1,0 +1,46 @@
+function normalizeNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function hasUnifiedPriceValue(payload: Record<string, unknown>): boolean {
+  if (payload['priceIsFree'] === true) {
+    return true;
+  }
+
+  const amountCandidate = payload['priceAmount'];
+  if (typeof amountCandidate === 'number') {
+    return Number.isFinite(amountCandidate) && amountCandidate >= 0;
+  }
+  if (typeof amountCandidate === 'string') {
+    const parsed = Number.parseFloat(amountCandidate.trim());
+    return Number.isFinite(parsed) && parsed >= 0;
+  }
+
+  return false;
+}
+
+export function resolvePriceFetchedAtMs(payload: Record<string, unknown>): number | null {
+  // Freshness should track successful unified pricing snapshots, not fetch attempts.
+  if (!hasUnifiedPriceValue(payload)) {
+    return null;
+  }
+
+  const candidates = [payload['priceFetchedAt']];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeNonEmptyString(candidate);
+    if (!normalized) {
+      continue;
+    }
+    const parsedMs = Date.parse(normalized);
+    if (Number.isFinite(parsedMs)) {
+      return parsedMs;
+    }
+  }
+
+  return null;
+}

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -31,7 +31,10 @@ const RELEASE_NOTIFICATION_MONTH_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US
 });
 
 type ReleaseEventType =
-  'release_date_set' | 'release_date_changed' | 'release_date_removed' | 'release_day';
+  | 'release_date_set'
+  | 'release_date_changed'
+  | 'release_date_removed'
+  | 'release_day';
 type ReleaseState = 'unknown' | 'scheduled' | 'released';
 export type ReleasePrecision = 'unknown' | 'year' | 'quarter' | 'month' | 'day';
 
@@ -50,6 +53,8 @@ interface DueGameRow {
   last_notified_release_day: string | null;
   force_hltb?: boolean;
   force_review?: boolean;
+  respect_recency?: boolean;
+  respect_staleness?: boolean;
 }
 
 interface NotificationPreferences {
@@ -257,7 +262,12 @@ async function processDueGames(pool: Pool, runtimeState: MonitorRuntimeState): P
 
 function buildReleaseMonitorGameJobPayload(
   row: DueGameRow,
-  forceOverrides?: { hltb: boolean; review: boolean }
+  forceOverrides?: {
+    hltb: boolean;
+    review: boolean;
+    respectRecency?: boolean;
+    respectStaleness?: boolean;
+  }
 ): Record<string, unknown> {
   return {
     igdb_game_id: row.igdb_game_id,
@@ -274,6 +284,8 @@ function buildReleaseMonitorGameJobPayload(
     last_notified_release_day: row.last_notified_release_day,
     force_hltb: forceOverrides?.hltb === true,
     force_review: forceOverrides?.review === true,
+    respect_recency: forceOverrides?.respectRecency ?? true,
+    respect_staleness: forceOverrides?.respectStaleness ?? false,
   };
 }
 
@@ -325,15 +337,22 @@ const FORCED_REFRESH_ENQUEUE_CONCURRENCY = 5;
 
 export async function enqueueForcedReleaseMonitorRefreshJobs(
   pool: Pool,
-  force: { hltb: boolean; review: boolean }
+  force: { hltb: boolean; review: boolean },
+  options?: { respectRecency?: boolean; respectStaleness?: boolean }
 ): Promise<{ scanned: number; enqueued: number; deduped: number }> {
   const jobs = new BackgroundJobRepository(pool);
   const rows = await queryAllEligibleGamesForForcedRefresh(pool);
-  const forceSuffix = `${force.hltb ? '1' : '0'}${force.review ? '1' : '0'}`;
+  const respectRecency = options?.respectRecency ?? true;
+  const respectStaleness = options?.respectStaleness ?? false;
+  const forceSuffix = `${force.hltb ? '1' : '0'}${force.review ? '1' : '0'}${respectRecency ? '1' : '0'}${respectStaleness ? '1' : '0'}`;
 
   const tasks = rows.map((row) => async () => {
     const dedupeKey = `release-monitor:forced:${forceSuffix}:${row.igdb_game_id}:${String(row.platform_igdb_id)}`;
-    const payload = buildReleaseMonitorGameJobPayload(row, force);
+    const payload = buildReleaseMonitorGameJobPayload(row, {
+      ...force,
+      respectRecency,
+      respectStaleness,
+    });
     return jobs.enqueue({
       jobType: 'release_monitor_game',
       dedupeKey,
@@ -379,6 +398,8 @@ function parseDueGameRowFromPayload(payload: Record<string, unknown>): DueGameRo
     last_notified_release_day: stringOrNull(payload['last_notified_release_day']),
     force_hltb: payload['force_hltb'] === true,
     force_review: payload['force_review'] === true,
+    respect_recency: payload['respect_recency'] !== false,
+    respect_staleness: payload['respect_staleness'] === true,
   };
   /* node:coverage enable */
 }
@@ -531,14 +552,21 @@ async function processGameRow(
     const hltbRefreshEligible = hltbEligible;
     const reviewRefreshEligible = metacriticEligible;
 
+    // Forced refresh always bypasses the bootstrap check; recency and staleness are each
+    // bypassed only when the corresponding respect_* flag is explicitly turned off.
     const hltbDue =
-      row.force_hltb === true ||
-      (!isBootstrap &&
-        hltbRefreshEligible &&
-        isHltbRefreshDue(lastHltbRefreshAt, mergedPayload, now));
+      row.force_hltb === true
+        ? (row.respect_recency === false || hltbRefreshEligible) &&
+          (row.respect_staleness !== true ||
+            isHltbRefreshDue(lastHltbRefreshAt, mergedPayload, now))
+        : !isBootstrap &&
+          hltbRefreshEligible &&
+          isHltbRefreshDue(lastHltbRefreshAt, mergedPayload, now);
     const reviewDue =
-      row.force_review === true ||
-      (!isBootstrap && reviewRefreshEligible && isReviewRefreshDue(lastMetacriticRefreshAt, now));
+      row.force_review === true
+        ? (row.respect_recency === false || reviewRefreshEligible) &&
+          (row.respect_staleness !== true || isReviewRefreshDue(lastMetacriticRefreshAt, now))
+        : !isBootstrap && reviewRefreshEligible && isReviewRefreshDue(lastMetacriticRefreshAt, now);
 
     if (hltbDue) {
       stats.hltbRefreshAttempts += 1;

--- a/server/src/tests/release-monitor.delivery.test.ts
+++ b/server/src/tests/release-monitor.delivery.test.ts
@@ -163,6 +163,7 @@ interface DueGameSeedRow {
 class ReleaseMonitorFlowPoolMock {
   private readonly dueRows: DueGameSeedRow[];
   queuedJobs = 0;
+  lastEnqueuedPayload: Record<string, unknown> | null = null;
   private readonly queuedByDedupeKey = new Map<string, number>();
   private nextJobId = 1;
   private enqueueFailuresRemaining: number;
@@ -222,6 +223,8 @@ class ReleaseMonitorFlowPoolMock {
         this.queuedByDedupeKey.set(dedupeKey, jobId);
       }
       this.queuedJobs += 1;
+      const payloadJson = typeof params[2] === 'string' ? params[2] : '{}';
+      this.lastEnqueuedPayload = JSON.parse(payloadJson) as Record<string, unknown>;
       return Promise.resolve({ rows: [{ id: jobId }], rowCount: 1 });
     }
 
@@ -1408,7 +1411,45 @@ void test('parseDueGameRowFromPayload defaults force_hltb/force_review to false 
   assert.equal(parsed.force_review, false);
 });
 
-void test('processGameRow bypasses bootstrap/cadence gating for hltb/review when forced', async () => {
+void test('parseDueGameRowFromPayload defaults respect_recency to true and respect_staleness to false when absent', () => {
+  const parsed = releaseMonitorInternals.parseDueGameRowFromPayload({
+    igdb_game_id: '52189',
+    platform_igdb_id: 167,
+    payload: {
+      title: 'Grand Theft Auto VI',
+      platform: 'PlayStation 5',
+      releaseYear: 2026,
+      listType: 'wishlist',
+    },
+    watch_exists: false,
+  });
+
+  assert.ok(parsed);
+  assert.equal(parsed.respect_recency, true);
+  assert.equal(parsed.respect_staleness, false);
+});
+
+void test('parseDueGameRowFromPayload round-trips explicit respect_recency/respect_staleness overrides', () => {
+  const parsed = releaseMonitorInternals.parseDueGameRowFromPayload({
+    igdb_game_id: '52189',
+    platform_igdb_id: 167,
+    payload: {
+      title: 'Grand Theft Auto VI',
+      platform: 'PlayStation 5',
+      releaseYear: 2026,
+      listType: 'wishlist',
+    },
+    watch_exists: false,
+    respect_recency: false,
+    respect_staleness: true,
+  });
+
+  assert.ok(parsed);
+  assert.equal(parsed.respect_recency, false);
+  assert.equal(parsed.respect_staleness, true);
+});
+
+void test('processGameRow bypasses bootstrap gating but still respects recency by default when forced', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = () => Promise.resolve(new Response(null, { status: 404 }));
 
@@ -1429,7 +1470,8 @@ void test('processGameRow bypasses bootstrap/cadence gating for hltb/review when
           listType: 'wishlist',
         },
         // Bootstrap (no existing watch state) and far outside the eligibility
-        // window: without force flags, hltbDue/reviewDue would both be false.
+        // window: force bypasses the bootstrap check, but with the default
+        // respect_recency (true), the game is still too old to refresh.
         watch_exists: false,
         last_known_release_marker: null,
         last_known_release_precision: null,
@@ -1447,8 +1489,156 @@ void test('processGameRow bypasses bootstrap/cadence gating for hltb/review when
       stats
     );
 
+    assert.equal(stats.hltbRefreshAttempts, 0);
+    assert.equal(stats.reviewRefreshAttempts, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test('processGameRow bypasses bootstrap/recency gating for hltb/review when forced with respect_recency false', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => Promise.resolve(new Response(null, { status: 404 }));
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Ancient Game',
+          platform: 'PlayStation 5',
+          releaseYear: 2000,
+          releaseMarker: '2000',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+        },
+        // Bootstrap (no existing watch state) and far outside the eligibility
+        // window: with respect_recency explicitly false, force bypasses both
+        // bootstrap and recency gating.
+        watch_exists: false,
+        last_known_release_marker: null,
+        last_known_release_precision: null,
+        last_known_release_date: null,
+        last_known_release_year: null,
+        last_seen_state: null,
+        last_hltb_refresh_at: null,
+        last_metacritic_refresh_at: null,
+        last_notified_release_day: null,
+        force_hltb: true,
+        force_review: true,
+        respect_recency: false,
+      },
+      { enabled: false, events: { set: true, changed: true, removed: true, day: true } },
+      new Set<string>(),
+      stats
+    );
+
     assert.equal(stats.hltbRefreshAttempts, 1);
     assert.equal(stats.reviewRefreshAttempts, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test('processGameRow bypasses staleness by default when forced, even with a recent last refresh', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => Promise.resolve(new Response(null, { status: 404 }));
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    const recentRefresh = new Date().toISOString();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Recent Game',
+          platform: 'PlayStation 5',
+          releaseYear: 2026,
+          releaseMarker: '2026',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+          // Existing hltb/review values so isHltbRefreshDue/isReviewRefreshDue gate on
+          // last-refresh age rather than "missing data" always being due.
+          hltbMainHours: 10,
+          metacriticScore: 80,
+        },
+        watch_exists: true,
+        last_known_release_marker: '2026',
+        last_known_release_precision: 'year',
+        last_known_release_date: null,
+        last_known_release_year: 2026,
+        last_seen_state: null,
+        // Already refreshed moments ago: without force, this would not be due again.
+        last_hltb_refresh_at: recentRefresh,
+        last_metacritic_refresh_at: recentRefresh,
+        last_notified_release_day: null,
+        force_hltb: true,
+        force_review: true,
+      },
+      { enabled: false, events: { set: true, changed: true, removed: true, day: true } },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshAttempts, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test('processGameRow respects staleness when forced with respect_staleness true and a recent last refresh', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => Promise.resolve(new Response(null, { status: 404 }));
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    const recentRefresh = new Date().toISOString();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Recent Game',
+          platform: 'PlayStation 5',
+          releaseYear: 2026,
+          releaseMarker: '2026',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+          // Existing hltb/review values so isHltbRefreshDue/isReviewRefreshDue gate on
+          // last-refresh age rather than "missing data" always being due.
+          hltbMainHours: 10,
+          metacriticScore: 80,
+        },
+        watch_exists: true,
+        last_known_release_marker: '2026',
+        last_known_release_precision: 'year',
+        last_known_release_date: null,
+        last_known_release_year: 2026,
+        last_seen_state: null,
+        last_hltb_refresh_at: recentRefresh,
+        last_metacritic_refresh_at: recentRefresh,
+        last_notified_release_day: null,
+        force_hltb: true,
+        force_review: true,
+        respect_staleness: true,
+      },
+      { enabled: false, events: { set: true, changed: true, removed: true, day: true } },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.hltbRefreshAttempts, 0);
+    assert.equal(stats.reviewRefreshAttempts, 0);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1542,4 +1732,74 @@ void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows
     { hltb: true, review: false }
   );
   assert.deepEqual(repeat, { scanned: 2, enqueued: 0, deduped: 2 });
+});
+
+void test('enqueueForcedReleaseMonitorRefreshJobs defaults respect_recency true and respect_staleness false on job payloads', async () => {
+  const rows: DueGameSeedRow[] = [
+    {
+      igdb_game_id: '1',
+      platform_igdb_id: 6,
+      payload: { title: 'Collection Game', listType: 'collection' },
+      watch_exists: true,
+      last_known_release_marker: null,
+      last_known_release_precision: null,
+      last_known_release_date: null,
+      last_known_release_year: null,
+      last_seen_state: null,
+      last_hltb_refresh_at: null,
+      last_metacritic_refresh_at: null,
+      last_notified_release_day: null,
+    },
+  ];
+  const pool = new ReleaseMonitorFlowPoolMock(rows);
+
+  await releaseMonitorInternals.enqueueForcedReleaseMonitorRefreshJobs(pool as unknown as Pool, {
+    hltb: true,
+    review: true,
+  });
+
+  const payload = pool.lastEnqueuedPayload;
+  assert.ok(payload);
+  assert.equal(payload['respect_recency'], true);
+  assert.equal(payload['respect_staleness'], false);
+});
+
+void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respectStaleness options onto job payloads and dedupe keys', async () => {
+  const rows: DueGameSeedRow[] = [
+    {
+      igdb_game_id: '1',
+      platform_igdb_id: 6,
+      payload: { title: 'Collection Game', listType: 'collection' },
+      watch_exists: true,
+      last_known_release_marker: null,
+      last_known_release_precision: null,
+      last_known_release_date: null,
+      last_known_release_year: null,
+      last_seen_state: null,
+      last_hltb_refresh_at: null,
+      last_metacritic_refresh_at: null,
+      last_notified_release_day: null,
+    },
+  ];
+  const pool = new ReleaseMonitorFlowPoolMock(rows);
+
+  const first = await releaseMonitorInternals.enqueueForcedReleaseMonitorRefreshJobs(
+    pool as unknown as Pool,
+    { hltb: true, review: true },
+    { respectRecency: false, respectStaleness: true }
+  );
+  assert.deepEqual(first, { scanned: 1, enqueued: 1, deduped: 0 });
+  const firstPayload = pool.lastEnqueuedPayload;
+  assert.ok(firstPayload);
+  assert.equal(firstPayload['respect_recency'], false);
+  assert.equal(firstPayload['respect_staleness'], true);
+
+  // A repeat call with different respect flags must not dedupe against the first,
+  // since the two requests carry different forced-refresh semantics.
+  const second = await releaseMonitorInternals.enqueueForcedReleaseMonitorRefreshJobs(
+    pool as unknown as Pool,
+    { hltb: true, review: true },
+    { respectRecency: true, respectStaleness: false }
+  );
+  assert.deepEqual(second, { scanned: 1, enqueued: 1, deduped: 0 });
 });


### PR DESCRIPTION
## Summary

- Adds `respectRecency` and `respectStaleness` boolean overrides to `POST /v1/admin/refresh-data`, `enqueueForcedReleaseMonitorRefreshJobs`, `MetadataEnrichmentService.runOnce`, and the forced wishlist/discovery pricing refresh helpers, replacing the previous all-or-nothing "force bypasses every date gate" behavior.
- By default, forced hltb/reviews/igdb refreshes now still respect release recency (`respectRecency: true`) but continue to bypass the last-refreshed staleness check (`respectStaleness: false`), matching the original endpoint intent of "refresh now regardless of when it last ran" while adding an opt-in recency override for genuinely old games.
- Extracts `hasUnifiedPriceValue`/`resolvePriceFetchedAtMs` out of `background-worker.ts` into a new shared `server/src/pricing-freshness.ts` module so the admin route can apply the same staleness check to forced pricing refreshes.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `admin-refresh-data-routes.ts`: parses `respectRecency`/`respectStaleness` from the request body (400 on non-boolean), threads them through to the hltb/reviews forced-refresh call, the igdb `metadata_enrichment_run` job payload (and its dedupe key, so distinct flag combinations no longer dedupe against each other), and the wishlist/discovery forced pricing refresh helpers (staleness-only, no recency concept for pricing).
- `release-monitor.ts`: `buildReleaseMonitorGameJobPayload` now stamps `respect_recency`/`respect_staleness` (defaulting true/false) onto job payloads; `parseDueGameRowFromPayload` round-trips them; `processGameRow`'s `hltbDue`/`reviewDue` logic now independently gates on recency and staleness only when forced and the corresponding respect flag is set.
- `metadata-enrichment/repository.ts`: `listRowsMissingMetadata`'s forced query gained two independently toggleable SQL conditions (recency window via `refreshMonths`, staleness via `refreshDays`/missing-field check), parameterized to avoid injection.
- `metadata-enrichment/service.ts` / `background-worker.ts`: `runOnce` and the `metadata_enrichment_run` job handler pass the new overrides through end-to-end.
- `pricing-freshness.ts` (new): lossless extraction of `hasUnifiedPriceValue`/`resolvePriceFetchedAtMs` from `background-worker.ts`, reused by both the worker and the new admin pricing staleness check.
- Docs: updated `server/README.md` and the Postman collection to describe the new fields and defaults.

## Testing performed

- `npm run lint` — passes (root ESLint over the whole monorepo).
- `npm --prefix server test` (with coverage) — 673 passed, 2 skipped, 0 failed; 95.67% lines / 80.72% branches / 94.24% functions, meeting the 80% gate.
- `npm run test` (root Vitest/Angular suite) — 1539 passed (frontend is unaffected by this branch; run for completeness).
- `npm run build` — Angular build succeeds.
- Added a new test covering the previously-uncovered forced-pricing-staleness path for discovery rows (mirroring the existing wishlist-row test), plus the suite's existing new tests for: default vs. overridden respect flags on the admin route, response body echoing the resolved flags, dedupe-key isolation across flag combinations, repository SQL param threading, service override passthrough, and release-monitor `processGameRow`/`parseDueGameRowFromPayload`/`enqueueForcedReleaseMonitorRefreshJobs` behavior under all four recency/staleness combinations.

## Screenshots (if applicable)

N/A — server-only change.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
