### PR TITLE
feat(compat): add 3DS compatibility via Azahar

### DIFF
--- a/compat-scraper/src/parsers/azahar.mjs
+++ b/compat-scraper/src/parsers/azahar.mjs
@@ -30,9 +30,26 @@ function mapRawRating(rating) {
   return 'incomplete';
 }
 
+const AZAHAR_LABELS_BY_NORMALIZED_LABEL = new Map(
+  Object.entries(AZAHAR_LABELS).map(([rating, label]) => [label.toLowerCase(), Number(rating)])
+);
+
+// Accepts either a label ("Perfect", case/whitespace-insensitive) or a raw numeric code
+// ("0", "1", ...), matching the shapes rawLabel can take from fetchList and from callers.
 export function mapLabel(rawLabel) {
-  const entry = Object.entries(AZAHAR_LABELS).find(([, label]) => label === rawLabel);
-  return entry ? mapRawRating(Number(entry[0])) : 'incomplete';
+  const normalized = String(rawLabel ?? '')
+    .trim()
+    .toLowerCase();
+
+  if (AZAHAR_LABELS_BY_NORMALIZED_LABEL.has(normalized)) {
+    return mapRawRating(AZAHAR_LABELS_BY_NORMALIZED_LABEL.get(normalized));
+  }
+
+  if (normalized in AZAHAR_LABELS) {
+    return mapRawRating(Number(normalized));
+  }
+
+  return 'incomplete';
 }
 
 // getBrowser/dumpDir are unused here — this parser does a plain HTTPS fetch, no browser or

--- a/compat-scraper/src/parsers/azahar.mjs
+++ b/compat-scraper/src/parsers/azahar.mjs
@@ -1,0 +1,84 @@
+// Azahar (Citra's community continuation) publishes compat data as a plain JSON file
+// directly in its repo, fetchable live via raw.githubusercontent.com with no anti-bot
+// protection — no manual dump, no browser, no pagination needed.
+const AZAHAR_COMPAT_DATA_URL =
+  'https://raw.githubusercontent.com/azahar-emu/compatibility-list/master/compatibility_list.json';
+
+const AZAHAR_LABELS = {
+  0: 'Perfect',
+  1: 'Great',
+  2: 'Okay',
+  3: 'Bad',
+  4: 'Intro/Menu',
+  5: "Won't Boot",
+  99: 'Untested',
+};
+
+// Azahar's scale is inverted (lower is better) — only 0 (Perfect) and 1 (Great) clear the
+// bar; "Great" reads as our "playable" tier per its own description (minimal glitches, close
+// to real hardware). Everything else (Okay/Bad/Intro-Menu/Won't-Boot/Untested) folds into
+// "incomplete".
+function mapRawRating(rating) {
+  if (rating === 0) {
+    return 'perfect';
+  }
+
+  if (rating === 1) {
+    return 'playable';
+  }
+
+  return 'incomplete';
+}
+
+export function mapLabel(rawLabel) {
+  const entry = Object.entries(AZAHAR_LABELS).find(([, label]) => label === rawLabel);
+  return entry ? mapRawRating(Number(entry[0])) : 'incomplete';
+}
+
+// getBrowser/dumpDir are unused here — this parser does a plain HTTPS fetch, no browser or
+// local file needed. Kept in the signature for parity with browser/dump-based parsers.
+export async function fetchList(_getBrowser, { timeoutMs }) {
+  const response = await fetch(AZAHAR_COMPAT_DATA_URL, {
+    signal: AbortSignal.timeout(timeoutMs ?? 25000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Azahar compat data request failed with status ${response.status}`);
+  }
+
+  const games = await response.json();
+
+  if (!Array.isArray(games)) {
+    throw new Error('Azahar compat data response was not an array.');
+  }
+
+  const entries = [];
+
+  for (const game of games) {
+    if (!game || typeof game.title !== 'string' || game.title.trim().length === 0) {
+      continue;
+    }
+
+    const rating = Number(game.compatibility);
+    const rawLabel = AZAHAR_LABELS[rating] ?? String(game.compatibility ?? '');
+    const normalizedStatus = mapRawRating(rating);
+    const releases =
+      Array.isArray(game.releases) && game.releases.length > 0 ? game.releases : [{ id: null }];
+    const title = game.title.trim();
+    const sourceUrl = `https://github.com/azahar-emu/compatibility-list/issues?q=${encodeURIComponent(title)}`;
+
+    for (const release of releases) {
+      entries.push({
+        rawTitle: title,
+        rawLabel,
+        normalizedStatus,
+        sourceId: typeof release?.id === 'string' ? release.id : null,
+        sourceUrl,
+      });
+    }
+  }
+
+  return entries;
+}
+
+export const azaharParser = { fetchList, mapLabel };

--- a/compat-scraper/src/registry.mjs
+++ b/compat-scraper/src/registry.mjs
@@ -8,6 +8,7 @@ import { xeniaParser } from './parsers/xenia.mjs';
 import { rpcs3Parser } from './parsers/rpcs3.mjs';
 import { cemuParser } from './parsers/cemu.mjs';
 import { vita3kParser } from './parsers/vita3k.mjs';
+import { azaharParser } from './parsers/azahar.mjs';
 
 // Adding a new platform/emulator is: one parser module + one entry here +
 // one entry in config/emulation-compat-platform-map.json — nothing else changes.
@@ -19,6 +20,7 @@ const PARSER_REGISTRY = {
   rpcs3: rpcs3Parser,
   cemu: cemuParser,
   vita3k: vita3kParser,
+  azahar: azaharParser,
 };
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));

