### PR TITLE
feat(compat): sync bound-game status on refresh and surface compat indicator

### DIFF
--- a/server/src/emulation-compat/refresh.test.ts
+++ b/server/src/emulation-compat/refresh.test.ts
@@ -35,6 +35,8 @@ interface StoredStatusRow {
   igdb_game_id: string;
   normalized_status: string;
   match_locked: boolean;
+  raw_source_id?: string | null;
+  match_query_title?: string | null;
 }
 
 class FakeCompatPool {
@@ -55,6 +57,8 @@ class FakeCompatPool {
           title: game.title,
           match_locked: stored?.match_locked ?? false,
           normalized_status: stored?.normalized_status ?? null,
+          raw_source_id: stored?.raw_source_id ?? null,
+          match_query_title: stored?.match_query_title ?? null,
         };
       });
       return Promise.resolve({ rows, rowCount: rows.length });
@@ -70,6 +74,19 @@ class FakeCompatPool {
           match_locked: false,
         });
       }
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    }
+
+    if (normalized.startsWith('update emulation_compat_status set')) {
+      const [igdbGameId, , , normalizedStatus] = params as [string, number, string, string];
+      const existing = this.statuses.get(igdbGameId);
+      this.statuses.set(igdbGameId, {
+        igdb_game_id: igdbGameId,
+        normalized_status: normalizedStatus,
+        match_locked: true,
+        raw_source_id: existing?.raw_source_id ?? null,
+        match_query_title: existing?.match_query_title ?? null,
+      });
       return Promise.resolve({ rows: [], rowCount: 1 });
     }
 
