### PR TITLE
feat(compat): add PS Vita compatibility via Vita3K

### DIFF
--- a/compat-scraper/src/parsers/vita3k.mjs
+++ b/compat-scraper/src/parsers/vita3k.mjs
@@ -1,0 +1,58 @@
+// Vita3K's compat data lives as GitHub Issues (Vita3K/compatibility), but the Vita3K org
+// runs its own purpose-built Cloudflare Worker (Vita3K/api) that cron-refreshes from those
+// issues every minute and serves clean JSON with no anti-bot protection, so this can be
+// fetched live — no manual dump, no browser, no pagination.
+const VITA3K_COMPAT_DATA_URL = 'https://vita3k-api.pedro.moe/list/commercial';
+
+// Vita3K has no "Perfect" tier — "Playable" is the ceiling (this platform's bestStatus is
+// "playable", not "perfect"). Everything else (Ingame +/-, Intro, Menu, Bootable, Nothing)
+// folds into "incomplete".
+function mapRawStatus(rawLabel) {
+  const normalized = String(rawLabel ?? '')
+    .trim()
+    .toLowerCase();
+
+  if (normalized === 'playable') {
+    return 'playable';
+  }
+
+  return 'incomplete';
+}
+
+export function mapLabel(rawLabel) {
+  return mapRawStatus(rawLabel);
+}
+
+// getBrowser/dumpDir are unused here — this parser does a plain HTTPS fetch, no browser or
+// local file needed. Kept in the signature for parity with browser/dump-based parsers.
+export async function fetchList(_getBrowser, { timeoutMs }) {
+  const response = await fetch(VITA3K_COMPAT_DATA_URL, {
+    signal: AbortSignal.timeout(timeoutMs ?? 25000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Vita3K compat data request failed with status ${response.status}`);
+  }
+
+  const body = await response.json();
+  const games = Array.isArray(body?.list) ? body.list : null;
+
+  if (!games) {
+    throw new Error('Vita3K compat data response had no "list" array.');
+  }
+
+  return games
+    .filter((entry) => entry && typeof entry.name === 'string' && entry.name.trim().length > 0)
+    .map((entry) => ({
+      rawTitle: entry.name.trim(),
+      rawLabel: String(entry.status ?? '').trim(),
+      normalizedStatus: mapRawStatus(entry.status),
+      sourceId: typeof entry.titleId === 'string' ? entry.titleId : null,
+      sourceUrl:
+        typeof entry.issueId === 'number'
+          ? `https://github.com/Vita3K/compatibility/issues/${entry.issueId}`
+          : VITA3K_COMPAT_DATA_URL,
+    }));
+}
+
+export const vita3kParser = { fetchList, mapLabel };

--- a/compat-scraper/src/registry.mjs
+++ b/compat-scraper/src/registry.mjs
@@ -7,6 +7,7 @@ import { xemuParser } from './parsers/xemu.mjs';
 import { xeniaParser } from './parsers/xenia.mjs';
 import { rpcs3Parser } from './parsers/rpcs3.mjs';
 import { cemuParser } from './parsers/cemu.mjs';
+import { vita3kParser } from './parsers/vita3k.mjs';
 
 // Adding a new platform/emulator is: one parser module + one entry here +
 // one entry in config/emulation-compat-platform-map.json — nothing else changes.
@@ -17,6 +18,7 @@ const PARSER_REGISTRY = {
   xenia: xeniaParser,
   rpcs3: rpcs3Parser,
   cemu: cemuParser,
+  vita3k: vita3kParser,
 };
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));

--- a/config/emulation-compat-platform-map.json
+++ b/config/emulation-compat-platform-map.json
@@ -40,5 +40,11 @@
     "displayName": "Wii U",
     "sourceUrl": "https://compat.cemu.info/",
     "bestStatus": "perfect"
+  },
+  "46": {
+    "emulator": "vita3k",
+    "displayName": "PlayStation Vita",
+    "sourceUrl": "https://vita3k-api.pedro.moe/list/commercial",
+    "bestStatus": "playable"
   }
 }

--- a/server/src/emulation-compat/platform-map.test.ts
+++ b/server/src/emulation-compat/platform-map.test.ts
@@ -10,6 +10,7 @@ void test('isCompatEligiblePlatform is true only for configured platforms', () =
   assert.equal(isCompatEligiblePlatform(12), true);
   assert.equal(isCompatEligiblePlatform(9), true);
   assert.equal(isCompatEligiblePlatform(41), true);
+  assert.equal(isCompatEligiblePlatform(46), true);
   assert.equal(isCompatEligiblePlatform(999), false);
 });
 
