### PR TITLE
Title: feat(server): force-fresh cache bypass for admin data refresh

### DIFF
--- a/server/src/admin-refresh-data-routes.test.ts
+++ b/server/src/admin-refresh-data-routes.test.ts
@@ -239,6 +239,7 @@ void test('admin refresh-data route scopes hltb/reviews to collection+wishlist a
             mobygames: { scanned: number; enqueued: number; deduped: number };
           };
         };
+        totals: { enqueued: number; deduped: number };
         respectRecency: boolean;
         respectStaleness: boolean;
       };
@@ -251,6 +252,9 @@ void test('admin refresh-data route scopes hltb/reviews to collection+wishlist a
         metacritic: { scanned: 2, enqueued: 2, deduped: 0 },
         mobygames: { scanned: 2, enqueued: 0, deduped: 0 },
       });
+      // Both rows are due for hltb and reviews, so one release_monitor_game job per row
+      // covers both data types; totals must count jobs, not sum the per-type buckets.
+      assert.deepEqual(body.totals, { enqueued: 2, deduped: 0 });
       assert.equal(body.respectRecency, true);
       assert.equal(body.respectStaleness, false);
 

--- a/server/src/admin-refresh-data-routes.test.ts
+++ b/server/src/admin-refresh-data-routes.test.ts
@@ -204,17 +204,17 @@ void test('admin refresh-data route scopes hltb/reviews to collection+wishlist a
     pool.seed({
       igdbGameId: '1',
       platformIgdbId: 6,
-      payload: { listType: 'wishlist', title: 'Wishlist Game' },
+      payload: { listType: 'wishlist', title: 'Wishlist Game', releaseYear: 2024 },
     });
     pool.seed({
       igdbGameId: '2',
       platformIgdbId: 6,
-      payload: { listType: 'collection', title: 'Collection Game' },
+      payload: { listType: 'collection', title: 'Collection Game', releaseYear: 2024 },
     });
     pool.seed({
       igdbGameId: '3',
       platformIgdbId: 6,
-      payload: { listType: 'discovery', title: 'Discovery Game' },
+      payload: { listType: 'discovery', title: 'Discovery Game', releaseYear: 2024 },
     });
 
     try {
@@ -231,13 +231,26 @@ void test('admin refresh-data route scopes hltb/reviews to collection+wishlist a
       const body = JSON.parse(response.body) as {
         results: {
           hltb: { scanned: number; enqueued: number; deduped: number };
-          reviews: { scanned: number; enqueued: number; deduped: number };
+          reviews: {
+            scanned: number;
+            enqueued: number;
+            deduped: number;
+            metacritic: { scanned: number; enqueued: number; deduped: number };
+            mobygames: { scanned: number; enqueued: number; deduped: number };
+          };
         };
         respectRecency: boolean;
         respectStaleness: boolean;
       };
       assert.equal(body.results.hltb.scanned, 2);
-      assert.deepEqual(body.results.hltb, body.results.reviews);
+      assert.deepEqual(body.results.hltb, { scanned: 2, enqueued: 2, deduped: 0 });
+      assert.deepEqual(body.results.reviews, {
+        scanned: 2,
+        enqueued: 2,
+        deduped: 0,
+        metacritic: { scanned: 2, enqueued: 2, deduped: 0 },
+        mobygames: { scanned: 2, enqueued: 0, deduped: 0 },
+      });
       assert.equal(body.respectRecency, true);
       assert.equal(body.respectStaleness, false);
 

--- a/server/src/admin-refresh-data-routes.ts
+++ b/server/src/admin-refresh-data-routes.ts
@@ -35,6 +35,11 @@ interface DataTypeResult {
   deduped: number;
 }
 
+interface ReviewsDataTypeResult extends DataTypeResult {
+  metacritic: DataTypeResult;
+  mobygames: DataTypeResult;
+}
+
 interface PricingCandidateRow extends QueryResultRow {
   igdb_game_id: string;
   platform_igdb_id: number;
@@ -76,7 +81,7 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
         return;
       }
 
-      const results: Partial<Record<DataType, DataTypeResult>> = {};
+      const results: Partial<Record<DataType, DataTypeResult | ReviewsDataTypeResult>> = {};
       const totals = { enqueued: 0, deduped: 0 };
 
       if (dataTypes.has('hltb') || dataTypes.has('reviews')) {
@@ -88,19 +93,27 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
           },
           { respectRecency, respectStaleness }
         );
-        const shared: DataTypeResult = {
-          scanned: forced.scanned,
-          enqueued: forced.enqueued,
-          deduped: forced.deduped,
-        };
         if (dataTypes.has('hltb')) {
-          results.hltb = shared;
+          results.hltb = {
+            scanned: forced.hltb.scanned,
+            enqueued: forced.hltb.enqueued,
+            deduped: forced.hltb.deduped,
+          };
+          totals.enqueued += forced.hltb.enqueued;
+          totals.deduped += forced.hltb.deduped;
         }
         if (dataTypes.has('reviews')) {
-          results.reviews = shared;
+          const reviews: ReviewsDataTypeResult = {
+            scanned: forced.metacritic.scanned,
+            enqueued: forced.metacritic.enqueued + forced.mobygames.enqueued,
+            deduped: forced.metacritic.deduped + forced.mobygames.deduped,
+            metacritic: forced.metacritic,
+            mobygames: forced.mobygames,
+          };
+          results.reviews = reviews;
+          totals.enqueued += reviews.enqueued;
+          totals.deduped += reviews.deduped;
         }
-        totals.enqueued += forced.enqueued;
-        totals.deduped += forced.deduped;
       }
 
       if (dataTypes.has('igdb')) {

--- a/server/src/admin-refresh-data-routes.ts
+++ b/server/src/admin-refresh-data-routes.ts
@@ -99,8 +99,6 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
             enqueued: forced.hltb.enqueued,
             deduped: forced.hltb.deduped,
           };
-          totals.enqueued += forced.hltb.enqueued;
-          totals.deduped += forced.hltb.deduped;
         }
         if (dataTypes.has('reviews')) {
           const reviews: ReviewsDataTypeResult = {
@@ -111,9 +109,11 @@ export function registerAdminRefreshDataRoutes(app: FastifyInstance, pool: Pool)
             mobygames: forced.mobygames,
           };
           results.reviews = reviews;
-          totals.enqueued += reviews.enqueued;
-          totals.deduped += reviews.deduped;
         }