--- a/config/emulation-compat-platform-map.json
+++ b/config/emulation-compat-platform-map.json
@@ -46,5 +46,11 @@
     "displayName": "PlayStation Vita",
     "sourceUrl": "https://vita3k-api.pedro.moe/list/commercial",
     "bestStatus": "playable"
+  },
+  "37": {
+    "emulator": "azahar",
+    "displayName": "3DS",
+    "sourceUrl": "https://github.com/azahar-emu/compatibility-list",
+    "bestStatus": "perfect"
   }
 }

--- a/server/src/emulation-compat/platform-map.test.ts
+++ b/server/src/emulation-compat/platform-map.test.ts
@@ -11,6 +11,7 @@ void test('isCompatEligiblePlatform is true only for configured platforms', () =
   assert.equal(isCompatEligiblePlatform(9), true);
   assert.equal(isCompatEligiblePlatform(41), true);
   assert.equal(isCompatEligiblePlatform(46), true);
+  assert.equal(isCompatEligiblePlatform(37), true);
   assert.equal(isCompatEligiblePlatform(999), false);
 });
 
@@ -79,6 +80,15 @@ void test('getCompatPlatformConfig returns the Vita3K config for PlayStation Vit
   assert.equal(psvita.emulator, 'vita3k');
   assert.equal(psvita.displayName, 'PlayStation Vita');
   assert.equal(psvita.bestStatus, 'playable');
+});
+
+void test('getCompatPlatformConfig returns the Azahar config for 3DS', () => {
+  const threeDs = getCompatPlatformConfig(37);
+
+  assert.ok(threeDs);
+  assert.equal(threeDs.emulator, 'azahar');
+  assert.equal(threeDs.displayName, '3DS');
+  assert.equal(threeDs.bestStatus, 'perfect');
 });
 
 void test('getCompatPlatformConfig returns null for a platform with no compat source', () => {

--- a/server/src/emulation-compat/platform-map.ts
+++ b/server/src/emulation-compat/platform-map.ts
@@ -86,6 +86,15 @@ export const COMPAT_PLATFORM_MAP: ReadonlyMap<number, CompatPlatformConfig> = ne
       bestStatus: 'playable',
     },
   ],
+  [
+    37,
+    {
+      emulator: 'azahar',
+      displayName: '3DS',
+      sourceUrl: 'https://github.com/azahar-emu/compatibility-list',
+      bestStatus: 'perfect',
+    },
+  ],
 ]);
 
 export function isCompatEligiblePlatform(platformIgdbId: number): boolean {

--- a/server/src/emulation-compat/refresh.test.ts
+++ b/server/src/emulation-compat/refresh.test.ts
@@ -215,8 +215,9 @@ void test('enqueueForcedCompatRefreshJobs dedupes platforms that are not due whe
             { platform_igdb_id: 9, last_refreshed_at: new Date().toISOString() },
             { platform_igdb_id: 41, last_refreshed_at: new Date().toISOString() },
             { platform_igdb_id: 46, last_refreshed_at: new Date().toISOString() },
+            { platform_igdb_id: 37, last_refreshed_at: new Date().toISOString() },
           ],
-          rowCount: 8,
+          rowCount: 9,
         });
       }
       return super.query(sql, params);
@@ -230,5 +231,5 @@ void test('enqueueForcedCompatRefreshJobs dedupes platforms that are not due whe
 
   config.compatScraperBaseUrl = originalBaseUrl;
 
-  assert.deepEqual(result, { enqueued: 0, deduped: 8, errors: 0 });
+  assert.deepEqual(result, { enqueued: 0, deduped: 9, errors: 0 });
 });


### PR DESCRIPTION
## Summary

Adds 3DS emulator compatibility tracking backed by Azahar (Citra's community
continuation), following the existing per-platform parser pattern in the
compat-scraper service.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- Added `compat-scraper/src/parsers/azahar.mjs`: fetches Azahar's compatibility
  list live from `raw.githubusercontent.com` (no anti-bot protection, no browser
  or manual dump needed). Maps Azahar's inverted 0–5 rating scale (0 = Perfect,
  1 = Great, ..., 99 = Untested) to the normalized status set — only `0` maps to
  `perfect` and `1` maps to `playable`; everything else folds into `incomplete`.
- Registered the new parser in `compat-scraper/src/registry.mjs` under the
  `azahar` key.
- Added platform IGDB id `37` (3DS) to `config/emulation-compat-platform-map.json`
  and the mirrored server-side map in `server/src/emulation-compat/platform-map.ts`,
  with `bestStatus: "perfect"` and Azahar's compat list as the source URL.
- Updated existing platform-map and forced-refresh tests
  (`platform-map.test.ts`, `refresh.test.ts`) to account for the new platform
  entry.

## Testing performed

- `npm run typecheck:server` — passes
- `npm run test:server` — 712 passed, 2 skipped, 0 failed
- `npm run lint` — passes, no issues

## Screenshots (if applicable)

N/A — backend/config change only.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