@@ -69,6 +70,15 @@ void test('getCompatPlatformConfig returns the Cemu config for Wii U', () => {
   assert.equal(wiiu.emulator, 'cemu');
   assert.equal(wiiu.displayName, 'Wii U');
   assert.equal(wiiu.bestStatus, 'perfect');
+});
+
+void test('getCompatPlatformConfig returns the Vita3K config for PlayStation Vita with a non-perfect bestStatus', () => {
+  const psvita = getCompatPlatformConfig(46);
+
+  assert.ok(psvita);
+  assert.equal(psvita.emulator, 'vita3k');
+  assert.equal(psvita.displayName, 'PlayStation Vita');
+  assert.equal(psvita.bestStatus, 'playable');
 });
 
 void test('getCompatPlatformConfig returns null for a platform with no compat source', () => {

--- a/server/src/emulation-compat/platform-map.ts
+++ b/server/src/emulation-compat/platform-map.ts
@@ -77,6 +77,15 @@ export const COMPAT_PLATFORM_MAP: ReadonlyMap<number, CompatPlatformConfig> = ne
       bestStatus: 'perfect',
     },
   ],
+  [
+    46,
+    {
+      emulator: 'vita3k',
+      displayName: 'PlayStation Vita',
+      sourceUrl: 'https://vita3k-api.pedro.moe/list/commercial',
+      bestStatus: 'playable',
+    },
+  ],
 ]);
 
 export function isCompatEligiblePlatform(platformIgdbId: number): boolean {

--- a/server/src/emulation-compat/refresh.test.ts
+++ b/server/src/emulation-compat/refresh.test.ts
@@ -214,8 +214,9 @@ void test('enqueueForcedCompatRefreshJobs dedupes platforms that are not due whe
             { platform_igdb_id: 12, last_refreshed_at: new Date().toISOString() },
             { platform_igdb_id: 9, last_refreshed_at: new Date().toISOString() },
             { platform_igdb_id: 41, last_refreshed_at: new Date().toISOString() },
+            { platform_igdb_id: 46, last_refreshed_at: new Date().toISOString() },
           ],
-          rowCount: 7,
+          rowCount: 8,
         });
       }
       return super.query(sql, params);
@@ -229,5 +230,5 @@ void test('enqueueForcedCompatRefreshJobs dedupes platforms that are not due whe
 
   config.compatScraperBaseUrl = originalBaseUrl;
 
-  assert.deepEqual(result, { enqueued: 0, deduped: 7, errors: 0 });
+  assert.deepEqual(result, { enqueued: 0, deduped: 8, errors: 0 });
 });


### PR DESCRIPTION
## Summary

Adds PlayStation Vita to the emulation-compat tracking system, sourcing compatibility data from Vita3K via the Vita3K org's own Cloudflare Worker API (a live JSON feed refreshed every minute from the Vita3K/compatibility GitHub Issues, with no anti-bot protection or pagination required).

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Added `compat-scraper/src/parsers/vita3k.mjs`: fetches `https://vita3k-api.pedro.moe/list/commercial`, maps raw status labels to `playable`/`incomplete` (Vita3K has no "Perfect" tier, so `playable` is the ceiling), and normalizes entries with title, source id, and a GitHub issue URL (falling back to the API URL when no issue id is present).
- Registered the new parser in `compat-scraper/src/registry.mjs`.
- Added platform id `46` (PlayStation Vita) to `config/emulation-compat-platform-map.json` and the mirrored server-side `COMPAT_PLATFORM_MAP` in `server/src/emulation-compat/platform-map.ts`, with `bestStatus: 'playable'`.
- Follows the existing parser interface/conventions used by other platforms (e.g. Cemu) — same `fetchList(getBrowser, { timeoutMs })` / `mapLabel` shape, same error-handling style for non-OK responses.

## Testing performed

- `npm run typecheck:server` — passes
- `npm run test:server` — 711 passed, 0 failed, 2 skipped
- `npm run lint` — passes, no errors
- Manual sanity check: `mapLabel` verified for `Playable`, `Ingame+`, and `undefined` inputs, mapping to `playable`, `incomplete`, `incomplete` respectively
- Updated `platform-map.test.ts` to assert platform 46 resolves to the Vita3K config
- Updated `refresh.test.ts` row-count/dedupe assertions to account for the new eligible platform

## Screenshots (if applicable)

N/A — backend/config change only, no UI impact.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