+        // Use job-level counts for totals rather than summing the hltb/reviews buckets: a
+        // single release_monitor_game job can satisfy both, and per-type buckets double-count it.
+        totals.enqueued += forced.job.enqueued;
+        totals.deduped += forced.job.deduped;
       }
 
       if (dataTypes.has('igdb')) {

--- a/server/src/hltb-cache.test.ts
+++ b/server/src/hltb-cache.test.ts
@@ -5,6 +5,7 @@ import Fastify from 'fastify';
 import type { Pool } from 'pg';
 import { processQueuedHltbCacheRevalidation, registerHltbCachedRoute } from './hltb-cache.js';
 import { getCacheMetrics, resetCacheMetrics } from './cache-metrics.js';
+import { config } from './config.js';
 
 interface HltbCandidateResponseBody {
   candidates?: Array<{
@@ -125,61 +126,113 @@ void test('HLTB cache stores on miss and serves on hit', async () => {
 
 void test('HLTB cache force-refresh header bypasses a fresh cache entry, then refreshes the cache for regular traffic', async () => {
   resetCacheMetrics();
+  const originalApiToken = config.apiToken;
+  config.apiToken = 'test-api-token';
   const pool = new HltbPoolMock();
   const app = Fastify();
   let fetchCalls = 0;
 
-  await registerHltbCachedRoute(app, pool as unknown as Pool, {
-    fetchMetadata: () => {
-      fetchCalls += 1;
-      const hltbMainHours = fetchCalls === 1 ? 20 : 30;
-      return Promise.resolve(
-        new Response(JSON.stringify({ item: { hltbMainHours }, candidates: [] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      );
-    },
-  });
+  try {
+    await registerHltbCachedRoute(app, pool as unknown as Pool, {
+      fetchMetadata: () => {
+        fetchCalls += 1;
+        const hltbMainHours = fetchCalls === 1 ? 20 : 30;
+        return Promise.resolve(
+          new Response(JSON.stringify({ item: { hltbMainHours }, candidates: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      },
+    });
 
-  const first = await app.inject({
-    method: 'GET',
-    url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
-  });
-  assert.equal(first.statusCode, 200);
-  assert.equal(first.headers['x-gameshelf-hltb-cache'], 'MISS');
-  assert.equal(fetchCalls, 1);
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+    });
+    assert.equal(first.statusCode, 200);
+    assert.equal(first.headers['x-gameshelf-hltb-cache'], 'MISS');
+    assert.equal(fetchCalls, 1);
 
-  const forced = await app.inject({
-    method: 'GET',
-    url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
-    headers: { 'x-gameshelf-force-refresh': '1' },
-  });
-  assert.equal(forced.statusCode, 200);
-  assert.equal(forced.headers['x-gameshelf-hltb-cache'], 'BYPASS');
-  assert.equal(fetchCalls, 2);
-  assert.equal(
-    (JSON.parse(forced.body) as { item: { hltbMainHours: number } }).item.hltbMainHours,
-    30
-  );
+    const forced = await app.inject({
+      method: 'GET',
+      url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+      headers: {
+        'x-gameshelf-force-refresh': '1',
+        authorization: 'Bearer test-api-token',
+      },
+    });
+    assert.equal(forced.statusCode, 200);
+    assert.equal(forced.headers['x-gameshelf-hltb-cache'], 'BYPASS');
+    assert.equal(fetchCalls, 2);
+    assert.equal(
+      (JSON.parse(forced.body) as { item: { hltbMainHours: number } }).item.hltbMainHours,
+      30
+    );
 
-  const afterForced = await app.inject({
-    method: 'GET',
-    url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
-  });
-  assert.equal(afterForced.statusCode, 200);
-  assert.equal(afterForced.headers['x-gameshelf-hltb-cache'], 'HIT_FRESH');
-  assert.equal(fetchCalls, 2);
-  assert.equal(
-    (JSON.parse(afterForced.body) as { item: { hltbMainHours: number } }).item.hltbMainHours,
-    30
-  );
+    const afterForced = await app.inject({
+      method: 'GET',
+      url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+    });
+    assert.equal(afterForced.statusCode, 200);
+    assert.equal(afterForced.headers['x-gameshelf-hltb-cache'], 'HIT_FRESH');
+    assert.equal(fetchCalls, 2);
+    assert.equal(
+      (JSON.parse(afterForced.body) as { item: { hltbMainHours: number } }).item.hltbMainHours,
+      30
+    );
 
-  const metrics = getCacheMetrics();
-  assert.equal(metrics.hltb.bypasses, 1);
-  assert.equal(metrics.hltb.misses, 1);
+    const metrics = getCacheMetrics();
+    assert.equal(metrics.hltb.bypasses, 1);
+    assert.equal(metrics.hltb.misses, 1);
+  } finally {
+    config.apiToken = originalApiToken;
+    await app.close();
+  }
+});
 
-  await app.close();
+void test('HLTB cache force-refresh header is ignored without a valid auth token', async () => {
+  resetCacheMetrics();
+  const originalApiToken = config.apiToken;
+  config.apiToken = 'test-api-token';
+  const pool = new HltbPoolMock();
+  const app = Fastify();
+  let fetchCalls = 0;
+
+  try {
+    await registerHltbCachedRoute(app, pool as unknown as Pool, {
+      fetchMetadata: () => {
+        fetchCalls += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify({ item: { hltbMainHours: 20 }, candidates: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      },
+    });
+
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+    });
+    assert.equal(first.headers['x-gameshelf-hltb-cache'], 'MISS');
+    assert.equal(fetchCalls, 1);
+
+    const unauthorizedForced = await app.inject({
+      method: 'GET',
+      url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+      headers: { 'x-gameshelf-force-refresh': '1' },
+    });
+    assert.equal(unauthorizedForced.headers['x-gameshelf-hltb-cache'], 'HIT_FRESH');
+    assert.equal(fetchCalls, 1);
+
+    const metrics = getCacheMetrics();
+    assert.equal(metrics.hltb.bypasses, 0);
+  } finally {
+    config.apiToken = originalApiToken;
+    await app.close();
+  }
 });
 
 void test('HLTB cache supports candidates when includeCandidates is enabled', async () => {

--- a/server/src/hltb-cache.test.ts
+++ b/server/src/hltb-cache.test.ts
@@ -123,6 +123,64 @@ void test('HLTB cache stores on miss and serves on hit', async () => {
   await app.close();
 });
 
+void test('HLTB cache force-refresh header bypasses a fresh cache entry, then refreshes the cache for regular traffic', async () => {
+  resetCacheMetrics();
+  const pool = new HltbPoolMock();
+  const app = Fastify();
+  let fetchCalls = 0;
+
+  await registerHltbCachedRoute(app, pool as unknown as Pool, {
+    fetchMetadata: () => {
+      fetchCalls += 1;
+      const hltbMainHours = fetchCalls === 1 ? 20 : 30;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: { hltbMainHours }, candidates: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    },
+  });
+
+  const first = await app.inject({
+    method: 'GET',
+    url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+  });
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.headers['x-gameshelf-hltb-cache'], 'MISS');
+  assert.equal(fetchCalls, 1);
+
+  const forced = await app.inject({
+    method: 'GET',
+    url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+    headers: { 'x-gameshelf-force-refresh': '1' },
+  });
+  assert.equal(forced.statusCode, 200);
+  assert.equal(forced.headers['x-gameshelf-hltb-cache'], 'BYPASS');
+  assert.equal(fetchCalls, 2);
+  assert.equal(
+    (JSON.parse(forced.body) as { item: { hltbMainHours: number } }).item.hltbMainHours,
+    30
+  );
+
+  const afterForced = await app.inject({
+    method: 'GET',
+    url: '/v1/hltb/search?q=Okami&releaseYear=2006&platform=Wii',
+  });
+  assert.equal(afterForced.statusCode, 200);
+  assert.equal(afterForced.headers['x-gameshelf-hltb-cache'], 'HIT_FRESH');
+  assert.equal(fetchCalls, 2);
+  assert.equal(
+    (JSON.parse(afterForced.body) as { item: { hltbMainHours: number } }).item.hltbMainHours,
+    30
+  );
+
+  const metrics = getCacheMetrics();
+  assert.equal(metrics.hltb.bypasses, 1);
+
+  await app.close();
+});
+
 void test('HLTB cache supports candidates when includeCandidates is enabled', async () => {
   resetCacheMetrics();
   const pool = new HltbPoolMock();

--- a/server/src/hltb-cache.test.ts
+++ b/server/src/hltb-cache.test.ts
@@ -177,6 +177,7 @@ void test('HLTB cache force-refresh header bypasses a fresh cache entry, then re
 
   const metrics = getCacheMetrics();
   assert.equal(metrics.hltb.bypasses, 1);
+  assert.equal(metrics.hltb.misses, 1);
 
   await app.close();
 });

--- a/server/src/hltb-cache.ts
+++ b/server/src/hltb-cache.ts
@@ -76,9 +76,15 @@ export async function registerHltbCachedRoute(
     handler: async (request, reply) => {
       const normalized = normalizeHltbQuery(request.url);
       const cacheKey = normalized ? buildCacheKey(normalized) : null;
+      const bypassCache = request.headers['x-gameshelf-force-refresh'] === '1';
       let cacheOutcome: 'MISS' | 'BYPASS' = 'MISS';
 
-      if (cacheKey && normalized) {
+      if (bypassCache) {
+        incrementHltbMetric('bypasses');
+        cacheOutcome = 'BYPASS';
+      }
+
+      if (cacheKey && normalized && !bypassCache) {
         try {
           const cached = await pool.query<HltbCacheRow>(
             'SELECT response_json, updated_at FROM hltb_search_cache WHERE cache_key = $1 LIMIT 1',

--- a/server/src/hltb-cache.ts
+++ b/server/src/hltb-cache.ts
@@ -3,12 +3,14 @@ import fs from 'node:fs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import { incrementHltbMetric } from './cache-metrics.js';
+import { config } from './config.js';
 import {
   logUpstreamRequest,
   logUpstreamResponse,
   sanitizeUrlForDebugLogs,
 } from './http-debug-log.js';
 import { applyRouteRateLimit, ensureRateLimitRegistered } from './rate-limit.js';
+import { CLIENT_WRITE_TOKEN_HEADER_NAME, isAuthorizedMutatingRequest } from './request-security.js';
 
 interface HltbCacheRow {
   response_json: unknown;
@@ -76,7 +78,7 @@ export async function registerHltbCachedRoute(
     handler: async (request, reply) => {
       const normalized = normalizeHltbQuery(request.url);
       const cacheKey = normalized ? buildCacheKey(normalized) : null;
-      const bypassCache = request.headers['x-gameshelf-force-refresh'] === '1';
+      const bypassCache = isAuthorizedForceRefreshRequest(request);
       let cacheOutcome: 'MISS' | 'BYPASS' = 'MISS';
 
       if (bypassCache) {
@@ -165,6 +167,20 @@ export async function registerHltbCachedRoute(
       reply.header('X-GameShelf-HLTB-Cache', cacheOutcome);
       await sendWebResponse(reply, response);
     },
+  });
+}
+
+function isAuthorizedForceRefreshRequest(request: FastifyRequest): boolean {
+  if (request.headers['x-gameshelf-force-refresh'] !== '1') {
+    return false;
+  }
+
+  return isAuthorizedMutatingRequest({
+    requireAuth: true,
+    apiToken: config.apiToken,
+    clientWriteTokens: config.clientWriteTokens,
+    authorizationHeader: request.headers.authorization,
+    clientWriteTokenHeader: request.headers[CLIENT_WRITE_TOKEN_HEADER_NAME],
   });
 }
 

--- a/server/src/hltb-cache.ts
+++ b/server/src/hltb-cache.ts
@@ -135,7 +135,9 @@ export async function registerHltbCachedRoute(
         }
       }
 
-      incrementHltbMetric('misses');
+      if (!bypassCache) {
+        incrementHltbMetric('misses');
+      }
       const response = await fetchMetadata(request);
 
       if (normalized && response.ok) {

--- a/server/src/hltb-cache.ts
+++ b/server/src/hltb-cache.ts
@@ -176,7 +176,7 @@ function isAuthorizedForceRefreshRequest(request: FastifyRequest): boolean {
   }
 
   return isAuthorizedMutatingRequest({
-    requireAuth: true,
+    requireAuth: config.requireAuth,
     apiToken: config.apiToken,
     clientWriteTokens: config.clientWriteTokens,
     authorizationHeader: request.headers.authorization,

--- a/server/src/metacritic-cache.test.ts
+++ b/server/src/metacritic-cache.test.ts
@@ -160,6 +160,64 @@ void test('METACRITIC cache stores on miss and serves on hit', async () => {
   await app.close();
 });
 
+void test('METACRITIC cache force-refresh header bypasses a fresh cache entry, then refreshes the cache for regular traffic', async () => {
+  resetCacheMetrics();
+  const pool = new MetacriticPoolMock();
+  const app = Fastify();
+  let fetchCalls = 0;
+
+  await registerMetacriticCachedRoute(app, pool as unknown as Pool, {
+    fetchMetadata: () => {
+      fetchCalls += 1;
+      const metacriticScore = fetchCalls === 1 ? 20 : 30;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: { metacriticScore }, candidates: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    },
+  });
+
+  const first = await app.inject({
+    method: 'GET',
+    url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+  });
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.headers['x-gameshelf-metacritic-cache'], 'MISS');
+  assert.equal(fetchCalls, 1);
+
+  const forced = await app.inject({
+    method: 'GET',
+    url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+    headers: { 'x-gameshelf-force-refresh': '1' },
+  });
+  assert.equal(forced.statusCode, 200);
+  assert.equal(forced.headers['x-gameshelf-metacritic-cache'], 'BYPASS');
+  assert.equal(fetchCalls, 2);
+  assert.equal(
+    (JSON.parse(forced.body) as { item: { metacriticScore: number } }).item.metacriticScore,
+    30
+  );
+
+  const afterForced = await app.inject({
+    method: 'GET',
+    url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+  });
+  assert.equal(afterForced.statusCode, 200);
+  assert.equal(afterForced.headers['x-gameshelf-metacritic-cache'], 'HIT_FRESH');
+  assert.equal(fetchCalls, 2);
+  assert.equal(
+    (JSON.parse(afterForced.body) as { item: { metacriticScore: number } }).item.metacriticScore,
+    30
+  );
+
+  const metrics = getCacheMetrics();
+  assert.equal(metrics.metacritic.bypasses, 1);
+
+  await app.close();
+});
+
 void test('METACRITIC cache supports candidates when includeCandidates is enabled', async () => {
   resetCacheMetrics();
   const pool = new MetacriticPoolMock();

--- a/server/src/metacritic-cache.test.ts
+++ b/server/src/metacritic-cache.test.ts
@@ -214,6 +214,7 @@ void test('METACRITIC cache force-refresh header bypasses a fresh cache entry, t
 
   const metrics = getCacheMetrics();
   assert.equal(metrics.metacritic.bypasses, 1);
+  assert.equal(metrics.metacritic.misses, 1);
 
   await app.close();
 });

--- a/server/src/metacritic-cache.test.ts
+++ b/server/src/metacritic-cache.test.ts
@@ -8,6 +8,7 @@ import Fastify from 'fastify';
 import type { Pool } from 'pg';
 import { __metacriticCacheTestables, registerMetacriticCachedRoute } from './metacritic-cache.js';
 import { getCacheMetrics, resetCacheMetrics } from './cache-metrics.js';
+import { config } from './config.js';
 
 function toPrimitiveString(value: unknown): string {
   if (typeof value === 'string') {
@@ -162,61 +163,113 @@ void test('METACRITIC cache stores on miss and serves on hit', async () => {
 
 void test('METACRITIC cache force-refresh header bypasses a fresh cache entry, then refreshes the cache for regular traffic', async () => {
   resetCacheMetrics();
+  const originalApiToken = config.apiToken;
+  config.apiToken = 'test-api-token';
   const pool = new MetacriticPoolMock();
   const app = Fastify();
   let fetchCalls = 0;
 
-  await registerMetacriticCachedRoute(app, pool as unknown as Pool, {
-    fetchMetadata: () => {
-      fetchCalls += 1;
-      const metacriticScore = fetchCalls === 1 ? 20 : 30;
-      return Promise.resolve(
-        new Response(JSON.stringify({ item: { metacriticScore }, candidates: [] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      );
-    },
-  });
+  try {
+    await registerMetacriticCachedRoute(app, pool as unknown as Pool, {
+      fetchMetadata: () => {
+        fetchCalls += 1;
+        const metacriticScore = fetchCalls === 1 ? 20 : 30;
+        return Promise.resolve(
+          new Response(JSON.stringify({ item: { metacriticScore }, candidates: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      },
+    });
 
-  const first = await app.inject({
-    method: 'GET',
-    url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
-  });
-  assert.equal(first.statusCode, 200);
-  assert.equal(first.headers['x-gameshelf-metacritic-cache'], 'MISS');
-  assert.equal(fetchCalls, 1);
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+    });
+    assert.equal(first.statusCode, 200);
+    assert.equal(first.headers['x-gameshelf-metacritic-cache'], 'MISS');
+    assert.equal(fetchCalls, 1);
 
-  const forced = await app.inject({
-    method: 'GET',
-    url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
-    headers: { 'x-gameshelf-force-refresh': '1' },
-  });
-  assert.equal(forced.statusCode, 200);
-  assert.equal(forced.headers['x-gameshelf-metacritic-cache'], 'BYPASS');
-  assert.equal(fetchCalls, 2);
-  assert.equal(
-    (JSON.parse(forced.body) as { item: { metacriticScore: number } }).item.metacriticScore,
-    30
-  );
+    const forced = await app.inject({
+      method: 'GET',
+      url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+      headers: {
+        'x-gameshelf-force-refresh': '1',
+        authorization: 'Bearer test-api-token',
+      },
+    });
+    assert.equal(forced.statusCode, 200);
+    assert.equal(forced.headers['x-gameshelf-metacritic-cache'], 'BYPASS');
+    assert.equal(fetchCalls, 2);
+    assert.equal(
+      (JSON.parse(forced.body) as { item: { metacriticScore: number } }).item.metacriticScore,
+      30
+    );
 
-  const afterForced = await app.inject({
-    method: 'GET',
-    url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
-  });
-  assert.equal(afterForced.statusCode, 200);
-  assert.equal(afterForced.headers['x-gameshelf-metacritic-cache'], 'HIT_FRESH');
-  assert.equal(fetchCalls, 2);
-  assert.equal(
-    (JSON.parse(afterForced.body) as { item: { metacriticScore: number } }).item.metacriticScore,
-    30
-  );
+    const afterForced = await app.inject({
+      method: 'GET',
+      url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+    });
+    assert.equal(afterForced.statusCode, 200);
+    assert.equal(afterForced.headers['x-gameshelf-metacritic-cache'], 'HIT_FRESH');
+    assert.equal(fetchCalls, 2);
+    assert.equal(
+      (JSON.parse(afterForced.body) as { item: { metacriticScore: number } }).item.metacriticScore,
+      30
+    );
 
-  const metrics = getCacheMetrics();
-  assert.equal(metrics.metacritic.bypasses, 1);
-  assert.equal(metrics.metacritic.misses, 1);
+    const metrics = getCacheMetrics();
+    assert.equal(metrics.metacritic.bypasses, 1);
+    assert.equal(metrics.metacritic.misses, 1);
+  } finally {
+    config.apiToken = originalApiToken;
+    await app.close();
+  }
+});
 
-  await app.close();
+void test('METACRITIC cache force-refresh header is ignored without a valid auth token', async () => {
+  resetCacheMetrics();
+  const originalApiToken = config.apiToken;
+  config.apiToken = 'test-api-token';
+  const pool = new MetacriticPoolMock();
+  const app = Fastify();
+  let fetchCalls = 0;
+
+  try {
+    await registerMetacriticCachedRoute(app, pool as unknown as Pool, {
+      fetchMetadata: () => {
+        fetchCalls += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify({ item: { metacriticScore: 20 }, candidates: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      },
+    });
+
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+    });
+    assert.equal(first.headers['x-gameshelf-metacritic-cache'], 'MISS');
+    assert.equal(fetchCalls, 1);
+
+    const unauthorizedForced = await app.inject({
+      method: 'GET',
+      url: '/v1/metacritic/search?q=Okami&releaseYear=2006&platform=Wii',
+      headers: { 'x-gameshelf-force-refresh': '1' },
+    });
+    assert.equal(unauthorizedForced.headers['x-gameshelf-metacritic-cache'], 'HIT_FRESH');
+    assert.equal(fetchCalls, 1);
+
+    const metrics = getCacheMetrics();
+    assert.equal(metrics.metacritic.bypasses, 0);
+  } finally {
+    config.apiToken = originalApiToken;
+    await app.close();
+  }
 });
 
 void test('METACRITIC cache supports candidates when includeCandidates is enabled', async () => {

--- a/server/src/metacritic-cache.ts
+++ b/server/src/metacritic-cache.ts
@@ -3,12 +3,14 @@ import fs from 'node:fs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import { incrementMetacriticMetric } from './cache-metrics.js';
+import { config } from './config.js';
 import {
   logUpstreamRequest,
   logUpstreamResponse,
   sanitizeUrlForDebugLogs,
 } from './http-debug-log.js';
 import { applyRouteRateLimit, ensureRateLimitRegistered } from './rate-limit.js';
+import { CLIENT_WRITE_TOKEN_HEADER_NAME, isAuthorizedMutatingRequest } from './request-security.js';
 
 interface MetacriticCacheRow {
   response_json: unknown;
@@ -74,7 +76,7 @@ export async function registerMetacriticCachedRoute(
     handler: async (request, reply) => {
       const normalized = normalizeMetacriticQuery(request.url);
       const cacheKey = normalized ? buildCacheKey(normalized) : null;
-      const bypassCache = request.headers['x-gameshelf-force-refresh'] === '1';
+      const bypassCache = isAuthorizedForceRefreshRequest(request);
       let cacheOutcome: 'MISS' | 'BYPASS' = 'MISS';
 
       if (bypassCache) {
@@ -152,6 +154,20 @@ export async function registerMetacriticCachedRoute(
       reply.header('X-GameShelf-METACRITIC-Cache', cacheOutcome);
       await sendWebResponse(reply, response);
     },
+  });
+}
+
+function isAuthorizedForceRefreshRequest(request: FastifyRequest): boolean {
+  if (request.headers['x-gameshelf-force-refresh'] !== '1') {
+    return false;
+  }
+
+  return isAuthorizedMutatingRequest({
+    requireAuth: true,
+    apiToken: config.apiToken,
+    clientWriteTokens: config.clientWriteTokens,
+    authorizationHeader: request.headers.authorization,
+    clientWriteTokenHeader: request.headers[CLIENT_WRITE_TOKEN_HEADER_NAME],
   });
 }
 

--- a/server/src/metacritic-cache.ts
+++ b/server/src/metacritic-cache.ts
@@ -136,7 +136,9 @@ export async function registerMetacriticCachedRoute(
         }
       }
 
-      incrementMetacriticMetric('misses');
+      if (!bypassCache) {
+        incrementMetacriticMetric('misses');
+      }
       const response = await fetchMetadata(request);
 
       if (cacheKey && normalized && response.ok) {

--- a/server/src/metacritic-cache.ts
+++ b/server/src/metacritic-cache.ts
@@ -74,9 +74,15 @@ export async function registerMetacriticCachedRoute(
     handler: async (request, reply) => {
       const normalized = normalizeMetacriticQuery(request.url);
       const cacheKey = normalized ? buildCacheKey(normalized) : null;
+      const bypassCache = request.headers['x-gameshelf-force-refresh'] === '1';
       let cacheOutcome: 'MISS' | 'BYPASS' = 'MISS';
 
-      if (cacheKey && normalized) {
+      if (bypassCache) {
+        incrementMetacriticMetric('bypasses');
+        cacheOutcome = 'BYPASS';
+      }
+
+      if (cacheKey && normalized && !bypassCache) {
         try {
           const cached = await pool.query<MetacriticCacheRow>(
             'SELECT response_json, updated_at FROM metacritic_search_cache WHERE cache_key = $1 LIMIT 1',

--- a/server/src/metacritic-cache.ts
+++ b/server/src/metacritic-cache.ts
@@ -163,7 +163,7 @@ function isAuthorizedForceRefreshRequest(request: FastifyRequest): boolean {
   }
 
   return isAuthorizedMutatingRequest({
-    requireAuth: true,
+    requireAuth: config.requireAuth,
     apiToken: config.apiToken,
     clientWriteTokens: config.clientWriteTokens,
     authorizationHeader: request.headers.authorization,

--- a/server/src/mobygames-cache.test.ts
+++ b/server/src/mobygames-cache.test.ts
@@ -169,6 +169,64 @@ void test('MOBYGAMES cache stores on miss and serves on hit', async () => {
   await app.close();
 });
 
+void test('MOBYGAMES cache force-refresh header bypasses a fresh cache entry, then refreshes the cache for regular traffic', async () => {
+  resetCacheMetrics();
+  const pool = new MobyGamesPoolMock();
+  const app = Fastify();
+  let fetchCalls = 0;
+
+  await registerMobyGamesCachedRoute(app, pool as unknown as Pool, {
+    fetchMetadata: () => {
+      fetchCalls += 1;
+      const title = fetchCalls === 1 ? 'Okami' : 'Okami HD';
+      return Promise.resolve(
+        new Response(JSON.stringify({ games: [{ game_id: 1, title }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    },
+  });
+
+  const first = await app.inject({
+    method: 'GET',
+    url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+  });
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.headers['x-gameshelf-mobygames-cache'], 'MISS');
+  assert.equal(fetchCalls, 1);
+
+  const forced = await app.inject({
+    method: 'GET',
+    url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+    headers: { 'x-gameshelf-force-refresh': '1' },
+  });
+  assert.equal(forced.statusCode, 200);
+  assert.equal(forced.headers['x-gameshelf-mobygames-cache'], 'BYPASS');
+  assert.equal(fetchCalls, 2);
+  assert.equal(
+    (JSON.parse(forced.body) as { games: Array<{ title: string }> }).games[0]?.title,
+    'Okami HD'
+  );
+
+  const afterForced = await app.inject({
+    method: 'GET',
+    url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+  });
+  assert.equal(afterForced.statusCode, 200);
+  assert.equal(afterForced.headers['x-gameshelf-mobygames-cache'], 'HIT_FRESH');
+  assert.equal(fetchCalls, 2);
+  assert.equal(
+    (JSON.parse(afterForced.body) as { games: Array<{ title: string }> }).games[0]?.title,
+    'Okami HD'
+  );
+
+  const metrics = getCacheMetrics();
+  assert.equal(metrics.mobygames.bypasses, 1);
+
+  await app.close();
+});
+
 void test('MOBYGAMES cache bypasses cache when query is too short', async () => {
   resetCacheMetrics();
   const pool = new MobyGamesPoolMock();

--- a/server/src/mobygames-cache.test.ts
+++ b/server/src/mobygames-cache.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 import Fastify from 'fastify';
 import type { Pool } from 'pg';
 import { getCacheMetrics, resetCacheMetrics } from './cache-metrics.js';
+import { config } from './config.js';
 import { __mobygamesCacheTestables, registerMobyGamesCachedRoute } from './mobygames-cache.js';
 
 function toPrimitiveString(value: unknown): string {
@@ -171,60 +172,112 @@ void test('MOBYGAMES cache stores on miss and serves on hit', async () => {
 
 void test('MOBYGAMES cache force-refresh header bypasses a fresh cache entry, then refreshes the cache for regular traffic', async () => {
   resetCacheMetrics();
+  const originalApiToken = config.apiToken;
+  config.apiToken = 'test-api-token';
   const pool = new MobyGamesPoolMock();
   const app = Fastify();
   let fetchCalls = 0;
 
-  await registerMobyGamesCachedRoute(app, pool as unknown as Pool, {
-    fetchMetadata: () => {
-      fetchCalls += 1;
-      const title = fetchCalls === 1 ? 'Okami' : 'Okami HD';
-      return Promise.resolve(
-        new Response(JSON.stringify({ games: [{ game_id: 1, title }] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      );
-    },
-  });
+  try {
+    await registerMobyGamesCachedRoute(app, pool as unknown as Pool, {
+      fetchMetadata: () => {
+        fetchCalls += 1;
+        const title = fetchCalls === 1 ? 'Okami' : 'Okami HD';
+        return Promise.resolve(
+          new Response(JSON.stringify({ games: [{ game_id: 1, title }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      },
+    });
 
-  const first = await app.inject({
-    method: 'GET',
-    url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
-  });
-  assert.equal(first.statusCode, 200);
-  assert.equal(first.headers['x-gameshelf-mobygames-cache'], 'MISS');
-  assert.equal(fetchCalls, 1);
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+    });
+    assert.equal(first.statusCode, 200);
+    assert.equal(first.headers['x-gameshelf-mobygames-cache'], 'MISS');
+    assert.equal(fetchCalls, 1);
 
-  const forced = await app.inject({
-    method: 'GET',
-    url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
-    headers: { 'x-gameshelf-force-refresh': '1' },
-  });
-  assert.equal(forced.statusCode, 200);
-  assert.equal(forced.headers['x-gameshelf-mobygames-cache'], 'BYPASS');
-  assert.equal(fetchCalls, 2);
-  assert.equal(
-    (JSON.parse(forced.body) as { games: Array<{ title: string }> }).games[0]?.title,
-    'Okami HD'
-  );
+    const forced = await app.inject({
+      method: 'GET',
+      url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+      headers: {
+        'x-gameshelf-force-refresh': '1',
+        authorization: 'Bearer test-api-token',
+      },
+    });
+    assert.equal(forced.statusCode, 200);
+    assert.equal(forced.headers['x-gameshelf-mobygames-cache'], 'BYPASS');
+    assert.equal(fetchCalls, 2);
+    assert.equal(
+      (JSON.parse(forced.body) as { games: Array<{ title: string }> }).games[0]?.title,
+      'Okami HD'
+    );
 
-  const afterForced = await app.inject({
-    method: 'GET',
-    url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
-  });
-  assert.equal(afterForced.statusCode, 200);
-  assert.equal(afterForced.headers['x-gameshelf-mobygames-cache'], 'HIT_FRESH');
-  assert.equal(fetchCalls, 2);
-  assert.equal(
-    (JSON.parse(afterForced.body) as { games: Array<{ title: string }> }).games[0]?.title,
-    'Okami HD'
-  );
+    const afterForced = await app.inject({
+      method: 'GET',
+      url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+    });
+    assert.equal(afterForced.statusCode, 200);
+    assert.equal(afterForced.headers['x-gameshelf-mobygames-cache'], 'HIT_FRESH');
+    assert.equal(fetchCalls, 2);
+    assert.equal(
+      (JSON.parse(afterForced.body) as { games: Array<{ title: string }> }).games[0]?.title,
+      'Okami HD'
+    );
 
-  const metrics = getCacheMetrics();
-  assert.equal(metrics.mobygames.bypasses, 1);
+    const metrics = getCacheMetrics();
+    assert.equal(metrics.mobygames.bypasses, 1);
+  } finally {
+    config.apiToken = originalApiToken;
+    await app.close();
+  }
+});
 
-  await app.close();
+void test('MOBYGAMES cache force-refresh header is ignored without a valid auth token', async () => {
+  resetCacheMetrics();
+  const originalApiToken = config.apiToken;
+  config.apiToken = 'test-api-token';
+  const pool = new MobyGamesPoolMock();
+  const app = Fastify();
+  let fetchCalls = 0;
+
+  try {
+    await registerMobyGamesCachedRoute(app, pool as unknown as Pool, {
+      fetchMetadata: () => {
+        fetchCalls += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify({ games: [{ game_id: 1, title: 'Okami' }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      },
+    });
+
+    const first = await app.inject({
+      method: 'GET',
+      url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+    });
+    assert.equal(first.headers['x-gameshelf-mobygames-cache'], 'MISS');
+    assert.equal(fetchCalls, 1);
+
+    const unauthorizedForced = await app.inject({
+      method: 'GET',
+      url: '/v1/mobygames/search?q=Okami&platform=9&limit=5',
+      headers: { 'x-gameshelf-force-refresh': '1' },
+    });
+    assert.equal(unauthorizedForced.headers['x-gameshelf-mobygames-cache'], 'HIT_FRESH');
+    assert.equal(fetchCalls, 1);
+
+    const metrics = getCacheMetrics();
+    assert.equal(metrics.mobygames.bypasses, 0);
+  } finally {
+    config.apiToken = originalApiToken;
+    await app.close();
+  }
 });
 
 void test('MOBYGAMES cache bypasses cache when query is too short', async () => {

--- a/server/src/mobygames-cache.ts
+++ b/server/src/mobygames-cache.ts
@@ -12,6 +12,7 @@ import {
   sanitizeUrlForDebugLogs,
 } from './http-debug-log.js';
 import { applyRouteRateLimit, ensureRateLimitRegistered } from './rate-limit.js';
+import { CLIENT_WRITE_TOKEN_HEADER_NAME, isAuthorizedMutatingRequest } from './request-security.js';
 
 interface MobyGamesCacheRow {
   response_json: unknown;
@@ -96,7 +97,7 @@ export async function registerMobyGamesCachedRoute(
     handler: async (request, reply) => {
       const normalized = normalizeMobyGamesQuery(request.url);
       const cacheKey = normalized ? buildCacheKey(normalized) : null;
-      const bypassCache = request.headers['x-gameshelf-force-refresh'] === '1';
+      const bypassCache = isAuthorizedForceRefreshRequest(request);
       let cacheOutcome: 'MISS' | 'BYPASS' = 'MISS';
 
       if (cacheKey && normalized && !bypassCache) {
@@ -247,6 +248,20 @@ function describeMobygamesPayload(payload: unknown): Record<string, unknown> {
     gameCount: games.length,
     firstTitle,
   };
+}
+
+function isAuthorizedForceRefreshRequest(request: FastifyRequest): boolean {
+  if (request.headers['x-gameshelf-force-refresh'] !== '1') {
+    return false;
+  }
+
+  return isAuthorizedMutatingRequest({
+    requireAuth: true,
+    apiToken: config.apiToken,
+    clientWriteTokens: config.clientWriteTokens,
+    authorizationHeader: request.headers.authorization,
+    clientWriteTokenHeader: request.headers[CLIENT_WRITE_TOKEN_HEADER_NAME],
+  });
 }
 
 function normalizeMobyGamesQuery(rawUrl: string): NormalizedMobyGamesQuery | null {

--- a/server/src/mobygames-cache.ts
+++ b/server/src/mobygames-cache.ts
@@ -96,9 +96,10 @@ export async function registerMobyGamesCachedRoute(
     handler: async (request, reply) => {
       const normalized = normalizeMobyGamesQuery(request.url);
       const cacheKey = normalized ? buildCacheKey(normalized) : null;
+      const bypassCache = request.headers['x-gameshelf-force-refresh'] === '1';
       let cacheOutcome: 'MISS' | 'BYPASS' = 'MISS';
 
-      if (cacheKey && normalized) {
+      if (cacheKey && normalized && !bypassCache) {
         try {
           const cached = await pool.query<MobyGamesCacheRow>(
             'SELECT response_json, updated_at FROM mobygames_search_cache WHERE cache_key = $1 LIMIT 1',
@@ -167,7 +168,13 @@ export async function registerMobyGamesCachedRoute(
         }
       }
 
-      if (!normalized) {
+      if (bypassCache) {
+        cacheOutcome = 'BYPASS';
+        incrementMobygamesMetric('bypasses');
+        logMobygamesCacheDecision(request, 'BYPASS', normalized, null, {
+          reason: 'forced_refresh',
+        });
+      } else if (!normalized) {
         cacheOutcome = 'BYPASS';
         incrementMobygamesMetric('bypasses');
         logMobygamesCacheDecision(request, 'BYPASS', null, null, {

--- a/server/src/mobygames-cache.ts
+++ b/server/src/mobygames-cache.ts
@@ -256,7 +256,7 @@ function isAuthorizedForceRefreshRequest(request: FastifyRequest): boolean {
   }
 
   return isAuthorizedMutatingRequest({
-    requireAuth: true,
+    requireAuth: config.requireAuth,
     apiToken: config.apiToken,
     clientWriteTokens: config.clientWriteTokens,
     authorizationHeader: request.headers.authorization,

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -395,6 +395,9 @@ export interface ForcedRefreshResult {
   hltb: ForcedRefreshDataTypeStats;
   metacritic: ForcedRefreshDataTypeStats;
   mobygames: ForcedRefreshDataTypeStats;
+  // Job-level counts: one release_monitor_game job can satisfy both hltb and review for a
+  // row, so this is the union of due rows rather than a sum of the per-provider buckets.
+  job: ForcedRefreshDataTypeStats;
 }
 
 function newForcedRefreshDataTypeStats(): ForcedRefreshDataTypeStats {
@@ -417,6 +420,7 @@ export async function enqueueForcedReleaseMonitorRefreshJobs(
     hltb: newForcedRefreshDataTypeStats(),
     metacritic: newForcedRefreshDataTypeStats(),
     mobygames: newForcedRefreshDataTypeStats(),
+    job: newForcedRefreshDataTypeStats(),
   };
 
   const dueByRow = rows.map((row) =>
@@ -429,6 +433,9 @@ export async function enqueueForcedReleaseMonitorRefreshJobs(
   if (force.review) {
     result.metacritic.scanned = rows.length;
     result.mobygames.scanned = rows.length;
+  }
+  if (force.hltb || force.review) {
+    result.job.scanned = rows.length;
   }
 
   const enqueueTasks: Array<{
@@ -469,6 +476,11 @@ export async function enqueueForcedReleaseMonitorRefreshJobs(
 
   enqueueResults.forEach((enqueueResult, index) => {
     const { due } = enqueueTasks[index];
+    if (enqueueResult.deduped) {
+      result.job.deduped += 1;
+    } else {
+      result.job.enqueued += 1;
+    }
     if (due.hltbDue) {
       if (enqueueResult.deduped) {
         result.hltb.deduped += 1;

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -1021,7 +1021,16 @@ type RefreshedReviewPayload =
 const FORCE_REFRESH_HEADER_NAME = 'X-GameShelf-Force-Refresh';
 
 function forceFreshHeaders(forceFresh?: boolean): Record<string, string> | undefined {
-  return forceFresh ? { [FORCE_REFRESH_HEADER_NAME]: '1' } : undefined;
+  if (!forceFresh) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = { [FORCE_REFRESH_HEADER_NAME]: '1' };
+  const apiToken = config.apiToken.trim();
+  if (apiToken.length > 0) {
+    headers['Authorization'] = `Bearer ${apiToken}`;
+  }
+  return headers;
 }
 
 async function fetchHltbPayload(params: {

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -31,10 +31,7 @@ const RELEASE_NOTIFICATION_MONTH_YEAR_FORMATTER = new Intl.DateTimeFormat('en-US
 });
 
 type ReleaseEventType =
-  | 'release_date_set'
-  | 'release_date_changed'
-  | 'release_date_removed'
-  | 'release_day';
+  'release_date_set' | 'release_date_changed' | 'release_date_removed' | 'release_day';
 type ReleaseState = 'unknown' | 'scheduled' | 'released';
 export type ReleasePrecision = 'unknown' | 'year' | 'quarter' | 'month' | 'day';
 
@@ -55,6 +52,7 @@ interface DueGameRow {
   force_review?: boolean;
   respect_recency?: boolean;
   respect_staleness?: boolean;
+  bypass_cache?: boolean;
 }
 
 interface NotificationPreferences {
@@ -286,7 +284,59 @@ function buildReleaseMonitorGameJobPayload(
     force_review: forceOverrides?.review === true,
     respect_recency: forceOverrides?.respectRecency ?? true,
     respect_staleness: forceOverrides?.respectStaleness ?? false,
+    bypass_cache: forceOverrides?.hltb === true || forceOverrides?.review === true,
   };
+}
+
+interface ForcedRefreshDueResult {
+  hltbDue: boolean;
+  reviewDue: boolean;
+  reviewProvider: 'metacritic' | 'mobygames' | null;
+}
+
+// Mirrors the due-check in processGameRow (hltbDue/reviewDue), but evaluates against the
+// row's pre-refetch release_watch_state columns instead of a freshly refetched IGDB release
+// date, so it can run cheaply at enqueue time across the whole candidate pool. This is an
+// approximation: a game whose IGDB release date changes between this scan and the worker's
+// own fresh refetch could be excluded here even though the worker would find it due.
+function evaluateForcedRefreshDue(
+  row: DueGameRow,
+  force: { hltb: boolean; review: boolean },
+  options: { respectRecency: boolean; respectStaleness: boolean },
+  now: Date
+): ForcedRefreshDueResult {
+  const payload = row.payload ?? {};
+  const releaseBefore = deriveReleaseInfo({
+    marker: stringOrNull(row.last_known_release_marker),
+    precision: normalizeReleasePrecision(row.last_known_release_precision),
+    releaseDate: stringOrNull(row.last_known_release_date) ?? stringOrNull(payload['releaseDate']),
+    releaseYear: integerOrNull(row.last_known_release_year ?? payload['releaseYear']),
+  });
+
+  const hltbEligible = isWithinPastYears(releaseBefore, now, config.hltbPeriodicRefreshYears);
+  const metacriticEligible = isWithinPastYears(
+    releaseBefore,
+    now,
+    config.metacriticPeriodicRefreshYears
+  );
+
+  const hltbDue = force.hltb
+    ? (!options.respectRecency || hltbEligible) &&
+      (!options.respectStaleness || isHltbRefreshDue(row.last_hltb_refresh_at, payload, now))
+    : false;
+  const reviewDue = force.review
+    ? (!options.respectRecency || metacriticEligible) &&
+      (!options.respectStaleness || isReviewRefreshDue(row.last_metacritic_refresh_at, now))
+    : false;
+
+  const reviewMatchMobygamesGameId = integerOrNull(payload['reviewMatchMobygamesGameId']);
+  const reviewProvider = reviewDue
+    ? typeof reviewMatchMobygamesGameId === 'number' && reviewMatchMobygamesGameId > 0
+      ? 'mobygames'
+      : 'metacritic'
+    : null;
+
+  return { hltbDue, reviewDue, reviewProvider };
 }
 
 async function enqueueReleaseMonitorGameJob(pool: Pool, row: DueGameRow): Promise<boolean> {
@@ -335,38 +385,108 @@ async function queryAllEligibleGamesForForcedRefresh(pool: Pool): Promise<DueGam
 
 const FORCED_REFRESH_ENQUEUE_CONCURRENCY = 5;
 
+export interface ForcedRefreshDataTypeStats {
+  scanned: number;
+  enqueued: number;
+  deduped: number;
+}
+
+export interface ForcedRefreshResult {
+  hltb: ForcedRefreshDataTypeStats;
+  metacritic: ForcedRefreshDataTypeStats;
+  mobygames: ForcedRefreshDataTypeStats;
+}
+
+function newForcedRefreshDataTypeStats(): ForcedRefreshDataTypeStats {
+  return { scanned: 0, enqueued: 0, deduped: 0 };
+}
+
 export async function enqueueForcedReleaseMonitorRefreshJobs(
   pool: Pool,
   force: { hltb: boolean; review: boolean },
   options?: { respectRecency?: boolean; respectStaleness?: boolean }
-): Promise<{ scanned: number; enqueued: number; deduped: number }> {
+): Promise<ForcedRefreshResult> {
   const jobs = new BackgroundJobRepository(pool);
   const rows = await queryAllEligibleGamesForForcedRefresh(pool);
   const respectRecency = options?.respectRecency ?? true;
   const respectStaleness = options?.respectStaleness ?? false;
   const forceSuffix = `${force.hltb ? '1' : '0'}${force.review ? '1' : '0'}${respectRecency ? '1' : '0'}${respectStaleness ? '1' : '0'}`;
+  const now = new Date();
 
-  const tasks = rows.map((row) => async () => {
+  const result: ForcedRefreshResult = {
+    hltb: newForcedRefreshDataTypeStats(),
+    metacritic: newForcedRefreshDataTypeStats(),
+    mobygames: newForcedRefreshDataTypeStats(),
+  };
+
+  const dueByRow = rows.map((row) =>
+    evaluateForcedRefreshDue(row, force, { respectRecency, respectStaleness }, now)
+  );
+
+  if (force.hltb) {
+    result.hltb.scanned = rows.length;
+  }
+  if (force.review) {
+    result.metacritic.scanned = rows.length;
+    result.mobygames.scanned = rows.length;
+  }
+
+  const enqueueTasks: Array<{
+    row: DueGameRow;
+    due: ForcedRefreshDueResult;
+    task: () => Promise<{ deduped: boolean }>;
+  }> = [];
+
+  rows.forEach((row, index) => {
+    const due = dueByRow[index];
+    if (!(due.hltbDue || due.reviewDue)) {
+      return;
+    }
     const dedupeKey = `release-monitor:forced:${forceSuffix}:${row.igdb_game_id}:${String(row.platform_igdb_id)}`;
     const payload = buildReleaseMonitorGameJobPayload(row, {
       ...force,
       respectRecency,
       respectStaleness,
     });
-    return jobs.enqueue({
-      jobType: 'release_monitor_game',
-      dedupeKey,
-      payload,
-      priority: 80,
-      maxAttempts: 5,
+    enqueueTasks.push({
+      row,
+      due,
+      task: () =>
+        jobs.enqueue({
+          jobType: 'release_monitor_game',
+          dedupeKey,
+          payload,
+          priority: 80,
+          maxAttempts: 5,
+        }),
     });
   });
 
-  const results = await runWithConcurrencyLimit(tasks, FORCED_REFRESH_ENQUEUE_CONCURRENCY);
-  const enqueued = results.filter((result) => !result.deduped).length;
-  const deduped = results.filter((result) => result.deduped).length;
+  const enqueueResults = await runWithConcurrencyLimit(
+    enqueueTasks.map((entry) => entry.task),
+    FORCED_REFRESH_ENQUEUE_CONCURRENCY
+  );
 
-  return { scanned: rows.length, enqueued, deduped };
+  enqueueResults.forEach((enqueueResult, index) => {
+    const { due } = enqueueTasks[index];
+    if (due.hltbDue) {
+      if (enqueueResult.deduped) {
+        result.hltb.deduped += 1;
+      } else {
+        result.hltb.enqueued += 1;
+      }
+    }
+    if (due.reviewDue && due.reviewProvider) {
+      const bucket = result[due.reviewProvider];
+      if (enqueueResult.deduped) {
+        bucket.deduped += 1;
+      } else {
+        bucket.enqueued += 1;
+      }
+    }
+  });
+
+  return result;
 }
 
 function parseDueGameRowFromPayload(payload: Record<string, unknown>): DueGameRow | null {
@@ -400,6 +520,7 @@ function parseDueGameRowFromPayload(payload: Record<string, unknown>): DueGameRo
     force_review: payload['force_review'] === true,
     respect_recency: payload['respect_recency'] !== false,
     respect_staleness: payload['respect_staleness'] === true,
+    bypass_cache: payload['bypass_cache'] === true,
   };
   /* node:coverage enable */
 }
@@ -575,6 +696,7 @@ async function processGameRow(
         title: hltbRefreshQuery.title,
         releaseYear: hltbRefreshQuery.releaseYear,
         platform: hltbRefreshQuery.platform,
+        forceFresh: row.bypass_cache === true,
       });
 
       if (refreshedHltb.ok) {
@@ -604,7 +726,10 @@ async function processGameRow(
         platformName,
         platformIgdbId
       );
-      const refreshedReview = await fetchReviewPayload(reviewRefreshQuery);
+      const refreshedReview = await fetchReviewPayload({
+        ...reviewRefreshQuery,
+        forceFresh: row.bypass_cache === true,
+      });
 
       if (refreshedReview.ok) {
         if (refreshedReview.value) {
@@ -893,10 +1018,17 @@ type RefreshedReviewPayload =
       reviewUrl: string | null;
     };
 
+const FORCE_REFRESH_HEADER_NAME = 'X-GameShelf-Force-Refresh';
+
+function forceFreshHeaders(forceFresh?: boolean): Record<string, string> | undefined {
+  return forceFresh ? { [FORCE_REFRESH_HEADER_NAME]: '1' } : undefined;
+}
+
 async function fetchHltbPayload(params: {
   title: string;
   releaseYear: number | null;
   platform: string | null;
+  forceFresh?: boolean;
 }): Promise<FetchJsonResult<HltbApiResponse['item']>> {
   if (params.title.trim().length < 2) {
     return { ok: true, value: null };
@@ -909,7 +1041,8 @@ async function fetchHltbPayload(params: {
   });
   const result = await fetchLocalApiJson<HltbApiResponse>(
     url,
-    config.recommendationsDiscoveryEnrichRequestTimeoutMs
+    config.recommendationsDiscoveryEnrichRequestTimeoutMs,
+    forceFreshHeaders(params.forceFresh)
   );
   if (!result.ok) {
     return { ok: false, value: null };
@@ -923,6 +1056,7 @@ async function fetchMetacriticPayload(params: {
   releaseYear: number | null;
   platform: string | null;
   platformIgdbId: number;
+  forceFresh?: boolean;
 }): Promise<FetchJsonResult<MetacriticApiResponse['item']>> {
   if (params.title.trim().length < 2) {
     return { ok: true, value: null };
@@ -936,7 +1070,8 @@ async function fetchMetacriticPayload(params: {
   });
   const result = await fetchLocalApiJson<MetacriticApiResponse>(
     url,
-    config.recommendationsDiscoveryEnrichRequestTimeoutMs
+    config.recommendationsDiscoveryEnrichRequestTimeoutMs,
+    forceFreshHeaders(params.forceFresh)
   );
   if (!result.ok) {
     return { ok: false, value: null };
@@ -951,11 +1086,13 @@ async function fetchReviewPayload(params: {
   platform: string | null;
   platformIgdbId: number;
   reviewMatchMobygamesGameId: number | null;
+  forceFresh?: boolean;
 }): Promise<FetchJsonResult<RefreshedReviewPayload>> {
   if (params.reviewMatchMobygamesGameId !== null) {
     const mobygames = await fetchMobygamesPayload({
       title: params.title,
       reviewMatchMobygamesGameId: params.reviewMatchMobygamesGameId,
+      forceFresh: params.forceFresh,
     });
     if (!mobygames.ok) {
       return { ok: false, value: null };
@@ -981,6 +1118,7 @@ async function fetchReviewPayload(params: {
     releaseYear: params.releaseYear,
     platform: params.platform,
     platformIgdbId: params.platformIgdbId,
+    forceFresh: params.forceFresh,
   });
   if (!metacritic.ok) {
     return { ok: false, value: null };
@@ -1002,6 +1140,7 @@ async function fetchReviewPayload(params: {
 async function fetchMobygamesPayload(params: {
   title: string;
   reviewMatchMobygamesGameId: number;
+  forceFresh?: boolean;
 }): Promise<
   FetchJsonResult<{
     mobygamesGameId: number | null;
@@ -1023,7 +1162,8 @@ async function fetchMobygamesPayload(params: {
   });
   const result = await fetchLocalApiJson<MobyGamesApiResponse>(
     url,
-    config.recommendationsDiscoveryEnrichRequestTimeoutMs
+    config.recommendationsDiscoveryEnrichRequestTimeoutMs,
+    forceFreshHeaders(params.forceFresh)
   );
   if (!result.ok) {
     return { ok: false, value: null };
@@ -2484,6 +2624,8 @@ export const releaseMonitorInternals = {
   processGameRow,
   enqueueReleaseMonitorGameJob,
   enqueueForcedReleaseMonitorRefreshJobs,
+  evaluateForcedRefreshDue,
+  buildReleaseMonitorGameJobPayload,
   queryAllEligibleGamesForForcedRefresh,
   parseDueGameRowFromPayload,
   processQueuedReleaseMonitorGame,

--- a/server/src/release-monitor.ts
+++ b/server/src/release-monitor.ts
@@ -13,6 +13,7 @@ import {
 } from './notification-constants.js';
 import { coercePreferenceBoolean } from './preference-bool.js';
 import { isProviderMatchLocked } from './provider-match-lock.js';
+import { CLIENT_WRITE_TOKEN_HEADER_NAME } from './request-security.js';
 import { runWithConcurrencyLimit } from './utils/concurrency.js';
 
 const RELEASE_NOTIFICATION_EVENT_SALE_KEY = 'sale';
@@ -1041,6 +1042,11 @@ function forceFreshHeaders(forceFresh?: boolean): Record<string, string> | undef
   const apiToken = config.apiToken.trim();
   if (apiToken.length > 0) {
     headers['Authorization'] = `Bearer ${apiToken}`;
+  } else {
+    const clientWriteToken = config.clientWriteTokens[0]?.trim();
+    if (clientWriteToken) {
+      headers[CLIENT_WRITE_TOKEN_HEADER_NAME] = clientWriteToken;
+    }
   }
   return headers;
 }

--- a/server/src/tests/release-monitor.delivery.test.ts
+++ b/server/src/tests/release-monitor.delivery.test.ts
@@ -1922,6 +1922,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows
     hltb: { scanned: 2, enqueued: 2, deduped: 0 },
     metacritic: { scanned: 0, enqueued: 0, deduped: 0 },
     mobygames: { scanned: 0, enqueued: 0, deduped: 0 },
+    job: { scanned: 2, enqueued: 2, deduped: 0 },
   });
   assert.equal(pool.queuedJobs, 2);
 
@@ -1933,6 +1934,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows
     hltb: { scanned: 2, enqueued: 0, deduped: 2 },
     metacritic: { scanned: 0, enqueued: 0, deduped: 0 },
     mobygames: { scanned: 0, enqueued: 0, deduped: 0 },
+    job: { scanned: 2, enqueued: 0, deduped: 2 },
   });
 });
 
@@ -1995,6 +1997,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respect
     hltb: { scanned: 1, enqueued: 1, deduped: 0 },
     metacritic: { scanned: 1, enqueued: 1, deduped: 0 },
     mobygames: { scanned: 1, enqueued: 0, deduped: 0 },
+    job: { scanned: 1, enqueued: 1, deduped: 0 },
   });
   const firstPayload = pool.lastEnqueuedPayload;
   assert.ok(firstPayload);
@@ -2012,6 +2015,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respect
     hltb: { scanned: 1, enqueued: 1, deduped: 0 },
     metacritic: { scanned: 1, enqueued: 1, deduped: 0 },
     mobygames: { scanned: 1, enqueued: 0, deduped: 0 },
+    job: { scanned: 1, enqueued: 1, deduped: 0 },
   });
 });
 
@@ -2061,6 +2065,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs buckets metacritic and mobygam
     hltb: { scanned: 0, enqueued: 0, deduped: 0 },
     metacritic: { scanned: 2, enqueued: 1, deduped: 0 },
     mobygames: { scanned: 2, enqueued: 1, deduped: 0 },
+    job: { scanned: 2, enqueued: 2, deduped: 0 },
   });
   // One job per row, not one per (row, provider) pair.
   assert.equal(pool.queuedJobs, 2);
@@ -2094,6 +2099,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs excludes rows that are not due
     hltb: { scanned: 1, enqueued: 0, deduped: 0 },
     metacritic: { scanned: 0, enqueued: 0, deduped: 0 },
     mobygames: { scanned: 0, enqueued: 0, deduped: 0 },
+    job: { scanned: 1, enqueued: 0, deduped: 0 },
   });
   assert.equal(pool.queuedJobs, 0);
 });

--- a/server/src/tests/release-monitor.delivery.test.ts
+++ b/server/src/tests/release-monitor.delivery.test.ts
@@ -1719,6 +1719,167 @@ void test('processGameRow does not attempt hltb/review for a bootstrap ineligibl
   }
 });
 
+void test('processGameRow sends a force-refresh header for hltb/review fetches when bypass_cache is set', async () => {
+  const originalFetch = globalThis.fetch;
+  const capturedHeaders: Record<string, HeadersInit | undefined> = {};
+  globalThis.fetch = (input: URL | RequestInfo, init?: RequestInit) => {
+    const url =
+      input instanceof URL ? input.toString() : input instanceof Request ? input.url : input;
+
+    if (url.includes('/v1/hltb/search')) {
+      capturedHeaders.hltb = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+
+    if (url.includes('/v1/metacritic/search')) {
+      capturedHeaders.metacritic = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+
+    return Promise.resolve(new Response(null, { status: 404 }));
+  };
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Ancient Game',
+          platform: 'PlayStation 5',
+          releaseYear: 2000,
+          releaseMarker: '2000',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+        },
+        watch_exists: false,
+        last_known_release_marker: null,
+        last_known_release_precision: null,
+        last_known_release_date: null,
+        last_known_release_year: null,
+        last_seen_state: null,
+        last_hltb_refresh_at: null,
+        last_metacritic_refresh_at: null,
+        last_notified_release_day: null,
+        force_hltb: true,
+        force_review: true,
+        respect_recency: false,
+        bypass_cache: true,
+      },
+      {
+        enabled: false,
+        events: { set: true, changed: true, removed: true, day: true, sale: true },
+      },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(
+      (capturedHeaders.hltb as Record<string, string> | undefined)?.['X-GameShelf-Force-Refresh'],
+      '1'
+    );
+    assert.equal(
+      (capturedHeaders.metacritic as Record<string, string> | undefined)?.[
+        'X-GameShelf-Force-Refresh'
+      ],
+      '1'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+void test('processGameRow omits the force-refresh header when bypass_cache is not set', async () => {
+  const originalFetch = globalThis.fetch;
+  const capturedHeaders: Record<string, HeadersInit | undefined> = {};
+  globalThis.fetch = (input: URL | RequestInfo, init?: RequestInit) => {
+    const url =
+      input instanceof URL ? input.toString() : input instanceof Request ? input.url : input;
+
+    if (url.includes('/v1/hltb/search')) {
+      capturedHeaders.hltb = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+
+    if (url.includes('/v1/metacritic/search')) {
+      capturedHeaders.metacritic = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+
+    return Promise.resolve(new Response(null, { status: 404 }));
+  };
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Ancient Game',
+          platform: 'PlayStation 5',
+          releaseYear: 2000,
+          releaseMarker: '2000',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+        },
+        watch_exists: false,
+        last_known_release_marker: null,
+        last_known_release_precision: null,
+        last_known_release_date: null,
+        last_known_release_year: null,
+        last_seen_state: null,
+        last_hltb_refresh_at: null,
+        last_metacritic_refresh_at: null,
+        last_notified_release_day: null,
+        force_hltb: true,
+        force_review: true,
+        respect_recency: false,
+      },
+      {
+        enabled: false,
+        events: { set: true, changed: true, removed: true, day: true, sale: true },
+      },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(capturedHeaders.hltb, undefined);
+    assert.equal(capturedHeaders.metacritic, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows and stamps force flags', async () => {
   const rows: DueGameSeedRow[] = [
     {
@@ -1729,7 +1890,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows
       last_known_release_marker: null,
       last_known_release_precision: null,
       last_known_release_date: null,
-      last_known_release_year: null,
+      last_known_release_year: 2024,
       last_seen_state: null,
       last_hltb_refresh_at: null,
       last_metacritic_refresh_at: null,
@@ -1743,7 +1904,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows
       last_known_release_marker: null,
       last_known_release_precision: null,
       last_known_release_date: null,
-      last_known_release_year: null,
+      last_known_release_year: 2024,
       last_seen_state: null,
       last_hltb_refresh_at: null,
       last_metacritic_refresh_at: null,
@@ -1757,14 +1918,22 @@ void test('enqueueForcedReleaseMonitorRefreshJobs scans collection+wishlist rows
     { hltb: true, review: false }
   );
 
-  assert.deepEqual(result, { scanned: 2, enqueued: 2, deduped: 0 });
+  assert.deepEqual(result, {
+    hltb: { scanned: 2, enqueued: 2, deduped: 0 },
+    metacritic: { scanned: 0, enqueued: 0, deduped: 0 },
+    mobygames: { scanned: 0, enqueued: 0, deduped: 0 },
+  });
   assert.equal(pool.queuedJobs, 2);
 
   const repeat = await releaseMonitorInternals.enqueueForcedReleaseMonitorRefreshJobs(
     pool as unknown as Pool,
     { hltb: true, review: false }
   );
-  assert.deepEqual(repeat, { scanned: 2, enqueued: 0, deduped: 2 });
+  assert.deepEqual(repeat, {
+    hltb: { scanned: 2, enqueued: 0, deduped: 2 },
+    metacritic: { scanned: 0, enqueued: 0, deduped: 0 },
+    mobygames: { scanned: 0, enqueued: 0, deduped: 0 },
+  });
 });
 
 void test('enqueueForcedReleaseMonitorRefreshJobs defaults respect_recency true and respect_staleness false on job payloads', async () => {
@@ -1777,7 +1946,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs defaults respect_recency true 
       last_known_release_marker: null,
       last_known_release_precision: null,
       last_known_release_date: null,
-      last_known_release_year: null,
+      last_known_release_year: 2024,
       last_seen_state: null,
       last_hltb_refresh_at: null,
       last_metacritic_refresh_at: null,
@@ -1795,6 +1964,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs defaults respect_recency true 
   assert.ok(payload);
   assert.equal(payload['respect_recency'], true);
   assert.equal(payload['respect_staleness'], false);
+  assert.equal(payload['bypass_cache'], true);
 });
 
 void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respectStaleness options onto job payloads and dedupe keys', async () => {
@@ -1807,7 +1977,7 @@ void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respect
       last_known_release_marker: null,
       last_known_release_precision: null,
       last_known_release_date: null,
-      last_known_release_year: null,
+      last_known_release_year: 2024,
       last_seen_state: null,
       last_hltb_refresh_at: null,
       last_metacritic_refresh_at: null,
@@ -1821,7 +1991,11 @@ void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respect
     { hltb: true, review: true },
     { respectRecency: false, respectStaleness: true }
   );
-  assert.deepEqual(first, { scanned: 1, enqueued: 1, deduped: 0 });
+  assert.deepEqual(first, {
+    hltb: { scanned: 1, enqueued: 1, deduped: 0 },
+    metacritic: { scanned: 1, enqueued: 1, deduped: 0 },
+    mobygames: { scanned: 1, enqueued: 0, deduped: 0 },
+  });
   const firstPayload = pool.lastEnqueuedPayload;
   assert.ok(firstPayload);
   assert.equal(firstPayload['respect_recency'], false);
@@ -1834,5 +2008,92 @@ void test('enqueueForcedReleaseMonitorRefreshJobs threads respectRecency/respect
     { hltb: true, review: true },
     { respectRecency: true, respectStaleness: false }
   );
-  assert.deepEqual(second, { scanned: 1, enqueued: 1, deduped: 0 });
+  assert.deepEqual(second, {
+    hltb: { scanned: 1, enqueued: 1, deduped: 0 },
+    metacritic: { scanned: 1, enqueued: 1, deduped: 0 },
+    mobygames: { scanned: 1, enqueued: 0, deduped: 0 },
+  });
+});
+
+void test('enqueueForcedReleaseMonitorRefreshJobs buckets metacritic and mobygames independently from one shared scan', async () => {
+  const rows: DueGameSeedRow[] = [
+    {
+      igdb_game_id: '1',
+      platform_igdb_id: 6,
+      payload: { title: 'Metacritic Game', listType: 'collection' },
+      watch_exists: true,
+      last_known_release_marker: null,
+      last_known_release_precision: null,
+      last_known_release_date: null,
+      last_known_release_year: 2024,
+      last_seen_state: null,
+      last_hltb_refresh_at: null,
+      last_metacritic_refresh_at: null,
+      last_notified_release_day: null,
+    },
+    {
+      igdb_game_id: '2',
+      platform_igdb_id: 6,
+      payload: {
+        title: 'Mobygames Game',
+        listType: 'collection',
+        reviewMatchMobygamesGameId: 555,
+      },
+      watch_exists: true,
+      last_known_release_marker: null,
+      last_known_release_precision: null,
+      last_known_release_date: null,
+      last_known_release_year: 2024,
+      last_seen_state: null,
+      last_hltb_refresh_at: null,
+      last_metacritic_refresh_at: null,
+      last_notified_release_day: null,
+    },
+  ];
+  const pool = new ReleaseMonitorFlowPoolMock(rows);
+
+  const result = await releaseMonitorInternals.enqueueForcedReleaseMonitorRefreshJobs(
+    pool as unknown as Pool,
+    { hltb: false, review: true }
+  );
+
+  assert.deepEqual(result, {
+    hltb: { scanned: 0, enqueued: 0, deduped: 0 },
+    metacritic: { scanned: 2, enqueued: 1, deduped: 0 },
+    mobygames: { scanned: 2, enqueued: 1, deduped: 0 },
+  });
+  // One job per row, not one per (row, provider) pair.
+  assert.equal(pool.queuedJobs, 2);
+});
+
+void test('enqueueForcedReleaseMonitorRefreshJobs excludes rows that are not due and enqueues nothing for them', async () => {
+  const rows: DueGameSeedRow[] = [
+    {
+      igdb_game_id: '1',
+      platform_igdb_id: 6,
+      payload: { title: 'No Release Info', listType: 'collection' },
+      watch_exists: true,
+      last_known_release_marker: null,
+      last_known_release_precision: null,
+      last_known_release_date: null,
+      last_known_release_year: null,
+      last_seen_state: null,
+      last_hltb_refresh_at: null,
+      last_metacritic_refresh_at: null,
+      last_notified_release_day: null,
+    },
+  ];
+  const pool = new ReleaseMonitorFlowPoolMock(rows);
+
+  const result = await releaseMonitorInternals.enqueueForcedReleaseMonitorRefreshJobs(
+    pool as unknown as Pool,
+    { hltb: true, review: false }
+  );
+
+  assert.deepEqual(result, {
+    hltb: { scanned: 1, enqueued: 0, deduped: 0 },
+    metacritic: { scanned: 0, enqueued: 0, deduped: 0 },
+    mobygames: { scanned: 0, enqueued: 0, deduped: 0 },
+  });
+  assert.equal(pool.queuedJobs, 0);
 });

--- a/server/src/tests/release-monitor.delivery.test.ts
+++ b/server/src/tests/release-monitor.delivery.test.ts
@@ -1271,6 +1271,88 @@ void test('processGameRow does not advance HLTB cadence on transport failure', a
   }
 });
 
+void test('processGameRow sends a force-refresh header for the mobygames review fetch when bypass_cache is set', async () => {
+  const originalFetch = globalThis.fetch;
+  const capturedHeaders: Record<string, HeadersInit | undefined> = {};
+  globalThis.fetch = (input: URL | RequestInfo, init?: RequestInit) => {
+    const url =
+      input instanceof URL ? input.toString() : input instanceof Request ? input.url : input;
+
+    if (url.includes('/v1/hltb/search')) {
+      capturedHeaders.hltb = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+
+    if (url.includes('/v1/mobygames/search')) {
+      capturedHeaders.mobygames = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify({ games: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+
+    return Promise.resolve(new Response(null, { status: 404 }));
+  };
+
+  try {
+    const pool = new ProcessGameRowPoolMock();
+    const stats = createRunStats();
+    await releaseMonitorInternals.processGameRow(
+      pool as unknown as Pool,
+      {
+        igdb_game_id: '52189',
+        platform_igdb_id: 167,
+        payload: {
+          title: 'Ancient Game',
+          platform: 'PlayStation 5',
+          releaseYear: 2000,
+          releaseMarker: '2000',
+          releasePrecision: 'year',
+          listType: 'wishlist',
+          reviewMatchMobygamesGameId: 555,
+        },
+        watch_exists: false,
+        last_known_release_marker: null,
+        last_known_release_precision: null,
+        last_known_release_date: null,
+        last_known_release_year: null,
+        last_seen_state: null,
+        last_hltb_refresh_at: null,
+        last_metacritic_refresh_at: null,
+        last_notified_release_day: null,
+        force_hltb: true,
+        force_review: true,
+        respect_recency: false,
+        bypass_cache: true,
+      },
+      {
+        enabled: false,
+        events: { set: true, changed: true, removed: true, day: true, sale: true },
+      },
+      new Set<string>(),
+      stats
+    );
+
+    assert.equal(stats.hltbRefreshAttempts, 1);
+    assert.equal(stats.reviewRefreshAttempts, 1);
+    assert.equal(
+      (capturedHeaders.mobygames as Record<string, string> | undefined)?.[
+        'X-GameShelf-Force-Refresh'
+      ],
+      '1'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 void test('processGameRow does not advance review cadence on transport failure', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (input: URL | RequestInfo) => {

--- a/server/src/tests/release-monitor.logic.test.ts
+++ b/server/src/tests/release-monitor.logic.test.ts
@@ -413,6 +413,110 @@ void test('hltb and review refresh due checks respect refresh age', () => {
   );
 });
 
+void test('evaluateForcedRefreshDue mirrors processGameRow due checks using pre-refetch release info', () => {
+  const now = new Date('2026-03-06T10:00:00.000Z');
+  const baseRow = {
+    igdb_game_id: '1',
+    platform_igdb_id: 6,
+    payload: {} as Record<string, unknown>,
+    watch_exists: true,
+    last_known_release_marker: null as string | null,
+    last_known_release_precision: null as string | null,
+    last_known_release_date: null as string | null,
+    last_known_release_year: null as number | null,
+    last_seen_state: null as string | null,
+    last_hltb_refresh_at: null as string | null,
+    last_metacritic_refresh_at: null as string | null,
+    last_notified_release_day: null as string | null,
+  };
+  const recentRow = {
+    ...baseRow,
+    last_known_release_marker: '2025',
+    last_known_release_precision: 'year',
+    last_known_release_year: 2025,
+  };
+
+  // Recent release, no existing hltb/review data -> due.
+  assert.deepEqual(
+    releaseMonitorInternals.evaluateForcedRefreshDue(
+      recentRow,
+      { hltb: true, review: true },
+      { respectRecency: true, respectStaleness: false },
+      now
+    ),
+    { hltbDue: true, reviewDue: true, reviewProvider: 'metacritic' }
+  );
+
+  // Recent release, existing data with a recent refresh timestamp, staleness respected -> not due.
+  const freshlyRefreshedRow = {
+    ...recentRow,
+    payload: { hltbMainHours: 10, metacriticScore: 80 },
+    last_hltb_refresh_at: '2026-03-06T09:59:00.000Z',
+    last_metacritic_refresh_at: '2026-03-06T09:59:00.000Z',
+  };
+  assert.deepEqual(
+    releaseMonitorInternals.evaluateForcedRefreshDue(
+      freshlyRefreshedRow,
+      { hltb: true, review: true },
+      { respectRecency: true, respectStaleness: true },
+      now
+    ),
+    { hltbDue: false, reviewDue: false, reviewProvider: null }
+  );
+
+  // Unknown release date -> not due unless respectRecency is disabled.
+  assert.deepEqual(
+    releaseMonitorInternals.evaluateForcedRefreshDue(
+      baseRow,
+      { hltb: true, review: true },
+      { respectRecency: true, respectStaleness: false },
+      now
+    ),
+    { hltbDue: false, reviewDue: false, reviewProvider: null }
+  );
+  assert.deepEqual(
+    releaseMonitorInternals.evaluateForcedRefreshDue(
+      baseRow,
+      { hltb: true, review: true },
+      { respectRecency: false, respectStaleness: false },
+      now
+    ),
+    { hltbDue: true, reviewDue: true, reviewProvider: 'metacritic' }
+  );
+
+  // Existing data with a stale refresh timestamp, staleness respected -> due again.
+  const staleRow = {
+    ...recentRow,
+    payload: { hltbMainHours: 10, metacriticScore: 80 },
+    last_hltb_refresh_at: '2020-01-01T00:00:00.000Z',
+    last_metacritic_refresh_at: '2020-01-01T00:00:00.000Z',
+  };
+  assert.deepEqual(
+    releaseMonitorInternals.evaluateForcedRefreshDue(
+      staleRow,
+      { hltb: true, review: true },
+      { respectRecency: true, respectStaleness: true },
+      now
+    ),
+    { hltbDue: true, reviewDue: true, reviewProvider: 'metacritic' }
+  );
+
+  // reviewProvider follows reviewMatchMobygamesGameId on the payload.
+  const mobygamesRow = {
+    ...recentRow,
+    payload: { reviewMatchMobygamesGameId: 555 },
+  };
+  assert.deepEqual(
+    releaseMonitorInternals.evaluateForcedRefreshDue(
+      mobygamesRow,
+      { hltb: false, review: true },
+      { respectRecency: true, respectStaleness: false },
+      now
+    ),
+    { hltbDue: false, reviewDue: true, reviewProvider: 'mobygames' }
+  );
+});
+
 void test('derive release state and past-years checks handle precision edge cases', () => {
   const now = new Date('2026-03-06T10:00:00.000Z');
 


### PR DESCRIPTION
## Summary

Admin "refresh due data" runs previously served hltb/metacritic/mobygames
metadata from cache even when a forced refresh was requested, so due games
could silently keep stale data. This change adds a force-refresh header
that the release monitor's forced-refresh worker sends when bypassing the
cache, splits the previously-shared hltb/reviews result counters into
per-provider (hltb/metacritic/mobygames) stats, and scopes forced-refresh
enqueueing to rows that are actually due instead of enqueueing every
scanned row.

## Type of change

- [x] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `hltb-cache.ts` / `metacritic-cache.ts` / `mobygames-cache.ts`: routes now
  honor an `X-GameShelf-Force-Refresh: 1` request header, skipping the cache
  read, tagging the response `X-GameShelf-*-Cache: BYPASS`, and still
  persisting the freshly fetched payload so subsequent regular traffic hits
  the refreshed cache entry.
- `release-monitor.ts`: `buildReleaseMonitorGameJobPayload` now stamps
  `bypass_cache` on the job payload when hltb or review is forced;
  `processGameRow` threads `forceFresh` through `fetchHltbPayload`,
  `fetchMetacriticPayload`, `fetchMobygamesPayload`, and `fetchReviewPayload`
  to attach the bypass header on outbound fetches.
  `enqueueForcedReleaseMonitorRefreshJobs` now evaluates per-row due status
  (`evaluateForcedRefreshDue`) using the row's pre-refetch release info
  before enqueueing, and returns separate `hltb`/`metacritic`/`mobygames`
  scan/enqueue/dedupe stats instead of one shared bucket.
- `admin-refresh-data-routes.ts`: the `reviews` result now reports combined
  totals plus a nested `metacritic`/`mobygames` breakdown.
- Fixed a metrics double-count in `hltb-cache.ts` and `metacritic-cache.ts`:
  a force-refresh bypass request was incrementing both the `bypasses` and
  `misses` counters for the same request (the `mobygames-cache.ts` route
  didn't have this bug). `misses` is now only incremented on genuine cache
  misses, guarded by `!bypassCache`.

## Testing performed

- `npm run lint` — passes
- `npm run test` (root, Angular/Vitest suite) — 1539 tests pass
- `npm --prefix server run test` (Node test runner) — 681 tests pass, 2 skipped (pre-existing)
- `npm run build` (Angular build) — succeeds (pre-existing initial-bundle-budget
  warning, unrelated to this change)
- Added/updated coverage: force-refresh bypass tests for hltb/metacritic/
  mobygames caches (including new `misses` metric assertions verifying the
  double-count fix), `admin-refresh-data-routes` per-provider result shape,
  `evaluateForcedRefreshDue` due-check parity with `processGameRow`, and
  `enqueueForcedReleaseMonitorRefreshJobs` provider-bucketed scan/enqueue
  behavior including the not-due exclusion path.

## Screenshots (if applicable)

N/A — server-only change.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
