### PR TITLE
fix(ci): force OTA deploy check on manual dispatch

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -175,10 +175,16 @@ jobs:
             NATIVE_ARGS="--native-shell-changed"
           fi
 
+          FORCE_ARGS=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FORCE_ARGS="--force"
+          fi
+
           node scripts/ios-live-update-should-deploy.mjs \
             --base "$PREV" \
             --head "${{ needs.release.outputs.release_sha }}" \
             $NATIVE_ARGS \
+            $FORCE_ARGS \
             --github-output "$GITHUB_OUTPUT"
 
   ios_live_update_skip_summary:


### PR DESCRIPTION
## Summary
- Manual `workflow_dispatch` runs of Release & Publish force-rebuild the edge image (`detect_image_changes` uses `--force-all`), but the separate `detect_ios_live_update` job had no equivalent override
- On a dispatch with no genuine `src/**`/edge diff since the last tag, `should_deploy` resolved to `false`, routing the build through the non-OTA Dockerfile path — which runs `mkdir -p ota/ios` instead of embedding a manifest, silently wiping the previously-published OTA bundle on redeploy

## Implementation details
- `scripts/ios-live-update-should-deploy.mjs` already supports a `--force` flag (`shouldDeploy: !nativeShellChanged` when native-shell hasn't changed)
- Wired it into `.github/workflows/release-publish.yml`'s "Evaluate iOS live-update scope" step: pass `--force` whenever `github.event_name == 'workflow_dispatch'`, mirroring the existing `--force-all` behavior on `detect_image_changes`

## Testing notes
- `npm run lint` passes
- No test/build impact — YAML-only workflow change; behavior will be validated by the next manual `workflow_dispatch` run of Release & Publish