### PR TITLE
feat(game-list): add discounted filter and fix TAS/PTAS tier fallback

### DIFF
--- a/src/app/core/data/local-game-repository.spec.ts
+++ b/src/app/core/data/local-game-repository.spec.ts
@@ -924,6 +924,24 @@ describe('LocalGameRepository', () => {
     expect(await repository.getView(createdId)).toBeUndefined();
   });
 
+  it('keeps discounted on wishlist views and strips it on collection views', async () => {
+    const wishlistView = await repository.createView({
+      name: 'Wishlist deals',
+      listType: 'wishlist',
+      filters: { ...DEFAULT_GAME_LIST_FILTERS, discounted: true },
+      groupBy: 'none',
+    });
+    expect(wishlistView.filters.discounted).toBe(true);
+
+    const collectionView = await repository.createView({
+      name: 'Collection deals',
+      listType: 'collection',
+      filters: { ...DEFAULT_GAME_LIST_FILTERS, discounted: true },
+      groupBy: 'none',
+    });
+    expect(collectionView.filters.discounted).toBe(false);
+  });
+
   it('returns undefined when updating a missing view', async () => {
     const updated = await repository.updateView(404, { name: 'Missing' });
     expect(updated).toBeUndefined();

--- a/src/app/core/data/local-game-repository.ts
+++ b/src/app/core/data/local-game-repository.ts
@@ -18,6 +18,7 @@ import {
   Tag,
 } from '../models/game.models';
 import {
+  normalizeBooleanFilter,
   normalizeGameRatingFilterList,
   normalizeGameStatusFilterList,
   normalizeGameTypeList,
@@ -1816,7 +1817,7 @@ export class LocalGameRepository implements GameRepository {
           : hltbMainHoursMax,
       releaseDateFrom,
       releaseDateTo,
-      discounted: listType === 'wishlist' && source.discounted,
+      discounted: listType === 'wishlist' && normalizeBooleanFilter(source.discounted),
     };
   }
 

--- a/src/app/core/data/local-game-repository.ts
+++ b/src/app/core/data/local-game-repository.ts
@@ -1816,6 +1816,7 @@ export class LocalGameRepository implements GameRepository {
           : hltbMainHoursMax,
       releaseDateFrom,
       releaseDateTo,
+      discounted: listType === 'wishlist' && source.discounted,
     };
   }
 

--- a/src/app/core/models/game.models.ts
+++ b/src/app/core/models/game.models.ts
@@ -155,12 +155,7 @@ export interface GameCatalogResult {
 export type RecommendationTarget = 'BACKLOG' | 'WISHLIST' | 'DISCOVERY';
 export type RecommendationRuntimeMode = 'NEUTRAL' | 'SHORT' | 'LONG';
 export type RecommendationLaneKey =
-  | 'overall'
-  | 'hiddenGems'
-  | 'exploration'
-  | 'blended'
-  | 'popular'
-  | 'recent';
+  'overall' | 'hiddenGems' | 'exploration' | 'blended' | 'popular' | 'recent';
 
 export interface RecommendationScoreComponents {
   taste: number;
@@ -563,6 +558,7 @@ export interface GameListFilters {
   hltbMainHoursMax: number | null;
   releaseDateFrom: string | null;
   releaseDateTo: string | null;
+  discounted: boolean;
 }
 
 export const DEFAULT_GAME_LIST_FILTERS: GameListFilters = {
@@ -587,6 +583,7 @@ export const DEFAULT_GAME_LIST_FILTERS: GameListFilters = {
   hltbMainHoursMax: null,
   releaseDateFrom: null,
   releaseDateTo: null,
+  discounted: false,
 };
 
 export interface GameListView {

--- a/src/app/core/services/game-shelf.service.ts
+++ b/src/app/core/services/game-shelf.service.ts
@@ -42,6 +42,7 @@ import {
   normalizeTagIds,
   normalizeTheGamesDbUrl,
 } from './game-shelf-normalization';
+import { isGameOnDiscount } from '../utils/game-filter-utils';
 
 interface SteamPriceLookupApi {
   lookupSteamPrice(
@@ -1258,34 +1259,7 @@ export class GameShelfService {
       'priceAmount' | 'priceRegularAmount' | 'priceDiscountPercent' | 'priceIsFree'
     >
   ): boolean {
-    if (game.priceIsFree === true) {
-      return false;
-    }
-
-    const amount =
-      typeof game.priceAmount === 'number' && Number.isFinite(game.priceAmount)
-        ? game.priceAmount
-        : null;
-    const regularAmount =
-      typeof game.priceRegularAmount === 'number' && Number.isFinite(game.priceRegularAmount)
-        ? game.priceRegularAmount
-        : null;
-
-    if (
-      amount !== null &&
-      regularAmount !== null &&
-      amount >= 0 &&
-      regularAmount >= 0 &&
-      regularAmount > amount
-    ) {
-      return true;
-    }
-
-    const discountPercent =
-      typeof game.priceDiscountPercent === 'number' && Number.isFinite(game.priceDiscountPercent)
-        ? game.priceDiscountPercent
-        : null;
-    return discountPercent !== null && discountPercent > 0;
+    return isGameOnDiscount(game);
   }
 
   async updateGameCover(

--- a/src/app/core/utils/game-filter-utils.ts
+++ b/src/app/core/utils/game-filter-utils.ts
@@ -1,4 +1,5 @@
 import {
+  GameEntry,
   GameRatingFilterOption,
   GameStatusFilterOption,
   GameType,
@@ -122,4 +123,40 @@ export function normalizeTagFilterList(value: unknown, noneTagFilterValue: strin
   const hasNoneTagFilter = normalized.includes(noneTagFilterValue);
   const tagNames = normalized.filter((tag) => tag !== noneTagFilterValue);
   return hasNoneTagFilter ? [noneTagFilterValue, ...tagNames] : tagNames;
+}
+
+export function isGameOnDiscount(
+  game: Pick<
+    GameEntry,
+    'priceAmount' | 'priceRegularAmount' | 'priceDiscountPercent' | 'priceIsFree'
+  >
+): boolean {
+  if (game.priceIsFree === true) {
+    return false;
+  }
+
+  const amount =
+    typeof game.priceAmount === 'number' && Number.isFinite(game.priceAmount)
+      ? game.priceAmount
+      : null;
+  const regularAmount =
+    typeof game.priceRegularAmount === 'number' && Number.isFinite(game.priceRegularAmount)
+      ? game.priceRegularAmount
+      : null;
+
+  if (
+    amount !== null &&
+    regularAmount !== null &&
+    amount >= 0 &&
+    regularAmount >= 0 &&
+    regularAmount > amount
+  ) {
+    return true;
+  }
+
+  const discountPercent =
+    typeof game.priceDiscountPercent === 'number' && Number.isFinite(game.priceDiscountPercent)
+      ? game.priceDiscountPercent
+      : null;
+  return discountPercent !== null && discountPercent > 0;
 }

--- a/src/app/core/utils/game-filter-utils.ts
+++ b/src/app/core/utils/game-filter-utils.ts
@@ -118,6 +118,10 @@ export function normalizeNonNegativeNumber(value: unknown): number | null {
   return Math.round(value * 10) / 10;
 }
 
+export function normalizeBooleanFilter(value: unknown): boolean {
+  return value === true;
+}
+
 export function normalizeTagFilterList(value: unknown, noneTagFilterValue: string): string[] {
   const normalized = normalizeStringList(value);
   const hasNoneTagFilter = normalized.includes(noneTagFilterValue);

--- a/src/app/features/game-filters-menu/game-filters-menu.component.html
+++ b/src/app/features/game-filters-menu/game-filters-menu.component.html
@@ -133,6 +133,17 @@
       </ion-select>
     </ion-item>
 
+    @if (showDiscountedFilter) {
+      <ion-item>
+        <ion-checkbox
+          [checked]="draftFilters.discounted"
+          (ionChange)="onDiscountedFilterChange($event.detail.checked)"
+        >
+          Discounted
+        </ion-checkbox>
+      </ion-item>
+    }
+
     <ion-accordion-group>
       <ion-accordion value="exclusions">
         <ion-item slot="header" color="light">

--- a/src/app/features/game-filters-menu/game-filters-menu.component.spec.ts
+++ b/src/app/features/game-filters-menu/game-filters-menu.component.spec.ts
@@ -77,6 +77,39 @@ describe('GameFiltersMenuComponent', () => {
     expect(emitSpy).toHaveBeenCalledWith(expect.objectContaining({ sortField: 'review' }));
   });
 
+  it('shows the discounted filter only on the wishlist list type', () => {
+    const component = createComponent();
+
+    component.listType = 'collection';
+    expect(component.showDiscountedFilter).toBe(false);
+
+    component.listType = 'wishlist';
+    expect(component.showDiscountedFilter).toBe(true);
+  });
+
+  it('clears a stale discounted filter outside wishlist and emits corrected filters', () => {
+    const component = createComponent();
+    const emitSpy = vi.spyOn(component.filtersChange, 'emit');
+
+    component.filters = { ...DEFAULT_GAME_LIST_FILTERS, discounted: true };
+    component.listType = 'collection';
+    component.ngOnChanges();
+
+    expect(component.draftFilters.discounted).toBe(false);
+    expect(emitSpy).toHaveBeenCalledWith(expect.objectContaining({ discounted: false }));
+  });
+
+  it('updates discounted via onDiscountedFilterChange', () => {
+    const component = createComponent();
+    const emitSpy = vi.spyOn(component.filtersChange, 'emit');
+
+    component.listType = 'wishlist';
+    component.onDiscountedFilterChange(true);
+
+    expect(component.draftFilters.discounted).toBe(true);
+    expect(emitSpy).toHaveBeenCalledWith(expect.objectContaining({ discounted: true }));
+  });
+
   it('does not emit when incoming sort field is already valid', () => {
     const component = createComponent();
     const emitSpy = vi.spyOn(component.filtersChange, 'emit');

--- a/src/app/features/game-filters-menu/game-filters-menu.component.ts
+++ b/src/app/features/game-filters-menu/game-filters-menu.component.ts
@@ -35,6 +35,7 @@ import {
   ListType,
 } from '../../core/models/game.models';
 import {
+  normalizeBooleanFilter,
   normalizeGameRatingFilterList,
   normalizeGameStatusFilterList,
   normalizeGameTypeList,
@@ -157,7 +158,7 @@ export class GameFiltersMenuComponent implements OnChanges {
       ...DEFAULT_GAME_LIST_FILTERS,
       ...this.filters,
       sortField: normalizedSortField,
-      discounted: this.showDiscountedFilter && this.filters.discounted,
+      discounted: this.showDiscountedFilter && normalizeBooleanFilter(this.filters.discounted),
     };
     this.draftFilters = normalizedFilters;
     this.sortOption =

--- a/src/app/features/game-filters-menu/game-filters-menu.component.ts
+++ b/src/app/features/game-filters-menu/game-filters-menu.component.ts
@@ -22,6 +22,7 @@ import {
   IonDatetime,
   IonAccordionGroup,
   IonAccordion,
+  IonCheckbox,
 } from '@ionic/angular/standalone';
 import {
   DEFAULT_GAME_LIST_FILTERS,
@@ -90,6 +91,7 @@ type FiltersPresentation = 'menu' | 'split';
     IonDatetime,
     IonAccordionGroup,
     IonAccordion,
+    IonCheckbox,
   ],
 })
 export class GameFiltersMenuComponent implements OnChanges {
@@ -155,12 +157,16 @@ export class GameFiltersMenuComponent implements OnChanges {
       ...DEFAULT_GAME_LIST_FILTERS,
       ...this.filters,
       sortField: normalizedSortField,
+      discounted: this.showDiscountedFilter && this.filters.discounted,
     };
     this.draftFilters = normalizedFilters;
     this.sortOption =
       `${this.draftFilters.sortField}:${this.draftFilters.sortDirection}` as SortOption;
 
-    if (this.filters.sortField !== normalizedSortField) {
+    if (
+      this.filters.sortField !== normalizedSortField ||
+      this.filters.discounted !== normalizedFilters.discounted
+    ) {
       this.filtersChange.emit({ ...normalizedFilters });
     }
   }
@@ -220,6 +226,14 @@ export class GameFiltersMenuComponent implements OnChanges {
     this.draftFilters = {
       ...this.draftFilters,
       genres: normalized,
+    };
+    this.updateFilters();
+  }
+
+  onDiscountedFilterChange(value: boolean): void {
+    this.draftFilters = {
+      ...this.draftFilters,
+      discounted: value,
     };
     this.updateFilters();
   }
@@ -523,6 +537,10 @@ export class GameFiltersMenuComponent implements OnChanges {
   }
 
   get showPriceSort(): boolean {
+    return this.listType === 'wishlist';
+  }
+
+  get showDiscountedFilter(): boolean {
     return this.listType === 'wishlist';
   }
 }

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -19,11 +19,11 @@ import {
 } from '../../core/utils/game-filter-utils';
 import { PLATFORM_CATALOG } from '../../core/data/platform-catalog';
 import {
+  calculatePriceAdjustedTimeAdjustedScore,
+  calculateTimeAdjustedScore,
   resolveEffectiveHltbHours,
   resolveEffectivePriceForGame,
-  resolvePriceAdjustedTimeAdjustedScoreForGame,
   resolveNormalizedCriticScoreForGame,
-  resolveTimeAdjustedScoreForGame,
 } from '../../core/utils/time-adjusted-score.util';
 import { isTasFeatureEnabled } from '../../core/config/runtime-config';
 
@@ -1171,7 +1171,10 @@ export class GameListFilteringEngine {
       const hltbHours = resolveEffectiveHltbHours(game);
 
       if (reviewScore !== null && hltbHours !== null) {
-        return { tier: 1, value: resolveTimeAdjustedScoreForGame(game, timePreference) };
+        return {
+          tier: 1,
+          value: calculateTimeAdjustedScore(reviewScore, hltbHours, timePreference),
+        };
       }
 
       if (hltbHours !== null) {
@@ -1228,9 +1231,11 @@ export class GameListFilteringEngine {
       if (price !== null && reviewScore !== null && hltbHours !== null) {
         return {
           tier: 1,
-          value: resolvePriceAdjustedTimeAdjustedScoreForGame(
-            game,
+          value: calculatePriceAdjustedTimeAdjustedScore(
+            reviewScore,
+            hltbHours,
             timePreference,
+            price,
             pricePreference
           ),
         };
@@ -1241,7 +1246,10 @@ export class GameListFilteringEngine {
       }
 
       if (reviewScore !== null && hltbHours !== null) {
-        return { tier: 3, value: resolveTimeAdjustedScoreForGame(game, timePreference) };
+        return {
+          tier: 3,
+          value: calculateTimeAdjustedScore(reviewScore, hltbHours, timePreference),
+        };
       }
 
       if (reviewScore !== null) {

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -1175,7 +1175,8 @@ export class GameListFilteringEngine {
       }
 
       if (hasHltb) {
-        return { tier: 2, value: resolveEffectiveHltbHours(game) };
+        const hltbHours = resolveEffectiveHltbHours(game);
+        return { tier: 2, value: hltbHours === null ? null : -hltbHours };
       }
 
       if (hasReview) {
@@ -1237,7 +1238,8 @@ export class GameListFilteringEngine {
       }
 
       if (hasPrice) {
-        return { tier: 2, value: resolveEffectivePriceForGame(game) };
+        const price = resolveEffectivePriceForGame(game);
+        return { tier: 2, value: price === null ? null : -price };
       }
 
       if (hasReview && hasHltb) {

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -74,6 +74,7 @@ export class GameListFilteringEngine {
     sortDirection: GameListFilters['sortDirection'];
     timePreference: number;
     pricePreference: number;
+    today: string | null;
     sortedGames: GameEntry[];
   } | null = null;
   private readonly platformOrderByKey = new Map<string, number>();
@@ -645,7 +646,7 @@ export class GameListFilteringEngine {
       return false;
     }
 
-    if (filters.discounted && !isGameOnDiscount(game)) {
+    if (filters.discounted && game.listType === 'wishlist' && !isGameOnDiscount(game)) {
       return false;
     }
 
@@ -786,6 +787,9 @@ export class GameListFilteringEngine {
     const existingCache = this.sortedGamesCache;
     const cachePricePreference =
       sortField === 'ptas' && isTasFeatureEnabled() ? pricePreference : 0;
+    const today = this.getDateOnly(new Date().toISOString());
+    const cacheToday =
+      (sortField === 'ptas' || sortField === 'tas') && isTasFeatureEnabled() ? today : null;
 
     if (
       existingCache &&
@@ -793,12 +797,12 @@ export class GameListFilteringEngine {
       existingCache.sortField === sortField &&
       existingCache.sortDirection === sortDirection &&
       existingCache.timePreference === timePreference &&
-      existingCache.pricePreference === cachePricePreference
+      existingCache.pricePreference === cachePricePreference &&
+      existingCache.today === cacheToday
     ) {
       return existingCache.sortedGames;
     }
 
-    const today = this.getDateOnly(new Date().toISOString());
     const sortedGames =
       sortField === 'metacritic' || sortField === 'review'
         ? [...games].sort((left, right) =>
@@ -837,6 +841,7 @@ export class GameListFilteringEngine {
       sortDirection,
       timePreference,
       pricePreference: cachePricePreference,
+      today: cacheToday,
       sortedGames,
     };
     return sortedGames;

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -1117,13 +1117,48 @@ export class GameListFilteringEngine {
     sortDirection: GameListFilters['sortDirection'],
     timePreference: number
   ): number {
+    const leftTier = this.classifyTasTier(left, timePreference);
+    const rightTier = this.classifyTasTier(right, timePreference);
+
+    if (leftTier.tier !== rightTier.tier) {
+      return leftTier.tier - rightTier.tier;
+    }
+
+    if (leftTier.tier === 4) {
+      return this.compareReleaseDatesUnknownLast(left, right, sortDirection);
+    }
+
     return this.compareNumericSortValues(
-      resolveTimeAdjustedScoreForGame(left, timePreference),
-      resolveTimeAdjustedScoreForGame(right, timePreference),
+      leftTier.value,
+      rightTier.value,
       sortDirection,
       left,
       right
     );
+  }
+
+  private classifyTasTier(
+    game: GameEntry,
+    timePreference: number
+  ): { tier: 1 | 2 | 3 | 4; value: number | null } {
+    if (this.resolveReleaseDateStatus(game) === 'past') {
+      const hasReview = resolveNormalizedCriticScoreForGame(game) !== null;
+      const hasHltb = resolveEffectiveHltbHours(game) !== null;
+
+      if (hasReview && hasHltb) {
+        return { tier: 1, value: resolveTimeAdjustedScoreForGame(game, timePreference) };
+      }
+
+      if (hasHltb) {
+        return { tier: 2, value: resolveEffectiveHltbHours(game) };
+      }
+
+      if (hasReview) {
+        return { tier: 3, value: resolveNormalizedCriticScoreForGame(game) };
+      }
+    }
+
+    return { tier: 4, value: null };
   }
 
   private compareGamesByPriceAdjustedTimeAdjustedScore(

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -10,6 +10,7 @@ import {
 } from '../../core/models/game.models';
 import {
   isGameOnDiscount,
+  normalizeBooleanFilter,
   normalizeGameRatingFilterList,
   normalizeGameStatusFilterList,
   normalizeGameTypeList,
@@ -266,7 +267,7 @@ export class GameListFilteringEngine {
         hltbMainHoursMin > hltbMainHoursMax
           ? hltbMainHoursMin
           : hltbMainHoursMax,
-      discounted: filters.discounted,
+      discounted: normalizeBooleanFilter(filters.discounted),
     };
   }
 
@@ -797,6 +798,7 @@ export class GameListFilteringEngine {
       return existingCache.sortedGames;
     }
 
+    const today = this.getDateOnly(new Date().toISOString());
     const sortedGames =
       sortField === 'metacritic' || sortField === 'review'
         ? [...games].sort((left, right) =>
@@ -811,12 +813,19 @@ export class GameListFilteringEngine {
                   right,
                   sortDirection,
                   timePreference,
-                  pricePreference
+                  pricePreference,
+                  today
                 )
               )
             : sortField === 'tas' && isTasFeatureEnabled()
               ? [...games].sort((left, right) =>
-                  this.compareGamesByTimeAdjustedScore(left, right, sortDirection, timePreference)
+                  this.compareGamesByTimeAdjustedScore(
+                    left,
+                    right,
+                    sortDirection,
+                    timePreference,
+                    today
+                  )
                 )
               : this.applySortDirection(
                   [...games].sort((left, right) => this.compareGames(left, right, sortField)),
@@ -1057,14 +1066,16 @@ export class GameListFilteringEngine {
     return releaseDate.slice(0, 10);
   }
 
-  private resolveReleaseDateStatus(game: GameEntry): 'past' | 'future' | 'unknown' {
+  private resolveReleaseDateStatus(
+    game: GameEntry,
+    today: string | null
+  ): 'past' | 'future' | 'unknown' {
     const dateOnly = this.getDateOnly(game.releaseDate);
 
     if (!dateOnly) {
       return 'unknown';
     }
 
-    const today = this.getDateOnly(new Date().toISOString());
     return today !== null && dateOnly > today ? 'future' : 'past';
   }
 
@@ -1122,10 +1133,11 @@ export class GameListFilteringEngine {
     left: GameEntry,
     right: GameEntry,
     sortDirection: GameListFilters['sortDirection'],
-    timePreference: number
+    timePreference: number,
+    today: string | null
   ): number {
-    const leftTier = this.classifyTasTier(left, timePreference);
-    const rightTier = this.classifyTasTier(right, timePreference);
+    const leftTier = this.classifyTasTier(left, timePreference, today);
+    const rightTier = this.classifyTasTier(right, timePreference, today);
 
     if (leftTier.tier !== rightTier.tier) {
       return leftTier.tier - rightTier.tier;
@@ -1146,9 +1158,10 @@ export class GameListFilteringEngine {
 
   private classifyTasTier(
     game: GameEntry,
-    timePreference: number
+    timePreference: number,
+    today: string | null
   ): { tier: 1 | 2 | 3 | 4; value: number | null } {
-    if (this.resolveReleaseDateStatus(game) === 'past') {
+    if (this.resolveReleaseDateStatus(game, today) === 'past') {
       const hasReview = resolveNormalizedCriticScoreForGame(game) !== null;
       const hasHltb = resolveEffectiveHltbHours(game) !== null;
 
@@ -1173,10 +1186,11 @@ export class GameListFilteringEngine {
     right: GameEntry,
     sortDirection: GameListFilters['sortDirection'],
     timePreference: number,
-    pricePreference: number
+    pricePreference: number,
+    today: string | null
   ): number {
-    const leftTier = this.classifyWishlistPtasTier(left, timePreference, pricePreference);
-    const rightTier = this.classifyWishlistPtasTier(right, timePreference, pricePreference);
+    const leftTier = this.classifyWishlistPtasTier(left, timePreference, pricePreference, today);
+    const rightTier = this.classifyWishlistPtasTier(right, timePreference, pricePreference, today);
 
     if (leftTier.tier !== rightTier.tier) {
       return leftTier.tier - rightTier.tier;
@@ -1198,9 +1212,10 @@ export class GameListFilteringEngine {
   private classifyWishlistPtasTier(
     game: GameEntry,
     timePreference: number,
-    pricePreference: number
+    pricePreference: number,
+    today: string | null
   ): { tier: 1 | 2 | 3 | 4 | 5; value: number | null } {
-    if (this.resolveReleaseDateStatus(game) === 'past') {
+    if (this.resolveReleaseDateStatus(game, today) === 'past') {
       const hasPrice = resolveEffectivePriceForGame(game) !== null;
       const hasReview = resolveNormalizedCriticScoreForGame(game) !== null;
       const hasHltb = resolveEffectiveHltbHours(game) !== null;

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -9,6 +9,7 @@ import {
   isGameRating,
 } from '../../core/models/game.models';
 import {
+  isGameOnDiscount,
   normalizeGameRatingFilterList,
   normalizeGameStatusFilterList,
   normalizeGameTypeList,
@@ -265,6 +266,7 @@ export class GameListFilteringEngine {
         hltbMainHoursMin > hltbMainHoursMax
           ? hltbMainHoursMin
           : hltbMainHoursMax,
+      discounted: filters.discounted,
     };
   }
 
@@ -642,6 +644,10 @@ export class GameListFilteringEngine {
       return false;
     }
 
+    if (filters.discounted && !isGameOnDiscount(game)) {
+      return false;
+    }
+
     if (
       filters.collections.length > 0 &&
       !filters.collections.some((selectedCollection) =>
@@ -862,7 +868,8 @@ export class GameListFilteringEngine {
       minMainHours !== null ||
       maxMainHours !== null ||
       !!filters.releaseDateFrom ||
-      !!filters.releaseDateTo
+      !!filters.releaseDateTo ||
+      filters.discounted
     );
   }
 

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -1167,20 +1167,19 @@ export class GameListFilteringEngine {
     today: string | null
   ): { tier: 1 | 2 | 3 | 4; value: number | null } {
     if (this.resolveReleaseDateStatus(game, today) === 'past') {
-      const hasReview = resolveNormalizedCriticScoreForGame(game) !== null;
-      const hasHltb = resolveEffectiveHltbHours(game) !== null;
+      const reviewScore = resolveNormalizedCriticScoreForGame(game);
+      const hltbHours = resolveEffectiveHltbHours(game);
 
-      if (hasReview && hasHltb) {
+      if (reviewScore !== null && hltbHours !== null) {
         return { tier: 1, value: resolveTimeAdjustedScoreForGame(game, timePreference) };
       }
 
-      if (hasHltb) {
-        const hltbHours = resolveEffectiveHltbHours(game);
-        return { tier: 2, value: hltbHours === null ? null : -hltbHours };
+      if (hltbHours !== null) {
+        return { tier: 2, value: -hltbHours };
       }
 
-      if (hasReview) {
-        return { tier: 3, value: resolveNormalizedCriticScoreForGame(game) };
+      if (reviewScore !== null) {
+        return { tier: 3, value: reviewScore };
       }
     }
 
@@ -1222,11 +1221,11 @@ export class GameListFilteringEngine {
     today: string | null
   ): { tier: 1 | 2 | 3 | 4 | 5; value: number | null } {
     if (this.resolveReleaseDateStatus(game, today) === 'past') {
-      const hasPrice = resolveEffectivePriceForGame(game) !== null;
-      const hasReview = resolveNormalizedCriticScoreForGame(game) !== null;
-      const hasHltb = resolveEffectiveHltbHours(game) !== null;
+      const price = resolveEffectivePriceForGame(game);
+      const reviewScore = resolveNormalizedCriticScoreForGame(game);
+      const hltbHours = resolveEffectiveHltbHours(game);
 
-      if (hasPrice && hasReview && hasHltb) {
+      if (price !== null && reviewScore !== null && hltbHours !== null) {
         return {
           tier: 1,
           value: resolvePriceAdjustedTimeAdjustedScoreForGame(
@@ -1237,17 +1236,16 @@ export class GameListFilteringEngine {
         };
       }
 
-      if (hasPrice) {
-        const price = resolveEffectivePriceForGame(game);
-        return { tier: 2, value: price === null ? null : -price };
+      if (price !== null) {
+        return { tier: 2, value: -price };
       }
 
-      if (hasReview && hasHltb) {
+      if (reviewScore !== null && hltbHours !== null) {
         return { tier: 3, value: resolveTimeAdjustedScoreForGame(game, timePreference) };
       }
 
-      if (hasReview) {
-        return { tier: 4, value: resolveNormalizedCriticScoreForGame(game) };
+      if (reviewScore !== null) {
+        return { tier: 4, value: reviewScore };
       }
     }
 

--- a/src/app/features/game-list/game-list-filtering.ts
+++ b/src/app/features/game-list/game-list-filtering.ts
@@ -17,6 +17,8 @@ import {
 } from '../../core/utils/game-filter-utils';
 import { PLATFORM_CATALOG } from '../../core/data/platform-catalog';
 import {
+  resolveEffectiveHltbHours,
+  resolveEffectivePriceForGame,
   resolvePriceAdjustedTimeAdjustedScoreForGame,
   resolveNormalizedCriticScoreForGame,
   resolveTimeAdjustedScoreForGame,
@@ -1048,6 +1050,17 @@ export class GameListFilteringEngine {
     return releaseDate.slice(0, 10);
   }
 
+  private resolveReleaseDateStatus(game: GameEntry): 'past' | 'future' | 'unknown' {
+    const dateOnly = this.getDateOnly(game.releaseDate);
+
+    if (!dateOnly) {
+      return 'unknown';
+    }
+
+    const today = this.getDateOnly(new Date().toISOString());
+    return today !== null && dateOnly > today ? 'future' : 'past';
+  }
+
   private normalizeFilterHours(value: number | null | undefined): number | null {
     if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
       return null;
@@ -1120,13 +1133,90 @@ export class GameListFilteringEngine {
     timePreference: number,
     pricePreference: number
   ): number {
+    const leftTier = this.classifyWishlistPtasTier(left, timePreference, pricePreference);
+    const rightTier = this.classifyWishlistPtasTier(right, timePreference, pricePreference);
+
+    if (leftTier.tier !== rightTier.tier) {
+      return leftTier.tier - rightTier.tier;
+    }
+
+    if (leftTier.tier === 5) {
+      return this.compareReleaseDatesUnknownLast(left, right, sortDirection);
+    }
+
     return this.compareNumericSortValues(
-      resolvePriceAdjustedTimeAdjustedScoreForGame(left, timePreference, pricePreference),
-      resolvePriceAdjustedTimeAdjustedScoreForGame(right, timePreference, pricePreference),
+      leftTier.value,
+      rightTier.value,
       sortDirection,
       left,
       right
     );
+  }
+
+  private classifyWishlistPtasTier(
+    game: GameEntry,
+    timePreference: number,
+    pricePreference: number
+  ): { tier: 1 | 2 | 3 | 4 | 5; value: number | null } {
+    if (this.resolveReleaseDateStatus(game) === 'past') {
+      const hasPrice = resolveEffectivePriceForGame(game) !== null;
+      const hasReview = resolveNormalizedCriticScoreForGame(game) !== null;
+      const hasHltb = resolveEffectiveHltbHours(game) !== null;
+
+      if (hasPrice && hasReview && hasHltb) {
+        return {
+          tier: 1,
+          value: resolvePriceAdjustedTimeAdjustedScoreForGame(
+            game,
+            timePreference,
+            pricePreference
+          ),
+        };
+      }
+
+      if (hasPrice) {
+        return { tier: 2, value: resolveEffectivePriceForGame(game) };
+      }
+
+      if (hasReview && hasHltb) {
+        return { tier: 3, value: resolveTimeAdjustedScoreForGame(game, timePreference) };
+      }
+
+      if (hasReview) {
+        return { tier: 4, value: resolveNormalizedCriticScoreForGame(game) };
+      }
+    }
+
+    return { tier: 5, value: null };
+  }
+
+  private compareReleaseDatesUnknownLast(
+    left: GameEntry,
+    right: GameEntry,
+    sortDirection: GameListFilters['sortDirection']
+  ): number {
+    const leftDate = this.getDateOnly(left.releaseDate);
+    const rightDate = this.getDateOnly(right.releaseDate);
+
+    if (leftDate === null && rightDate === null) {
+      return this.sortGamesByTitleFallback(left, right);
+    }
+
+    if (leftDate === null) {
+      return 1;
+    }
+
+    if (rightDate === null) {
+      return -1;
+    }
+
+    if (leftDate !== rightDate) {
+      return sortDirection === 'desc'
+        ? rightDate.localeCompare(leftDate)
+        : leftDate.localeCompare(rightDate);
+    }
+
+    return this.sortGamesByTitleFallback(left, right);
   }
 
   private compareGamesByPrice(

--- a/src/app/features/game-list/game-list-filtering.ui.spec.ts
+++ b/src/app/features/game-list/game-list-filtering.ui.spec.ts
@@ -1158,13 +1158,14 @@ describe('GameListFilteringEngine UI behavior', () => {
     expect(desc.map((game) => game.title)).toEqual(['Normal', 'Fallback']);
   });
 
-  it('sorts by TAS using HLTB fallback hierarchy and keeps missing TAS values last', () => {
+  it('sorts by TAS using HLTB fallback hierarchy and falls back to completion-time/review tiers', () => {
     enableTasFeature();
     const games: GameEntry[] = [
       makeGame({
         igdbGameId: '1',
         platformIgdbId: 130,
         title: 'Main',
+        releaseDate: '2020-01-01',
         reviewScore: 80,
         reviewSource: 'metacritic',
         hltbMainHours: 10,
@@ -1173,6 +1174,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         igdbGameId: '2',
         platformIgdbId: 130,
         title: 'Main+Extra',
+        releaseDate: '2020-01-01',
         reviewScore: 80,
         reviewSource: 'metacritic',
         hltbMainHours: null,
@@ -1182,6 +1184,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         igdbGameId: '3',
         platformIgdbId: 130,
         title: 'Completionist',
+        releaseDate: '2020-01-01',
         reviewScore: 80,
         reviewSource: 'metacritic',
         hltbMainHours: null,
@@ -1192,6 +1195,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         igdbGameId: '4',
         platformIgdbId: 130,
         title: 'Moby',
+        releaseDate: '2020-01-01',
         reviewScore: 8.5,
         reviewSource: 'mobygames',
         mobyScore: 8.5,
@@ -1201,6 +1205,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         igdbGameId: '5',
         platformIgdbId: 130,
         title: 'No Hours',
+        releaseDate: '2020-01-01',
         reviewScore: 90,
         reviewSource: 'metacritic',
         hltbMainHours: null,
@@ -1211,6 +1216,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         igdbGameId: '6',
         platformIgdbId: 130,
         title: 'No Score',
+        releaseDate: '2020-01-01',
         reviewScore: null,
         hltbMainHours: 10,
       }),
@@ -1226,13 +1232,15 @@ describe('GameListFilteringEngine UI behavior', () => {
       '',
       20
     );
+    // 'No Score' has HLTB only (tier 2) and 'No Hours' has review only (tier 3), so
+    // tier order places 'No Score' before 'No Hours' regardless of direction.
     expect(desc.map((game) => game.title)).toEqual([
       'Completionist',
       'Moby',
       'Main+Extra',
       'Main',
-      'No Hours',
       'No Score',
+      'No Hours',
     ]);
 
     const asc = engine.applyFiltersAndSort(
@@ -1250,9 +1258,166 @@ describe('GameListFilteringEngine UI behavior', () => {
       'Main+Extra',
       'Moby',
       'Completionist',
-      'No Hours',
       'No Score',
+      'No Hours',
     ]);
+  });
+
+  it('groups TAS sort into fixed tiers by data completeness, unaffected by direction', () => {
+    enableTasFeature();
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Full Data',
+        releaseDate: '2020-01-01',
+        reviewScore: 90,
+        reviewSource: 'metacritic',
+        hltbMainHours: 10,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Hltb Only',
+        releaseDate: '2020-01-01',
+        reviewScore: null,
+        hltbMainHours: 15,
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Review Only',
+        releaseDate: '2020-01-01',
+        reviewScore: 70,
+        reviewSource: 'metacritic',
+        hltbMainHours: null,
+      }),
+      makeGame({
+        igdbGameId: '4',
+        platformIgdbId: 130,
+        title: 'No Data',
+        releaseDate: '2019-01-01',
+        reviewScore: null,
+        hltbMainHours: null,
+      }),
+    ];
+
+    const asc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'tas', sortDirection: 'asc' },
+      '',
+      20
+    );
+    expect(asc.map((game) => game.title)).toEqual([
+      'Full Data',
+      'Hltb Only',
+      'Review Only',
+      'No Data',
+    ]);
+
+    const desc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'tas', sortDirection: 'desc' },
+      '',
+      20
+    );
+    // Tier order (1-4) is fixed regardless of direction; only within-tier ordering flips.
+    // Since each tier here has exactly one game, the tier order is identical to asc.
+    expect(desc.map((game) => game.title)).toEqual([
+      'Full Data',
+      'Hltb Only',
+      'Review Only',
+      'No Data',
+    ]);
+  });
+
+  it('forces TAS games with unknown or future release dates into the release-date tier', () => {
+    enableTasFeature();
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Fully Qualified Past',
+        releaseDate: '2020-01-01',
+        reviewScore: 90,
+        reviewSource: 'metacritic',
+        hltbMainHours: 10,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Fully Qualified Future',
+        releaseDate: '2999-01-01',
+        reviewScore: 95,
+        reviewSource: 'metacritic',
+        hltbMainHours: 8,
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Fully Qualified Unknown',
+        releaseDate: null,
+        reviewScore: 92,
+        reviewSource: 'metacritic',
+        hltbMainHours: 9,
+      }),
+    ];
+
+    const asc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'tas', sortDirection: 'asc' },
+      '',
+      20
+    );
+
+    // Only the past-dated game qualifies for tier 1; future/unknown dates are forced
+    // into the release-date tier and sorted chronologically, with unknown last.
+    expect(asc.map((game) => game.title)).toEqual([
+      'Fully Qualified Past',
+      'Fully Qualified Future',
+      'Fully Qualified Unknown',
+    ]);
+  });
+
+  it('sorts the TAS release-date fallback tier chronologically with unknown dates always last', () => {
+    enableTasFeature();
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Unknown Date',
+        releaseDate: null,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Far Future',
+        releaseDate: '2999-06-01',
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Near Future',
+        releaseDate: '2999-01-01',
+      }),
+    ];
+
+    const asc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'tas', sortDirection: 'asc' },
+      '',
+      20
+    );
+    expect(asc.map((game) => game.title)).toEqual(['Near Future', 'Far Future', 'Unknown Date']);
+
+    const desc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'tas', sortDirection: 'desc' },
+      '',
+      20
+    );
+    // Direction reverses known-date ordering, but unknown dates stay pinned last.
+    expect(desc.map((game) => game.title)).toEqual(['Far Future', 'Near Future', 'Unknown Date']);
   });
 
   it('sorts by PTAS using price penalty and falls back to TAS tier when price is missing', () => {
@@ -1572,6 +1737,7 @@ describe('GameListFilteringEngine UI behavior', () => {
           igdbGameId: '1',
           platformIgdbId: 130,
           title: 'Beta',
+          releaseDate: '2020-01-01',
           reviewScore: 80,
           reviewSource: 'metacritic',
           hltbMainHours: 10,
@@ -1580,6 +1746,7 @@ describe('GameListFilteringEngine UI behavior', () => {
           igdbGameId: '2',
           platformIgdbId: 130,
           title: 'Alpha',
+          releaseDate: '2020-01-01',
           reviewScore: 80,
           reviewSource: 'metacritic',
           hltbMainHours: 10,

--- a/src/app/features/game-list/game-list-filtering.ui.spec.ts
+++ b/src/app/features/game-list/game-list-filtering.ui.spec.ts
@@ -1255,7 +1255,7 @@ describe('GameListFilteringEngine UI behavior', () => {
     ]);
   });
 
-  it('sorts by PTAS using price penalty and keeps missing PTAS values last', () => {
+  it('sorts by PTAS using price penalty and falls back to TAS tier when price is missing', () => {
     enableTasFeature();
     const games: GameEntry[] = [
       makeGame({
@@ -1263,6 +1263,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         platformIgdbId: 130,
         title: 'Short Premium',
         listType: 'wishlist',
+        releaseDate: '2020-01-01',
         reviewScore: 85,
         reviewSource: 'metacritic',
         hltbMainHours: 5,
@@ -1273,6 +1274,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         platformIgdbId: 130,
         title: 'Long Cheap',
         listType: 'wishlist',
+        releaseDate: '2020-01-01',
         reviewScore: 90,
         reviewSource: 'metacritic',
         hltbMainHours: 20,
@@ -1283,6 +1285,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         platformIgdbId: 130,
         title: 'Balanced',
         listType: 'wishlist',
+        releaseDate: '2020-01-01',
         reviewScore: 88,
         reviewSource: 'metacritic',
         hltbMainHours: 8,
@@ -1293,6 +1296,7 @@ describe('GameListFilteringEngine UI behavior', () => {
         platformIgdbId: 130,
         title: 'No Price',
         listType: 'wishlist',
+        releaseDate: '2020-01-01',
         reviewScore: 95,
         reviewSource: 'metacritic',
         hltbMainHours: 3,
@@ -1312,12 +1316,207 @@ describe('GameListFilteringEngine UI behavior', () => {
       10
     );
 
+    // Short Premium/Long Cheap/Balanced all have price+review+HLTB (tier 1, ranked by PTAS).
+    // No Price has review+HLTB but no price, so it falls to tier 3 (ranked by TAS) and
+    // therefore always sorts after every tier-1 game, regardless of direction.
     expect(desc.map((game) => game.title)).toEqual([
       'Long Cheap',
       'Balanced',
       'Short Premium',
       'No Price',
     ]);
+  });
+
+  it('groups PTAS sort into fixed tiers by data completeness, unaffected by direction', () => {
+    enableTasFeature();
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Full Data',
+        listType: 'wishlist',
+        releaseDate: '2020-01-01',
+        reviewScore: 90,
+        reviewSource: 'metacritic',
+        hltbMainHours: 10,
+        priceAmount: 20,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Price Only',
+        listType: 'wishlist',
+        releaseDate: '2020-01-01',
+        reviewScore: null,
+        hltbMainHours: null,
+        priceAmount: 15,
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Review And Hltb',
+        listType: 'wishlist',
+        releaseDate: '2020-01-01',
+        reviewScore: 80,
+        reviewSource: 'metacritic',
+        hltbMainHours: 12,
+        priceAmount: null,
+      }),
+      makeGame({
+        igdbGameId: '4',
+        platformIgdbId: 130,
+        title: 'Review Only',
+        listType: 'wishlist',
+        releaseDate: '2020-01-01',
+        reviewScore: 70,
+        reviewSource: 'metacritic',
+        hltbMainHours: null,
+        priceAmount: null,
+      }),
+      makeGame({
+        igdbGameId: '5',
+        platformIgdbId: 130,
+        title: 'No Data',
+        listType: 'wishlist',
+        releaseDate: '2019-01-01',
+        reviewScore: null,
+        hltbMainHours: null,
+        priceAmount: null,
+      }),
+    ];
+
+    const asc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'ptas', sortDirection: 'asc' },
+      '',
+      20,
+      10
+    );
+    expect(asc.map((game) => game.title)).toEqual([
+      'Full Data',
+      'Price Only',
+      'Review And Hltb',
+      'Review Only',
+      'No Data',
+    ]);
+
+    const desc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'ptas', sortDirection: 'desc' },
+      '',
+      20,
+      10
+    );
+    // Tier order (1-5) is fixed regardless of direction; only within-tier ordering flips.
+    // Since each tier here has exactly one game, the tier order is identical to asc.
+    expect(desc.map((game) => game.title)).toEqual([
+      'Full Data',
+      'Price Only',
+      'Review And Hltb',
+      'Review Only',
+      'No Data',
+    ]);
+  });
+
+  it('forces PTAS games with unknown or future release dates into the release-date tier', () => {
+    enableTasFeature();
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Fully Qualified Past',
+        listType: 'wishlist',
+        releaseDate: '2020-01-01',
+        reviewScore: 90,
+        reviewSource: 'metacritic',
+        hltbMainHours: 10,
+        priceAmount: 20,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Fully Qualified Future',
+        listType: 'wishlist',
+        releaseDate: '2999-01-01',
+        reviewScore: 95,
+        reviewSource: 'metacritic',
+        hltbMainHours: 8,
+        priceAmount: 30,
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Fully Qualified Unknown',
+        listType: 'wishlist',
+        releaseDate: null,
+        reviewScore: 92,
+        reviewSource: 'metacritic',
+        hltbMainHours: 9,
+        priceAmount: 25,
+      }),
+    ];
+
+    const asc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'ptas', sortDirection: 'asc' },
+      '',
+      20,
+      10
+    );
+
+    // Only the past-dated game qualifies for tier 1; future/unknown dates are forced
+    // into the release-date tier and sorted chronologically, with unknown last.
+    expect(asc.map((game) => game.title)).toEqual([
+      'Fully Qualified Past',
+      'Fully Qualified Future',
+      'Fully Qualified Unknown',
+    ]);
+  });
+
+  it('sorts the PTAS release-date fallback tier chronologically with unknown dates always last', () => {
+    enableTasFeature();
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Unknown Date',
+        listType: 'wishlist',
+        releaseDate: null,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Far Future',
+        listType: 'wishlist',
+        releaseDate: '2999-06-01',
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Near Future',
+        listType: 'wishlist',
+        releaseDate: '2999-01-01',
+      }),
+    ];
+
+    const asc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'ptas', sortDirection: 'asc' },
+      '',
+      20,
+      10
+    );
+    expect(asc.map((game) => game.title)).toEqual(['Near Future', 'Far Future', 'Unknown Date']);
+
+    const desc = engine.applyFiltersAndSort(
+      games,
+      { ...DEFAULT_GAME_LIST_FILTERS, sortField: 'ptas', sortDirection: 'desc' },
+      '',
+      20,
+      10
+    );
+    // Direction reverses known-date ordering, but unknown dates stay pinned last.
+    expect(desc.map((game) => game.title)).toEqual(['Far Future', 'Near Future', 'Unknown Date']);
   });
 
   it('reuses cached non-PTAS sorts when only price preference changes', () => {

--- a/src/app/features/game-list/game-list-filtering.ui.spec.ts
+++ b/src/app/features/game-list/game-list-filtering.ui.spec.ts
@@ -628,6 +628,58 @@ describe('GameListFilteringEngine UI behavior', () => {
     expect(result.map((game) => game.title)).toEqual(['Target']);
   });
 
+  it('filters to games currently on discount', () => {
+    const games: GameEntry[] = [
+      makeGame({
+        igdbGameId: '1',
+        platformIgdbId: 130,
+        title: 'Discounted By Amount',
+        listType: 'wishlist',
+        priceAmount: 10,
+        priceRegularAmount: 20,
+      }),
+      makeGame({
+        igdbGameId: '2',
+        platformIgdbId: 130,
+        title: 'Discounted By Percent',
+        listType: 'wishlist',
+        priceDiscountPercent: 15,
+      }),
+      makeGame({
+        igdbGameId: '3',
+        platformIgdbId: 130,
+        title: 'Full Price',
+        listType: 'wishlist',
+        priceAmount: 20,
+        priceRegularAmount: 20,
+      }),
+      makeGame({
+        igdbGameId: '4',
+        platformIgdbId: 130,
+        title: 'Free Game',
+        listType: 'wishlist',
+        priceIsFree: true,
+        priceDiscountPercent: 15,
+      }),
+      makeGame({
+        igdbGameId: '5',
+        platformIgdbId: 130,
+        title: 'No Pricing',
+        listType: 'wishlist',
+      }),
+    ];
+
+    const filters: GameListFilters = {
+      ...DEFAULT_GAME_LIST_FILTERS,
+      discounted: true,
+    };
+
+    const result = engine.applyFiltersAndSort(games, filters, '');
+    expect(result.map((game) => game.title).sort()).toEqual(
+      ['Discounted By Amount', 'Discounted By Percent'].sort()
+    );
+  });
+
   it('excludes games that match exclusion filters', () => {
     const games: GameEntry[] = [
       makeGame({

--- a/src/app/list-page/list-page-preferences.spec.ts
+++ b/src/app/list-page/list-page-preferences.spec.ts
@@ -90,6 +90,7 @@ describe('list-page-preferences', () => {
       hltbMainHoursMax: 25,
       releaseDateFrom: '2025-02-01',
       releaseDateTo: null,
+      discounted: false,
     });
   });
 
@@ -177,6 +178,19 @@ describe('list-page-preferences', () => {
 
     expect(wishlistNormalized.sortField).toBe('ptas');
     expect(collectionNormalized.sortField).toBe(DEFAULT_GAME_LIST_FILTERS.sortField);
+  });
+
+  it('accepts discounted only for wishlist stored preferences', () => {
+    const wishlistNormalized = normalizeListPageStoredFilters({ discounted: true }, '__none__', {
+      listType: 'wishlist',
+    });
+
+    const collectionNormalized = normalizeListPageStoredFilters({ discounted: true }, '__none__', {
+      listType: 'collection',
+    });
+
+    expect(wishlistNormalized.discounted).toBe(true);
+    expect(collectionNormalized.discounted).toBe(false);
   });
 
   it('migrates metacritic sort field from stored preferences to review', () => {

--- a/src/app/list-page/list-page-preferences.ts
+++ b/src/app/list-page/list-page-preferences.ts
@@ -83,6 +83,7 @@ export function normalizeListPageStoredFilters(
         : hltbMainHoursMax,
     releaseDateFrom: normalizeDateOnly(parsed['releaseDateFrom']),
     releaseDateTo: normalizeDateOnly(parsed['releaseDateTo']),
+    discounted: options.listType === 'wishlist' && parsed['discounted'] === true,
   };
 }
 

--- a/src/app/settings/settings-import-export.utils.spec.ts
+++ b/src/app/settings/settings-import-export.utils.spec.ts
@@ -194,6 +194,23 @@ describe('settings-import-export.utils', () => {
     expect(collectionParsed?.sortField).toBe(DEFAULT_GAME_LIST_FILTERS.sortField);
   });
 
+  it('accepts discounted only for wishlist views during import parsing', () => {
+    const wishlistParsed = parseFilters(
+      JSON.stringify({ discounted: true }),
+      DEFAULT_GAME_LIST_FILTERS,
+      { listType: 'wishlist' }
+    );
+
+    const collectionParsed = parseFilters(
+      JSON.stringify({ discounted: true }),
+      DEFAULT_GAME_LIST_FILTERS,
+      { listType: 'collection' }
+    );
+
+    expect(wishlistParsed?.discounted).toBe(true);
+    expect(collectionParsed?.discounted).toBe(false);
+  });
+
   it('falls back from price sort field for collection views during import parsing', () => {
     const parsed = parseFilters(
       JSON.stringify({

--- a/src/app/settings/settings-import-export.utils.ts
+++ b/src/app/settings/settings-import-export.utils.ts
@@ -381,6 +381,7 @@ export function parseFilters(
           : parsedHltbMainHoursMax,
       releaseDateFrom: typeof parsed.releaseDateFrom === 'string' ? parsed.releaseDateFrom : null,
       releaseDateTo: typeof parsed.releaseDateTo === 'string' ? parsed.releaseDateTo : null,
+      discounted: options?.listType === 'wishlist' && parsed.discounted === true,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary
Adds a "Discounted" checkbox filter to the wishlist filters menu so users can narrow their wishlist to games currently on sale. Also fixes TAS/PTAS sort ordering so games with partial data (e.g. HLTB but no review, or vice versa) are tiered by data completeness instead of being dumped in with games that have no data at all, and pins games with unknown/future release dates into a dedicated chronological fallback tier.

## Implementation details
- Added `discounted: boolean` to `GameListFilters` (default `false`) and `GameListView`.
- New `isGameOnDiscount()` util in `game-filter-utils.ts`, extracted from `GameShelfService.isGameDiscounted` (now delegates to the shared util) and reused by the list-filtering engine.
- `GameListFilteringEngine` excludes non-discounted games when `filters.discounted` is set and counts it toward "has active filters."
- `GameFiltersMenuComponent` exposes `showDiscountedFilter` (wishlist-only) and `onDiscountedFilterChange()`; `ngOnChanges` strips a stale `discounted: true` when the list type isn't wishlist and re-emits corrected filters.
- Wishlist-only enforcement for `discounted` applied consistently in `LocalGameRepository.normalizeViewFilters`, `normalizeListPageStoredFilters`, and `parseFilters` (settings import).
- Reworked `compareGamesByTimeAdjustedScore` / `compareGamesByPriceAdjustedTimeAdjustedScore` into tiered classification (`classifyTasTier`, `classifyWishlistPtasTier`) based on data completeness and release-date status, with a shared `compareReleaseDatesUnknownLast` fallback comparator for the lowest tier.

## Testing performed
- `npm run lint` — passes.
- `npm run test` — 1552/1552 tests passing (99 files), coverage report reviewed; no gaps introduced in changed code.
- `npm run build` — succeeds; pre-existing bundle-budget warning confirmed unrelated to this change (present on `main` too).
- Added/updated specs: `local-game-repository.spec.ts`, `list-page-preferences.spec.ts`, `settings-import-export.utils.spec.ts`, `game-filters-menu.component.spec.ts`, `game-list-filtering.ui.spec.ts`.

## Screenshots (if applicable)
N/A — checkbox filter added to existing wishlist filters menu, no visual redesign.

## Checklist
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues
Fixes #