@@ -214,6 +231,84 @@ void test('refreshCompatSource skips games already at the emulator best status',
   assert.equal(stored.normalized_status, 'perfect');
   assert.equal(pool.gamePayloads.size, 0);
   assert.equal(pool.syncEventCount, 0);
+});
+
+void test('refreshCompatSource re-resolves a bound game by raw_source_id and updates its status', async () => {
+  const originalBaseUrl = config.compatScraperBaseUrl;
+  config.compatScraperBaseUrl = 'http://compat-scraper.test';
+
+  const pool = new FakeCompatPool();
+  pool.ownedGames = [{ igdb_game_id: 'g1', title: 'Metroid Prime Trilogy' }];
+  pool.statuses.set('g1', {
+    igdb_game_id: 'g1',
+    normalized_status: 'incomplete',
+    match_locked: true,
+    raw_source_id: '/index.php?title=Metroid_Prime',
+    match_query_title: 'Metroid Prime',
+  });
+
+  await withMockFetch(
+    () =>
+      new Response(
+        JSON.stringify({
+          emulator: 'dolphin',
+          sourceUrl: 'https://www.dolphin-emu.org/compat/',
+          entries: [
+            {
+              rawTitle: 'Metroid Prime',
+              rawLabel: 'Perfect',
+              normalizedStatus: 'perfect',
+              sourceId: '/index.php?title=Metroid_Prime',
+              sourceUrl: 'https://wiki.dolphin-emu.org/index.php?title=Metroid_Prime',
+            },
+          ],
+        }),
+        { status: 200 }
+      ),
+    async () => {
+      await refreshCompatSource(pool as unknown as Pool, 21);
+    }
+  );
+
+  config.compatScraperBaseUrl = originalBaseUrl;
+
+  const stored = pool.statuses.get('g1');
+  assert.ok(stored);
+  assert.equal(stored.normalized_status, 'perfect');
+  assert.equal(stored.match_locked, true);
+  assert.equal(pool.gamePayloads.get('g1::21')?.compatStatus, 'perfect');
+});
+
+void test('refreshCompatSource leaves a bound game untouched when its upstream entry disappears', async () => {
+  const originalBaseUrl = config.compatScraperBaseUrl;
+  config.compatScraperBaseUrl = 'http://compat-scraper.test';
+
+  const pool = new FakeCompatPool();
+  pool.ownedGames = [{ igdb_game_id: 'g1', title: 'Metroid Prime Trilogy' }];
+  pool.statuses.set('g1', {
+    igdb_game_id: 'g1',
+    normalized_status: 'perfect',
+    match_locked: true,
+    raw_source_id: '/index.php?title=Metroid_Prime',
+    match_query_title: 'Metroid Prime',
+  });
+
+  await withMockFetch(
+    () =>
+      new Response(JSON.stringify({ emulator: 'dolphin', sourceUrl: null, entries: [] }), {
+        status: 200,
+      }),
+    async () => {
+      await refreshCompatSource(pool as unknown as Pool, 21);
+    }
+  );
+
+  config.compatScraperBaseUrl = originalBaseUrl;
+
+  const stored = pool.statuses.get('g1');
+  assert.ok(stored);
+  assert.equal(stored.normalized_status, 'perfect');
+  assert.equal(pool.gamePayloads.size, 0);
 });
 
 void test('refreshCompatSource rejects a non compat-eligible platform', async () => {

--- a/server/src/emulation-compat/refresh.test.ts
+++ b/server/src/emulation-compat/refresh.test.ts
@@ -50,8 +50,10 @@ class FakeCompatPool {
     const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase();
 
     if (normalized.startsWith('select g.igdb_game_id, btrim')) {
+      const [platformIgdbId] = params as [number];
       const rows = this.ownedGames.map((game) => {
         const stored = this.statuses.get(game.igdb_game_id);
+        const payloadKey = `${game.igdb_game_id}::${String(platformIgdbId)}`;
         return {
           igdb_game_id: game.igdb_game_id,
           title: game.title,
@@ -59,6 +61,7 @@ class FakeCompatPool {
           normalized_status: stored?.normalized_status ?? null,
           raw_source_id: stored?.raw_source_id ?? null,
           match_query_title: stored?.match_query_title ?? null,
+          payload_compat_status: this.gamePayloads.get(payloadKey)?.compatStatus ?? null,
         };
       });
       return Promise.resolve({ rows, rowCount: rows.length });
@@ -189,7 +192,7 @@ void test('refreshCompatSource matches owned games against the scraper response 
   assert.equal(pool.syncEventCount, 1);
 });
 
-void test('refreshCompatSource skips games already at the emulator best status', async () => {
+void test('refreshCompatSource skips re-matching games already at the emulator best status, but backfills payload', async () => {
   const originalBaseUrl = config.compatScraperBaseUrl;
   config.compatScraperBaseUrl = 'http://compat-scraper.test';
 
@@ -229,7 +232,35 @@ void test('refreshCompatSource skips games already at the emulator best status',
   const stored = pool.statuses.get('g1');
   assert.ok(stored);
   assert.equal(stored.normalized_status, 'perfect');
-  assert.equal(pool.gamePayloads.size, 0);
+  assert.equal(pool.gamePayloads.get('g1::21')?.compatStatus, 'perfect');
+  assert.equal(pool.syncEventCount, 1);
+});
+
+void test('refreshCompatSource does not repatch payload once it already matches the stored status', async () => {
+  const originalBaseUrl = config.compatScraperBaseUrl;
+  config.compatScraperBaseUrl = 'http://compat-scraper.test';
+
+  const pool = new FakeCompatPool();
+  pool.ownedGames = [{ igdb_game_id: 'g1', title: 'Metroid Prime' }];
+  pool.statuses.set('g1', {
+    igdb_game_id: 'g1',
+    normalized_status: 'perfect',
+    match_locked: false,
+  });
+  pool.gamePayloads.set('g1::21', { compatStatus: 'perfect' });
+
+  await withMockFetch(
+    () =>
+      new Response(JSON.stringify({ emulator: 'dolphin', sourceUrl: null, entries: [] }), {
+        status: 200,
+      }),
+    async () => {
+      await refreshCompatSource(pool as unknown as Pool, 21);
+    }
+  );
+
+  config.compatScraperBaseUrl = originalBaseUrl;
+
   assert.equal(pool.syncEventCount, 0);
 });
 
@@ -292,6 +323,7 @@ void test('refreshCompatSource leaves a bound game untouched when its upstream e
     raw_source_id: '/index.php?title=Metroid_Prime',
     match_query_title: 'Metroid Prime',
   });
+  pool.gamePayloads.set('g1::21', { compatStatus: 'perfect' });
 
   await withMockFetch(
     () =>
@@ -308,7 +340,7 @@ void test('refreshCompatSource leaves a bound game untouched when its upstream e
   const stored = pool.statuses.get('g1');
   assert.ok(stored);
   assert.equal(stored.normalized_status, 'perfect');
-  assert.equal(pool.gamePayloads.size, 0);
+  assert.equal(pool.syncEventCount, 0);
 });
 
 void test('refreshCompatSource rejects a non compat-eligible platform', async () => {

--- a/server/src/emulation-compat/refresh.ts
+++ b/server/src/emulation-compat/refresh.ts
@@ -22,6 +22,7 @@ interface OwnedGameRow {
   normalized_status: string | null;
   raw_source_id: string | null;
   match_query_title: string | null;
+  payload_compat_status: string | null;
 }
 
 export function isCompatRefreshDue(
@@ -99,7 +100,8 @@ async function loadOwnedGamesForPlatform(
       COALESCE(ecs.match_locked, FALSE) AS match_locked,
       ecs.normalized_status AS normalized_status,
       ecs.raw_source_id AS raw_source_id,
-      ecs.match_query_title AS match_query_title
+      ecs.match_query_title AS match_query_title,
+      g.payload->>'compatStatus' AS payload_compat_status
     FROM games g
     LEFT JOIN emulation_compat_status ecs
       ON ecs.igdb_game_id = g.igdb_game_id AND ecs.platform_igdb_id = g.platform_igdb_id
@@ -138,6 +140,7 @@ export async function refreshCompatSource(pool: Pool, platformIgdbId: number): P
     );
 
     let matchedCount = ownedGames.filter((game) => game.normalized_status !== null).length;
+    const payloadPatchedGameIds = new Set<string>();
 
     for (const game of boundGames) {
       const entry = game.raw_source_id
@@ -180,6 +183,7 @@ export async function refreshCompatSource(pool: Pool, platformIgdbId: number): P
         ]
       );
 
+      payloadPatchedGameIds.add(game.igdb_game_id);
       await applyGamePayloadPatch(pool, game.igdb_game_id, platformIgdbId, {
         compatStatus: normalizedStatus,
       });
@@ -233,8 +237,27 @@ export async function refreshCompatSource(pool: Pool, platformIgdbId: number): P
         matchedCount += 1;
       }
 
+      payloadPatchedGameIds.add(game.igdb_game_id);
       await applyGamePayloadPatch(pool, game.igdb_game_id, platformIgdbId, {
         compatStatus: normalizedStatus,
+      });
+    }
+
+    // Backfill games whose emulation_compat_status row already reflects a status
+    // that the payload hasn't caught up to — e.g. rows matched before payload
+    // syncing existed, or rows sitting at bestStatus/bound that the loops above
+    // don't touch every run.
+    for (const game of ownedGames) {
+      if (
+        payloadPatchedGameIds.has(game.igdb_game_id) ||
+        game.normalized_status === null ||
+        game.normalized_status === game.payload_compat_status
+      ) {
+        continue;
+      }
+
+      await applyGamePayloadPatch(pool, game.igdb_game_id, platformIgdbId, {
+        compatStatus: game.normalized_status,
       });
     }
 

--- a/server/src/emulation-compat/refresh.ts
+++ b/server/src/emulation-compat/refresh.ts
@@ -20,6 +20,8 @@ interface OwnedGameRow {
   title: string;
   match_locked: boolean;
   normalized_status: string | null;
+  raw_source_id: string | null;
+  match_query_title: string | null;
 }
 
 export function isCompatRefreshDue(
@@ -57,7 +59,7 @@ async function fetchWithTimeout(
   }
 }
 
-async function fetchCompatList(
+export async function fetchCompatList(
   platformIgdbId: number
 ): Promise<{ emulator: string; sourceUrl: string | null; entries: CompatSourceEntry[] }> {
   const baseUrl = config.compatScraperBaseUrl.replace(/\/$/, '');
@@ -95,7 +97,9 @@ async function loadOwnedGamesForPlatform(
       g.igdb_game_id,
       BTRIM(COALESCE(g.payload->>'title', '')) AS title,
       COALESCE(ecs.match_locked, FALSE) AS match_locked,
-      ecs.normalized_status AS normalized_status
+      ecs.normalized_status AS normalized_status,
+      ecs.raw_source_id AS raw_source_id,
+      ecs.match_query_title AS match_query_title
     FROM games g
     LEFT JOIN emulation_compat_status ecs
       ON ecs.igdb_game_id = g.igdb_game_id AND ecs.platform_igdb_id = g.platform_igdb_id
@@ -122,15 +126,66 @@ export async function refreshCompatSource(pool: Pool, platformIgdbId: number): P
   try {
     const { emulator, sourceUrl, entries } = await fetchCompatList(platformIgdbId);
     const ownedGames = await loadOwnedGamesForPlatform(pool, platformIgdbId);
-    // Games already locked (manual override) or already at this emulator's best
-    // reachable status are stable — they can't improve, so skip re-fetch/re-match work.
-    const candidates = ownedGames.filter(
+
+    // Bound rows (match_locked) are pinned to a specific upstream entry rather than
+    // a status — every refresh, look that entry up again by identity and take
+    // whatever status it currently reports, instead of re-running fuzzy matching.
+    const boundGames = ownedGames.filter((game) => game.match_locked);
+    // Unbound games below this emulator's best reachable status are the only ones
+    // that can still improve, so that's the only set worth fuzzy-matching.
+    const unboundCandidates = ownedGames.filter(
       (game) => !game.match_locked && game.normalized_status !== platformConfig.bestStatus
     );
 
     let matchedCount = ownedGames.filter((game) => game.normalized_status !== null).length;
 
-    for (const game of candidates) {
+    for (const game of boundGames) {
+      const entry = game.raw_source_id
+        ? entries.find((candidate) => candidate.sourceId === game.raw_source_id)
+        : entries.find(
+            (candidate) =>
+              candidate.rawTitle.trim().toLowerCase() ===
+              (game.match_query_title ?? '').trim().toLowerCase()
+          );
+
+      if (!entry) {
+        continue;
+      }
+
+      const normalizedStatus = isEmulationCompatStatus(entry.normalizedStatus)
+        ? entry.normalizedStatus
+        : 'incomplete';
+
+      await pool.query(
+        `
+        UPDATE emulation_compat_status SET
+          emulator = $3,
+          normalized_status = $4,
+          raw_label = $5,
+          raw_source_id = $6,
+          source_url = $7,
+          matched_at = $8,
+          updated_at = NOW()
+        WHERE igdb_game_id = $1 AND platform_igdb_id = $2
+        `,
+        [
+          game.igdb_game_id,
+          platformIgdbId,
+          emulator,
+          normalizedStatus,
+          entry.rawLabel,
+          entry.sourceId,
+          entry.sourceUrl,
+          now.toISOString(),
+        ]
+      );
+
+      await applyGamePayloadPatch(pool, game.igdb_game_id, platformIgdbId, {
+        compatStatus: normalizedStatus,
+      });
+    }
+
+    for (const game of unboundCandidates) {
       const best = findBestTitleMatch(game.title, entries, (entry) => entry.rawTitle);
 
       if (!best || best.score < MIN_MATCH_SCORE) {

--- a/server/src/scripts/compat-match-cli.ts
+++ b/server/src/scripts/compat-match-cli.ts
@@ -3,6 +3,8 @@ import { config } from '../config.js';
 import { isEmulationCompatStatus } from '../../../shared/emulation-compat-status.mjs';
 import { COMPAT_PLATFORM_MAP } from '../emulation-compat/platform-map.js';
 import { applyGamePayloadPatch } from '../release-monitor.js';
+import { fetchCompatList } from '../emulation-compat/refresh.js';
+import { getTitleSimilarityScore } from '../emulation-compat/title-similarity.js';
 
 type Flags = Record<string, string | undefined>;
 
@@ -140,15 +142,19 @@ async function runList(pool: import('pg').Pool, flags: Flags): Promise<void> {
   process.exitCode = 1;
 }
 
+const SUGGESTION_COUNT = 5;
+
 async function runSet(pool: import('pg').Pool, flags: Flags): Promise<void> {
   const igdbGameId = flags.game;
   const platformIgdbId = parseIntFlag(flags.platform);
-  const status = flags.status;
-  const rawLabel = flags.label ?? status;
+  const matchTitle = flags.matchTitle;
+  const matchSourceId = flags.matchSourceId ?? null;
 
-  if (!igdbGameId || platformIgdbId === null || !isEmulationCompatStatus(status)) {
+  if (!igdbGameId || platformIgdbId === null || !matchTitle) {
     console.error(
-      'Usage: compat:match set --game=<igdbGameId> --platform=<platformIgdbId> --status=<perfect|playable|incomplete> [--label=<raw>]'
+      'Usage: compat:match set --game=<igdbGameId> --platform=<platformIgdbId> --matchTitle=<exact upstream title> [--matchSourceId=<id>]\n' +
+        '  Binds the game to a specific upstream compat-list entry. Future refreshes keep\n' +
+        '  tracking that entry and update the status to whatever it currently reports.'
     );
     process.exitCode = 1;
     return;
@@ -161,27 +167,83 @@ async function runSet(pool: import('pg').Pool, flags: Flags): Promise<void> {
     return;
   }
 
+  const { emulator, entries } = await fetchCompatList(platformIgdbId);
+
+  const matches = matchSourceId
+    ? entries.filter((entry) => entry.sourceId === matchSourceId)
+    : entries.filter(
+        (entry) => entry.rawTitle.trim().toLowerCase() === matchTitle.trim().toLowerCase()
+      );
+
+  if (matches.length === 0) {
+    const suggestions = [...entries]
+      .map((entry) => ({ entry, score: getTitleSimilarityScore(matchTitle, entry.rawTitle) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, SUGGESTION_COUNT);
+    console.error(`No upstream entry found matching "${matchTitle}". Did you mean:`);
+    for (const { entry, score } of suggestions) {
+      console.error(
+        `  "${entry.rawTitle}" sourceId=${entry.sourceId ?? 'null'} (score=${score.toFixed(1)})`
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (matches.length > 1) {
+    console.error(
+      `Multiple upstream entries match "${matchTitle}". Disambiguate with --matchSourceId:`
+    );
+    for (const entry of matches) {
+      console.error(`  "${entry.rawTitle}" sourceId=${entry.sourceId ?? 'null'}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const entry = matches[0];
+  const normalizedStatus = isEmulationCompatStatus(entry.normalizedStatus)
+    ? entry.normalizedStatus
+    : 'incomplete';
+
   await pool.query(
     `
     INSERT INTO emulation_compat_status (
       igdb_game_id, platform_igdb_id, emulator, normalized_status, raw_label,
+      raw_source_id, source_url, match_query_title,
       match_locked, enrichment_retry, matched_at, updated_at
-    ) VALUES ($1, $2, $3, $4, $5, TRUE, '{}'::jsonb, NOW(), NOW())
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE, '{}'::jsonb, NOW(), NOW())
     ON CONFLICT (igdb_game_id, platform_igdb_id) DO UPDATE SET
+      emulator = EXCLUDED.emulator,
       normalized_status = EXCLUDED.normalized_status,
       raw_label = EXCLUDED.raw_label,
+      raw_source_id = EXCLUDED.raw_source_id,
+      source_url = EXCLUDED.source_url,
+      match_query_title = EXCLUDED.match_query_title,
       match_locked = TRUE,
       enrichment_retry = '{}'::jsonb,
       matched_at = NOW(),
       updated_at = NOW()
     `,
-    [igdbGameId, platformIgdbId, platform.emulator, status, rawLabel ?? status]
+    [
+      igdbGameId,
+      platformIgdbId,
+      emulator,
+      normalizedStatus,
+      entry.rawLabel,
+      entry.sourceId,
+      entry.sourceUrl,
+      entry.rawTitle,
+    ]
   );
 
-  await applyGamePayloadPatch(pool, igdbGameId, platformIgdbId, { compatStatus: status });
+  await applyGamePayloadPatch(pool, igdbGameId, platformIgdbId, {
+    compatStatus: normalizedStatus,
+  });
 
   console.log(
-    `Set game=${igdbGameId} platform=${String(platformIgdbId)} status=${status} (locked).`
+    `Bound game=${igdbGameId} platform=${String(platformIgdbId)} to "${entry.rawTitle}" ` +
+      `(status=${normalizedStatus}). Future refreshes will keep tracking this entry.`
   );
 }
 
@@ -203,7 +265,7 @@ async function runClear(pool: import('pg').Pool, flags: Flags): Promise<void> {
 
   console.log(
     result.rowCount && result.rowCount > 0
-      ? `Cleared manual lock for game=${igdbGameId} platform=${String(platformIgdbId)}.`
+      ? `Unbound game=${igdbGameId} platform=${String(platformIgdbId)} — back to automatic matching.`
       : `No row found for game=${igdbGameId} platform=${String(platformIgdbId)}.`
   );
 }

--- a/src/app/core/services/game-sync.service.spec.ts
+++ b/src/app/core/services/game-sync.service.spec.ts
@@ -993,6 +993,66 @@ describe('GameSyncService', () => {
     expect(stored?.psPricesMatchLocked).toBe(false);
   });
 
+  it('stores compatStatus from a pulled upsert', async () => {
+    await servicePrivate.applyGameChange({
+      eventId: '4e1-compat-status',
+      entityType: 'game',
+      operation: 'upsert',
+      payload: createBaseGame({
+        compatStatus: 'perfect',
+      }),
+      serverTimestamp: '2026-01-01T00:00:00.000Z',
+    });
+
+    const stored = await db.games.where('[igdbGameId+platformIgdbId]').equals(['123', 130]).first();
+    expect(stored?.compatStatus).toBe('perfect');
+  });
+
+  it('preserves existing compatStatus when a pulled upsert omits it', async () => {
+    await db.games.put({
+      igdbGameId: '123',
+      platformIgdbId: 130,
+      title: 'Stored',
+      coverUrl: null,
+      coverSource: 'igdb',
+      platform: 'Switch',
+      releaseDate: null,
+      releaseYear: null,
+      listType: 'collection',
+      compatStatus: 'playable',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    await servicePrivate.applyGameChange({
+      eventId: '4e2-preserve-compat-status',
+      entityType: 'game',
+      operation: 'upsert',
+      payload: createBaseGame({
+        title: 'Updated Title',
+      }),
+      serverTimestamp: '2026-01-01T00:00:00.000Z',
+    });
+
+    const stored = await db.games.where('[igdbGameId+platformIgdbId]').equals(['123', 130]).first();
+    expect(stored?.compatStatus).toBe('playable');
+  });
+
+  it('discards an invalid compatStatus from a pulled upsert', async () => {
+    await servicePrivate.applyGameChange({
+      eventId: '4e3-invalid-compat-status',
+      entityType: 'game',
+      operation: 'upsert',
+      payload: createBaseGame({
+        compatStatus: 'bogus',
+      }),
+      serverTimestamp: '2026-01-01T00:00:00.000Z',
+    });
+
+    const stored = await db.games.where('[igdbGameId+platformIgdbId]').equals(['123', 130]).first();
+    expect(stored?.compatStatus).toBeNull();
+  });
+
   it('normalizes scheme-less HLTB match urls from pulled upserts', async () => {
     await servicePrivate.applyGameChange({
       eventId: '4e-normalize-hltb-url',

--- a/src/app/core/services/game-sync.service.ts
+++ b/src/app/core/services/game-sync.service.ts
@@ -15,6 +15,7 @@ import {
   Tag,
   isGameRating,
 } from '../models/game.models';
+import { isCompatibilityStatus } from '../utils/game-filter-utils';
 import { environment } from '../../../environments/environment';
 import { SyncEventsService } from './sync-events.service';
 import { SyncBootstrapProgressService } from './sync-bootstrap-progress.service';
@@ -1773,6 +1774,12 @@ export class GameSyncService implements SyncOutboxWriter {
           : this.normalizeOptionalBoolean(payload.reviewMatchLocked),
       metacriticScore: normalizedMetacriticScore,
       metacriticUrl: normalizedMetacriticUrl,
+      compatStatus:
+        payload.compatStatus === undefined
+          ? (existingByIdentity?.compatStatus ?? null)
+          : isCompatibilityStatus(payload.compatStatus)
+            ? payload.compatStatus
+            : null,
       similarGameIgdbIds: this.normalizeGameIdList(payload.similarGameIgdbIds),
       collections: this.normalizeStringList(payload.collections),
       developers: this.normalizeStringList(payload.developers),

--- a/src/app/features/game-list/game-list.component.html
+++ b/src/app/features/game-list/game-list.component.html
@@ -101,7 +101,18 @@
                 </ion-badge>
               }
               <p>{{ getGameReleaseDateLabel(game) }}</p>
-              <p>{{ getGameDisplayPlatformLabel(game) }}</p>
+              <p class="game-row-platform">
+                {{ getGameDisplayPlatformLabel(game) }}
+                @if (listType === 'collection' && getCompatIndicatorColor(game); as compatColor) {
+                  <ion-icon
+                    name="radio-button-on"
+                    class="compat-status-icon"
+                    [color]="compatColor"
+                    [attr.aria-label]="getCompatIndicatorLabel(game)"
+                    [title]="getCompatIndicatorLabel(game)"
+                  ></ion-icon>
+                }
+              </p>
               @if (game.tags && game.tags.length > 0) {
                 <div class="game-tags">
                   @for (tag of game.tags; track tag) {

--- a/src/app/features/game-list/game-list.component.html
+++ b/src/app/features/game-list/game-list.component.html
@@ -106,7 +106,6 @@
                 @if (listType === 'collection' && getCompatIndicatorColor(game); as compatColor) {
                   <ion-icon
                     name="radio-button-on"
-                    class="compat-status-icon"
                     [color]="compatColor"
                     [attr.aria-label]="getCompatIndicatorLabel(game)"
                     [title]="getCompatIndicatorLabel(game)"

--- a/src/app/features/game-list/game-list.component.scss
+++ b/src/app/features/game-list/game-list.component.scss
@@ -40,6 +40,16 @@ ion-item-sliding ion-item {
   font-size: 1rem;
 }
 
+.game-row-platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.compat-status-icon {
+  font-size: 0.6rem;
+}
+
 .rating-indicator {
   display: inline-flex;
   align-items: center;

--- a/src/app/features/game-list/game-list.component.scss
+++ b/src/app/features/game-list/game-list.component.scss
@@ -46,10 +46,6 @@ ion-item-sliding ion-item {
   gap: 4px;
 }
 
-.compat-status-icon {
-  font-size: 0.6rem;
-}
-
 .rating-indicator {
   display: inline-flex;
   align-items: center;

--- a/src/app/features/game-list/game-list.component.ts
+++ b/src/app/features/game-list/game-list.component.ts
@@ -253,13 +253,7 @@ interface DetailGamePayloadCacheEntry {
 }
 
 type NotesToolbarAction =
-  | 'bold'
-  | 'italic'
-  | 'underline'
-  | 'bullet'
-  | 'number'
-  | 'check'
-  | 'details';
+  'bold' | 'italic' | 'underline' | 'bullet' | 'number' | 'check' | 'details';
 
 @Component({
   selector: 'app-game-list',
@@ -4983,6 +4977,38 @@ export class GameListComponent implements OnChanges, OnDestroy {
       .getDisplayNameWithAliasSource(displayPlatform.name, displayPlatform.igdbId)
       .trim();
     return label.length > 0 ? label : 'Unknown platform';
+  }
+
+  getCompatIndicatorColor(game: GameEntry): string | null {
+    if (game.compatStatus === 'perfect') {
+      return 'compat-perfect';
+    }
+
+    if (game.compatStatus === 'playable') {
+      return 'compat-playable';
+    }
+
+    if (game.compatStatus === 'incomplete') {
+      return 'compat-incomplete';
+    }
+
+    return null;
+  }
+
+  getCompatIndicatorLabel(game: GameEntry): string {
+    if (game.compatStatus === 'perfect') {
+      return 'Emulation compatibility: Perfect';
+    }
+
+    if (game.compatStatus === 'playable') {
+      return 'Emulation compatibility: Playable';
+    }
+
+    if (game.compatStatus === 'incomplete') {
+      return 'Emulation compatibility: Incomplete';
+    }
+
+    return '';
   }
 
   getPlatformLabel(

--- a/src/app/features/game-list/game-list.component.ts
+++ b/src/app/features/game-list/game-list.component.ts
@@ -208,6 +208,7 @@ import {
   book,
   film,
   link,
+  radioButtonOn,
 } from 'ionicons/icons';
 
 export interface GameListSelectionState {
@@ -6249,6 +6250,7 @@ export class GameListComponent implements OnChanges, OnDestroy {
       chevronBack,
       documentText,
       book,
+      radioButtonOn,
     });
   }
 }

--- a/src/app/list-page/list-page.component.spec.ts
+++ b/src/app/list-page/list-page.component.spec.ts
@@ -164,12 +164,13 @@ describe('ListPageComponent', () => {
     expect(component.isInitialListLoading).toBe(false);
   });
 
-  it('dismisses initial list loading when game list reports displayed games', () => {
+  it('dismisses initial list loading when game list reports displayed games', async () => {
     const component = createComponent();
 
     expect(component.showInitialListLoading).toBe(true);
 
     component.onDisplayedGamesChange([]);
+    await Promise.resolve();
 
     expect(component.showInitialListLoading).toBe(false);
     expect(component.displayedGames).toEqual([]);

--- a/src/app/list-page/list-page.component.ts
+++ b/src/app/list-page/list-page.component.ts
@@ -531,8 +531,16 @@ export class ListPageComponent {
   }
 
   onDisplayedGamesChange(games: GameEntry[]): void {
-    this.displayedGames = games;
-    this.finishInitialListLoading();
+    // app-game-list can emit this synchronously during the same change-detection
+    // pass that first renders this component (e.g. when its games$ observable
+    // replays cached data immediately on subscribe). Mutating displayedGames here
+    // directly would then change a value (getListCountSummary()) already checked
+    // earlier in that pass, tripping NG0100. Defer to the next microtask so the
+    // update lands in its own change-detection cycle.
+    queueMicrotask(() => {
+      this.displayedGames = games;
+      this.finishInitialListLoading();
+    });
   }
 
   get isInitialListLoading(): boolean {

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -93,12 +93,12 @@
   --ion-color-forest-dark-shade: #46813a;
   --ion-color-forest-dark-tint: #619e55;
 
-  --ion-color-compat-perfect: #2f6338;
-  --ion-color-compat-perfect-rgb: 47, 99, 56;
-  --ion-color-compat-perfect-contrast: #ffffff;
-  --ion-color-compat-perfect-contrast-rgb: 255, 255, 255;
-  --ion-color-compat-perfect-shade: #295731;
-  --ion-color-compat-perfect-tint: #44734c;
+  --ion-color-compat-perfect: #59b5cf;
+  --ion-color-compat-perfect-rgb: 89, 181, 207;
+  --ion-color-compat-perfect-contrast: #000000;
+  --ion-color-compat-perfect-contrast-rgb: 0, 0, 0;
+  --ion-color-compat-perfect-shade: #4e9fb6;
+  --ion-color-compat-perfect-tint: #6abcd4;
 
   --ion-color-compat-playable: #71a12f;
   --ion-color-compat-playable-rgb: 113, 161, 47;

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -92,6 +92,27 @@
   --ion-color-forest-dark-contrast-rgb: 0, 0, 0;
   --ion-color-forest-dark-shade: #46813a;
   --ion-color-forest-dark-tint: #619e55;
+
+  --ion-color-compat-perfect: #2f6338;
+  --ion-color-compat-perfect-rgb: 47, 99, 56;
+  --ion-color-compat-perfect-contrast: #ffffff;
+  --ion-color-compat-perfect-contrast-rgb: 255, 255, 255;
+  --ion-color-compat-perfect-shade: #295731;
+  --ion-color-compat-perfect-tint: #44734c;
+
+  --ion-color-compat-playable: #71a12f;
+  --ion-color-compat-playable-rgb: 113, 161, 47;
+  --ion-color-compat-playable-contrast: #000000;
+  --ion-color-compat-playable-contrast-rgb: 0, 0, 0;
+  --ion-color-compat-playable-shade: #638e29;
+  --ion-color-compat-playable-tint: #7faa44;
+
+  --ion-color-compat-incomplete: #ca3d2f;
+  --ion-color-compat-incomplete-rgb: 202, 61, 47;
+  --ion-color-compat-incomplete-contrast: #ffffff;
+  --ion-color-compat-incomplete-contrast-rgb: 255, 255, 255;
+  --ion-color-compat-incomplete-shade: #b23629;
+  --ion-color-compat-incomplete-tint: #cf5044;
 }
 
 .ion-palette-dark {
@@ -293,4 +314,31 @@
   --ion-color-contrast-rgb: var(--ion-color-forest-dark-contrast-rgb);
   --ion-color-shade: var(--ion-color-forest-dark-shade);
   --ion-color-tint: var(--ion-color-forest-dark-tint);
+}
+
+.ion-color-compat-perfect {
+  --ion-color-base: var(--ion-color-compat-perfect);
+  --ion-color-base-rgb: var(--ion-color-compat-perfect-rgb);
+  --ion-color-contrast: var(--ion-color-compat-perfect-contrast);
+  --ion-color-contrast-rgb: var(--ion-color-compat-perfect-contrast-rgb);
+  --ion-color-shade: var(--ion-color-compat-perfect-shade);
+  --ion-color-tint: var(--ion-color-compat-perfect-tint);
+}
+
+.ion-color-compat-playable {
+  --ion-color-base: var(--ion-color-compat-playable);
+  --ion-color-base-rgb: var(--ion-color-compat-playable-rgb);
+  --ion-color-contrast: var(--ion-color-compat-playable-contrast);
+  --ion-color-contrast-rgb: var(--ion-color-compat-playable-contrast-rgb);
+  --ion-color-shade: var(--ion-color-compat-playable-shade);
+  --ion-color-tint: var(--ion-color-compat-playable-tint);
+}
+
+.ion-color-compat-incomplete {
+  --ion-color-base: var(--ion-color-compat-incomplete);
+  --ion-color-base-rgb: var(--ion-color-compat-incomplete-rgb);
+  --ion-color-contrast: var(--ion-color-compat-incomplete-contrast);
+  --ion-color-contrast-rgb: var(--ion-color-compat-incomplete-contrast-rgb);
+  --ion-color-shade: var(--ion-color-compat-incomplete-shade);
+  --ion-color-tint: var(--ion-color-compat-incomplete-tint);
 }


### PR DESCRIPTION
## Summary

Manually-bound compat games were frozen at whatever status they were bound with — refreshes never re-checked the upstream entry, and the client payload could drift from the stored status. This change makes bound games track their upstream entry across refreshes, backfills stale payloads, reworks the CLI binding workflow to bind by upstream identity instead of a manual status, and surfaces the compat status as a colored indicator on collection list rows.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci
- [ ] chore
- [ ] style

## Implementation details

- `server/src/emulation-compat/refresh.ts`: split owned games into `boundGames` (match_locked) and `unboundCandidates`. Bound games are re-resolved each refresh against the current upstream list — by `raw_source_id` when present, else by `match_query_title` — and their `emulation_compat_status` row and game payload are updated to whatever status the entry currently reports. A game whose bound entry disappears from the upstream list is left untouched. A trailing backfill pass patches `payload.compatStatus` for any row where the stored `normalized_status` no longer matches the payload (covers rows matched before payload syncing existed).
- `server/src/scripts/compat-match-cli.ts` `set` command: now takes `--matchTitle`/`--matchSourceId` instead of `--status`/`--label`, fetches the live compat list, resolves the exact upstream entry (erroring with scored suggestions on no match, or a disambiguation list on multiple matches), and binds the game to it — writing `raw_source_id`, `source_url`, and `match_query_title` so future refreshes can re-resolve it.
- `src/app/core/services/game-sync.service.ts`: pulled-upsert payloads now populate `compatStatus`, validated via `isCompatibilityStatus`; an omitted field preserves the existing stored value, an invalid value is discarded to `null`.
- `src/app/features/game-list/`: adds a `radio-button-on` icon next to the platform label on collection rows, colored via new `compat-perfect`/`compat-playable`/`compat-incomplete` Ionic color tokens (`src/theme/variables.scss`), with an accessible label/title.
- `src/app/list-page/list-page.component.ts`: `onDisplayedGamesChange` now defers its state mutation via `queueMicrotask` to avoid an `NG0100` expression-changed error when `games$` replays cached data synchronously during the same change-detection pass that first renders the component.

## Testing performed

- `npm run typecheck:server` — passed
- `npm run test:server` — 715 passed, 2 skipped, 0 failed
- `npm run lint` — passed, no issues
- `npm run test` (root, with coverage) — 1558 passed across 99 files
- `npm run build` — succeeded (pre-existing bundle-budget warning, +15 KB over 2.10 MB, unrelated to this change's size)
- New/updated tests: 4 in `refresh.test.ts` covering bound-game re-resolution and payload backfill; 3 in `game-sync.service.spec.ts` covering `compatStatus` sync/preserve/discard; 1 updated in `list-page.component.spec.ts` for the microtask deferral

## Screenshots (if applicable)

N/A — indicator is a small colored dot next to existing platform text; not visually captured here.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits
- [ ] CI passes
- [x] Lint passes
- [x] Tests pass
- [x] No console errors

## Related issues

Fixes #
